### PR TITLE
fix: summarize local conversations reliably

### DIFF
--- a/Desktop/Sources/AppState.swift
+++ b/Desktop/Sources/AppState.swift
@@ -1717,6 +1717,10 @@ class AppState: ObservableObject {
         } else {
           try await TranscriptionStorage.shared.finishSession(id: sessionId)
           log("Transcription: Finished DB session \(sessionId) before reconnect")
+          Task(priority: .background) {
+            await ConversationSummaryBackfillService.shared.summarizeSessionIfNeeded(
+              sessionId, reason: "finishConversation")
+          }
         }
       } catch {
         logError("Transcription: Failed to finalize DB session \(sessionId)", error: error)
@@ -1898,6 +1902,10 @@ class AppState: ObservableObject {
           } else {
             try await TranscriptionStorage.shared.finishSession(id: sessionId)
             log("Transcription: Finished DB session \(sessionId)")
+            Task(priority: .background) {
+              await ConversationSummaryBackfillService.shared.summarizeSessionIfNeeded(
+                sessionId, reason: "stopTranscription")
+            }
           }
         } catch {
           logError("Transcription: Failed to finalize DB session \(sessionId)", error: error)

--- a/Desktop/Sources/OmiApp.swift
+++ b/Desktop/Sources/OmiApp.swift
@@ -313,8 +313,16 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         if purged > 0 {
           log("Conversations: Purged \(purged) empty session(s) on launch")
         }
+
+        let recovered = try await TranscriptionStorage.shared.recoverStaleRecordingSessions()
+        if recovered > 0 {
+          log("Conversations: Recovered \(recovered) stale recording session(s) on launch")
+          await ConversationSummaryBackfillService.shared.markBackfillNeeded(
+            reason: "recovered stale recording sessions")
+          await ConversationSummaryBackfillService.shared.runIfNeeded()
+        }
       } catch {
-        logError("Conversations: purgeEmptySessions failed", error: error)
+        logError("Conversations: launch cleanup/recovery failed", error: error)
       }
     }
 

--- a/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
+++ b/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
@@ -79,9 +79,13 @@ actor TranscriptionStorage {
                 throw TranscriptionStorageError.sessionNotFound
             }
 
-            record.finishedAt = Date()
-            record.status = .pendingUpload
-            record.updatedAt = Date()
+            let now = Date()
+            record.finishedAt = now
+            // Local-first fork: there is no remote upload/processing backend.
+            // A finished recording is complete locally and ready for summary generation.
+            record.status = .completed
+            record.conversationStatus = .completed
+            record.updatedAt = now
             try record.update(database)
         }
 
@@ -108,6 +112,7 @@ actor TranscriptionStorage {
             }
 
             record.status = .completed
+            record.conversationStatus = .completed
             record.backendId = backendId
             record.backendSynced = true
             record.updatedAt = Date()
@@ -496,6 +501,69 @@ actor TranscriptionStorage {
                 arguments: [sessionId]
             ) ?? 0
         }
