### PR TITLE
fix: default run script to Infinite Recall

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -96,7 +96,7 @@ substep() {
 
 # App configuration
 BINARY_NAME="Omi Computer"  # Package.swift target — binary paths, pkill, CFBundleExecutable
-APP_NAME="${OMI_APP_NAME:-Infinite Recall Dev}"
+APP_NAME="${OMI_APP_NAME:-Infinite Recall}"
 IS_NAMED_BUNDLE=false
 [ -n "${OMI_APP_NAME:-}" ] && IS_NAMED_BUNDLE=true
 


### PR DESCRIPTION
## Summary
- change run.sh default app name from Infinite Recall Dev to Infinite Recall
- OMI_APP_NAME can still override the name for named/dev builds

Closes #3

## Tests
- ✅ bash -n run.sh