+    }
+
+    /// Recover sessions left in `recording` after an app crash/quit. In the
+    /// local-first fork there is no remote backend retry to reconcile these, so
+    /// old recording rows with transcript/audio must be closed locally; otherwise
+    /// they remain forever in-progress and never qualify for summary backfill.
+    /// Returns the number of rows closed.
+    @discardableResult
+    func recoverStaleRecordingSessions(olderThan maxAge: TimeInterval = 120) async throws -> Int {
+        let db = try await ensureInitialized()
+        let cutoff = Date().addingTimeInterval(-maxAge)
+
+        let rows = try await db.read { database in
+            try Row.fetchAll(
+                database,
+                sql: """
+                    SELECT s.id,
+                           s.startedAt,
+                           COALESCE(MAX(seg.endTime), 1.0) AS maxEnd
+                      FROM transcription_sessions s
+                      LEFT JOIN transcription_segments seg ON seg.sessionId = s.id
+                     WHERE s.status = 'recording'
+                       AND s.finishedAt IS NULL
+                       AND s.createdAt < ?
+                       AND (
+                            EXISTS (SELECT 1 FROM transcription_segments ts WHERE ts.sessionId = s.id)
+                         OR EXISTS (SELECT 1 FROM audio_chunks ac WHERE ac.transcriptionSessionId = s.id)
+                       )
+                     GROUP BY s.id
+                    """,
+                arguments: [cutoff]
+            )
+        }
+
+        var recovered = 0
+        for row in rows {
+            guard let id: Int64 = row["id"], let startedAt: Date = row["startedAt"] else { continue }
+            let rawMaxEnd: Double = row["maxEnd"] ?? 1.0
+            let maxEnd = max(rawMaxEnd, 1.0)
+            let finishedAt = startedAt.addingTimeInterval(maxEnd)
+            let changed = try await db.write { database -> Int in
+                try database.execute(
+                    sql: """
+                        UPDATE transcription_sessions
+                           SET finishedAt = ?,
+                               status = 'completed',
+                               conversationStatus = 'completed',
+                               updatedAt = ?
+                         WHERE id = ?
+                           AND status = 'recording'
+                           AND finishedAt IS NULL
+                        """,
+                    arguments: [finishedAt, Date(), id]
+                )
+                return database.changesCount
+            }
+            recovered += changed
+        }
+
+        if recovered > 0 {
+            log("TranscriptionStorage: Recovered \(recovered) stale recording session(s)")
+        }
+        return recovered
     }
 
     /// Retrospectively delete sessions that produced no segments AND no

--- a/Desktop/Sources/Rewind/Services/ConversationSummaryBackfillService.swift
+++ b/Desktop/Sources/Rewind/Services/ConversationSummaryBackfillService.swift
@@ -10,9 +10,10 @@ import GRDB
 /// title/overview and appear as "Untitled Conversation" in the list.
 ///
 /// Idempotency guarantee: the UserDefaults flag
-/// `conversationSummaryBackfillCompleted_v1` is set only after 3 consecutive
+/// `conversationSummaryBackfillCompleted_v2` is set only after 3 consecutive
 /// empty queries confirm there is nothing left to process.  Running this 100
-/// times is safe.
+/// times is safe. v2 intentionally re-runs on machines where an earlier broken
+/// v1 attempt marked completion before local summaries were reliably generated.
 ///
 /// Battery awareness: the loop only runs when
 /// `BatteryAwareScheduler.shared.allowHeavyWork` is true.  If the machine is
@@ -21,7 +22,7 @@ import GRDB
 actor ConversationSummaryBackfillService {
     static let shared = ConversationSummaryBackfillService()
 
-    private static let userDefaultsKey = "conversationSummaryBackfillCompleted_v1"
+    private static let userDefaultsKey = "conversationSummaryBackfillCompleted_v2"
     /// Nanoseconds to sleep between individual LLM calls (~1 s).
     private static let throttleNanoseconds: UInt64 = 1_000_000_000
     /// Minimum total transcript length (chars) to bother summarizing.
@@ -40,7 +41,7 @@ actor ConversationSummaryBackfillService {
     /// machine lacks headroom to run heavy work.
     func runIfNeeded() async {
         guard !UserDefaults.standard.bool(forKey: Self.userDefaultsKey) else {
-            log("ConversationSummaryBackfillService: already complete (v1), skipping")
+            log("ConversationSummaryBackfillService: already complete (v2), skipping")
             return
         }
 
@@ -56,6 +57,39 @@ actor ConversationSummaryBackfillService {
             try await backfillLoop(startTime: startTime)
         } catch {
             logError("ConversationSummaryBackfillService: backfill loop failed, will retry next launch", error: error)
+        }
+    }
+
+    /// Mark the historical backfill as incomplete. Used when launch recovery
+    /// turns stale `recording` rows into finished conversations after a prior
+    /// empty scan, or when live summarization defers work.
+    func markBackfillNeeded(reason: String) {
+        UserDefaults.standard.set(false, forKey: Self.userDefaultsKey)
+        log("ConversationSummaryBackfillService: marked backfill needed (\(reason))")
+    }
+
+    /// Summarize one just-finished session immediately instead of waiting for
+    /// the historical backfill lifecycle. Safe to call repeatedly: rows that
+    /// already have a title or overview are ignored.
+    func summarizeSessionIfNeeded(_ sessionId: Int64, reason: String) async {
+        guard await MainActor.run(body: { BatteryAwareScheduler.shared.allowHeavyWork }) else {
+            markBackfillNeeded(reason: "live summary deferred for session \(sessionId): heavy work not allowed")
+            log("ConversationSummaryBackfillService: live summary deferred for session \(sessionId) — heavy work not allowed (\(reason))")
+            return
+        }
+
+        do {
+            guard let row = try await fetchSession(id: sessionId, onlyIfNeedsSummary: true) else {
+                log("ConversationSummaryBackfillService: live summary skipped for session \(sessionId) — already summarized or missing (\(reason))")
+                return
+            }
+            let outcome = try await process(row: row, mode: "live \(reason)")
+            if case .deferred = outcome {
+                markBackfillNeeded(reason: "live summary deferred for session \(sessionId)")
+            }
+        } catch {
+            markBackfillNeeded(reason: "live summary error for session \(sessionId)")
+            logError("ConversationSummaryBackfillService: live summary failed for session \(sessionId)", error: error)
         }
     }
 
@@ -80,42 +114,63 @@ actor ConversationSummaryBackfillService {
 
             consecutiveEmpty = 0
 
-            let sessionId = row.id
-            let transcript = row.transcript
-
-            guard transcript.count >= Self.minTranscriptLength else {
-                log("ConversationSummaryBackfillService: session \(sessionId) transcript too short (\(transcript.count) chars), skipping with placeholder")
-                // Write a sentinel so it won't be re-selected on the next run.
-                try await writeBackPlaceholder(sessionId: sessionId)
+            let outcome = try await process(row: row, mode: "backfill")
+            switch outcome {
+            case .summarized:
+                totalProcessed += 1
+                // Throttle: give the LLM server a brief breather.
+                try await Task.sleep(nanoseconds: Self.throttleNanoseconds)
+            case .placeholder:
                 continue
+            case .deferred:
+                // Do not spin forever on the same row if the local LLM is
+                // offline or returned unparsable JSON. Leave it eligible and
+                // retry on the next launch/manual trigger.
+                log("ConversationSummaryBackfillService: deferred after LLM/parse failure; will retry later")
+                return
             }
-
-            log("ConversationSummaryBackfillService: summarizing session \(sessionId) (\(transcript.count) chars)")
-
-            guard let structured = await callLLM(transcript: transcript, sessionId: sessionId) else {
-                // LLM call failed or parse error — skip this row without marking
-                // it done so the next launch retries it.
-                log("ConversationSummaryBackfillService: skipping session \(sessionId) due to LLM/parse failure")
-                continue
-            }
-
-            try await writeBack(sessionId: sessionId, structured: structured)
-            totalProcessed += 1
-
-            log("ConversationSummaryBackfillService: session \(sessionId) → \"\(structured.title)\"")
-
-            // Notify the conversations list so the row updates without a manual refresh.
-            await MainActor.run {
-                NotificationCenter.default.post(name: .conversationsListNeedsRefresh, object: nil)
-            }
-
-            // Throttle: give the LLM server a brief breather.
-            try await Task.sleep(nanoseconds: Self.throttleNanoseconds)
         }
 
         let elapsed = Date().timeIntervalSince(startTime)
         UserDefaults.standard.set(true, forKey: Self.userDefaultsKey)
         log(String(format: "ConversationSummaryBackfillService: complete — %d rows in %.1fs", totalProcessed, elapsed))
+    }
+
+    private enum ProcessOutcome {
+        case summarized
+        case placeholder
+        case deferred
+    }
+
+    private func process(row: PendingSession, mode: String) async throws -> ProcessOutcome {
+        let sessionId = row.id
+        let transcript = row.transcript
+
+        guard transcript.count >= Self.minTranscriptLength else {
+            log("ConversationSummaryBackfillService: session \(sessionId) transcript too short (\(transcript.count) chars), writing placeholder (\(mode))")
+            // Write a sentinel so it won't be re-selected on the next run.
+            try await writeBackPlaceholder(sessionId: sessionId)
+            await notifyConversationListNeedsRefresh()
+            return .placeholder
+        }
+
+        log("ConversationSummaryBackfillService: summarizing session \(sessionId) (\(transcript.count) chars, \(mode))")
+
+        guard let structured = await callLLM(transcript: transcript, sessionId: sessionId) else {
+            log("ConversationSummaryBackfillService: session \(sessionId) summary deferred due to LLM/parse failure (\(mode))")
+            return .deferred
+        }
+
+        try await writeBack(sessionId: sessionId, structured: structured)
+        log("ConversationSummaryBackfillService: session \(sessionId) → \"\(structured.title)\" (\(mode))")
+        await notifyConversationListNeedsRefresh()
+        return .summarized
+    }
+
+    private func notifyConversationListNeedsRefresh() async {
+        await MainActor.run {
+            NotificationCenter.default.post(name: .conversationsListNeedsRefresh, object: nil)
+        }
     }
 
     // MARK: - Database helpers
@@ -151,7 +206,29 @@ actor ConversationSummaryBackfillService {
             return nil
         }
 
-        // Step 2: assemble transcript from segments, stripping WhisperKit tokens.
+        return try await fetchSession(id: sessionId, onlyIfNeedsSummary: false)
+    }
+
+    private func fetchSession(id sessionId: Int64, onlyIfNeedsSummary: Bool) async throws -> PendingSession? {
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+            throw TranscriptionStorageError.databaseNotInitialized
+        }
+
+        if onlyIfNeedsSummary {
+            let needsSummarySQL = """
+                SELECT COUNT(*) FROM transcription_sessions
+                 WHERE id = ?
+                   AND finishedAt IS NOT NULL
+                   AND (title IS NULL OR title = '')
+                   AND (overview IS NULL OR overview = '')
+                """
+            let needsSummary = try await dbQueue.read { db in
+                try Int.fetchOne(db, sql: needsSummarySQL, arguments: [sessionId]) ?? 0
+            }
+            guard needsSummary > 0 else { return nil }
+        }
+
+        // Assemble transcript from segments, stripping WhisperKit tokens.
         let segmentSQL = """
             SELECT text FROM transcription_segments
              WHERE sessionId = ?

--- a/Desktop/Sources/Rewind/Services/RewindIndexer.swift
+++ b/Desktop/Sources/Rewind/Services/RewindIndexer.swift
@@ -77,7 +77,7 @@ actor RewindIndexer {
         // Generate structured summaries (title/overview/emoji/category) for
         // finished conversations that were recorded before the local extraction
         // pipeline was wired.  Idempotent; guarded by
-        // UserDefaults flag "conversationSummaryBackfillCompleted_v1".
+        // UserDefaults flag "conversationSummaryBackfillCompleted_v2".
         Task(priority: .background) {
             await ConversationSummaryBackfillService.shared.runIfNeeded()
         }


### PR DESCRIPTION
## Summary
- close stale local recording sessions on launch so they qualify for summary backfill
- run local title/summary generation immediately when a conversation finishes
- move summary backfill to v2 and make deferrals retry-safe instead of spinning or permanently skipping

Closes #1

## Tests
- ✅ `cd Desktop && swift build`
- ⚠️ `cd Desktop && swift test` currently fails in existing `ListenProtocolTests` because tests reference removed `TranscriptionService` members (`parseBackendResponse`, reconnect helpers); unrelated to this change

## Runtime checks
- ✅ local mlx server reachable: `http://127.0.0.1:8080/health`
- ✅ `/v1/models` reports local text model\n