### PR TITLE
activity: phase 0 — contract freeze + stubs (closes #10)

### DIFF
--- a/Backend-Rust/api/src/activity/contract.md
+++ b/Backend-Rust/api/src/activity/contract.md
@@ -1,0 +1,212 @@
+# Activity Tab — Phase 0 Contract (FROZEN)
+
+> Owner: Phase 0 contract-agent (issue #10).
+> Consumers: Phase 1 streams A–I (issues TBD; see umbrella #9).
+> Any change to this file requires a `stream 0-contract amendment` issue
+> and a re-freeze; downstream streams must pause work until merged.
+
+## Goals
+
+In-app **Activity** tab giving the user:
+1. Live process-tree CPU/RSS + system-wide GPU.
+2. Human-readable in-flight task list, one row per `WorkKind`.
+3. Per-kind / per-capture **Pause for N min** with persistence across restart.
+4. Honest explanation of *why* nothing is in-flight (idle gate vs battery
+   vs thermal vs locked vs manual pause).
+
+See `~/.claude/plans/for-ir-can-we-majestic-island.md` for full plan.
+
+---
+
+## REST surface
+
+All routes auth via existing bearer token (`Authorization: Bearer <token>`).
+All bodies + responses are JSON. Prefix: `/v1`.
+
+```
+GET  /v1/activity/snapshot                  → 200 ActivitySnapshot
+POST /v1/activity/pause                     → 200 { "paused_until": "<iso8601>" }
+POST /v1/activity/resume                    → 204
+POST /v1/activity/_internal/inflight        → 204    (loopback only)
+```
+
+The `_internal/inflight` route is Swift→Rust loopback. Stream A SHOULD reject
+non-loopback peer addresses defensively in addition to bearer auth.
+
+---
+
+## JSON shapes
+
+Field names are snake_case on the wire. Swift mirrors live in
+`Desktop/Sources/Activity/ActivityModels.swift` (see `CodingKeys`).
+
+### `ActivitySnapshot` (response of GET snapshot)
+
+```json
+{
+  "kinds": [
+    {
+      "kind": "transcribe",
+      "in_flight": { "label": "Transcribing 14:22:01→14:25:00 (en)",
+                     "started_at": "2026-04-26T14:22:03.812Z" },
+      "queued": 47,
+      "failed": 0,
+      "last_done_at": "2026-04-26T14:21:58.000Z",
+      "paused_until": null
+    }
+  ],
+  "capture": [
+    { "kind": "audio",  "running": true,  "paused_until": null },
+    { "kind": "screen", "running": true,  "paused_until": null }
+  ],
+  "resources": {
+    "cpu_percent": 142.0,
+    "rss_mb": 2342,
+    "gpu_system_percent": 38.0,
+    "thermal_state": "fair",
+    "on_battery": false,
+    "low_power": false,
+    "process_breakdown": [
+      { "name": "infinite-recall-api", "pid": 1234, "cpu_percent": 12.4, "rss_mb": 84 },
+      { "name": "Infinite Recall",     "pid": 1235, "cpu_percent": 51.2, "rss_mb": 760 },
+      { "name": "mlx-lm.server",       "pid": 1236, "cpu_percent": 78.4, "rss_mb": 1498 }
+    ]
+  },
+  "processing_gate": {
+    "allowed": false,
+    "reason": "device_active",
+    "since": "2026-04-26T14:25:00.000Z",
+    "waiting_for": "2 min of idle"
+  },
+  "generated_at": "2026-04-26T14:25:30.512Z"
+}
+```
+
+### Enums (string-valued)
+
+| Field | Allowed values |
+|---|---|
+| `KindRow.kind` / `WorkKind` | `transcribe`, `ocr`, `summarize`, `extract_memory`, `extract_action_items` |
+| `CaptureRow.kind` / `CaptureKind` | `audio`, `screen` |
+| `PauseRequest.target` / `ResumeRequest.target` / `PauseTarget` | `kind`, `capture` |
+| `ResourceSample.thermal_state` / `ThermalState` | `nominal`, `fair`, `serious`, `critical` |
+| `GateState.reason` / `GateReason` | `idle`, `device_active`, `on_battery`, `thermal`, `locked`, `manual_pause`, `none` |
+
+### `PauseRequest` / `ResumeRequest`
+
+```json
+// POST /v1/activity/pause
+{ "target": "kind", "id": "ocr", "minutes": 15 }
+
+// POST /v1/activity/resume
+{ "target": "capture", "id": "audio" }
+```
+
+For `target: "kind"`, `id` is a `WorkKind` snake_case string.
+For `target: "capture"`, `id` is `"audio"` or `"screen"`.
+
+### `InflightUpdate` (Swift → Rust loopback)
+
+```json
+// POST /v1/activity/_internal/inflight
+{ "kind": "transcribe",
+  "in_flight": { "label": "Transcribing 14:22:01→14:25:00 (en)",
+                 "started_at": "2026-04-26T14:22:03.812Z" } }
+
+// Clearing the slot:
+{ "kind": "transcribe", "in_flight": null }
+```
+
+---
+
+## Internal Rust traits
+
+Stream A wires; B/C/D and the idle-gate agent implement.
+
+```rust
+trait PauseStore : Send + Sync {
+    fn paused_until(&self, target: PauseTarget, id: &str) -> Option<DateTime<Utc>>;
+    fn pause       (&self, target: PauseTarget, id: &str, minutes: u32) -> DateTime<Utc>;
+    fn resume      (&self, target: PauseTarget, id: &str);
+}
+
+trait InflightRegistry : Send + Sync {
+    fn snapshot(&self) -> HashMap<WorkKind, InFlight>;
+    fn update  (&self, kind: WorkKind, in_flight: Option<InFlight>);
+}
+
+trait ResourceSampler : Send + Sync {
+    fn sample(&self) -> ResourceSample;     // expected to cache ~1s
+}
+
+trait ProcessingGate : Send + Sync {
+    fn current(&self) -> GateState;
+}
+```
+
+`AppState` extended with:
+```rust
+pub pause_store:     Arc<dyn PauseStore>,
+pub inflight:        Arc<dyn InflightRegistry>,
+pub resource_sampler:Arc<dyn ResourceSampler>,
+pub processing_gate: Arc<dyn ProcessingGate>,
+```
+
+Stream A owns the AppState mutation. B/C/D do not edit `state.rs`.
+
+---
+
+## File ownership map
+
+| Stream | Owns (new) | Touches (append-only) |
+|---|---|---|
+| 0 (this PR) | `activity/{mod,types,traits,pause_store,resources,inflight}.rs`, `activity/contract.md`, `routes/activity.rs`, `Desktop/Sources/Activity/{ActivityModels,ActivityMonitorService,ActivityPage,WorkLabels,CapturePauseGate}.swift` | `main.rs`, `routes/mod.rs` (registers `mod activity` only) |
+| A | `routes/activity.rs` (flesh out) | `routes/mod.rs` (`// === activity routes ===` block), `state.rs`, `main.rs` |
+| B | `activity/pause_store.rs` (flesh out), `migrations/NNNN_paused_work.sql` | — |
+| C | `activity/resources.rs` (flesh out) | `Cargo.toml` (add `libproc`) |
+| D | `activity/inflight.rs` (flesh out) | — |
+| E | `Activity/ActivityPage.swift` (flesh out), `Activity/WorkLabels.swift` (flesh out) | `MainWindow/SidebarView.swift`, `MainWindow/DesktopHomeView.swift`, `OmiApp.swift` |
+| F | `Activity/ActivityMonitorService.swift` (flesh out), `Activity/ActivityModels.swift` (already shipped) | `APIClient.swift` (append-only) |
+| G | — | `Power/BatteryAwareScheduler.swift` |
+| H | `Activity/CapturePauseGate.swift` (flesh out) | `AudioCaptureService.swift`, `ScreenCaptureService.swift` |
+| I | `Backend-Rust/tests/activity_endpoints.rs`, `Desktop/Tests/ActivityModelsTests.swift`, `e2e/activity-tab.md` | — |
+
+All append-only edits MUST use bracket comments:
+```
+// === activity:<stream> ===
+...
+// === /activity:<stream> ===
+```
+to keep merge conflicts to single-line resolutions.
+
+---
+
+## Notification names + UserDefaults keys
+
+Defined in `Desktop/Sources/Activity/ActivityModels.swift`:
+
+| Constant | Value | Owner |
+|---|---|---|
+| `ActivityNotifications.pauseChanged` | `"activityPauseChanged"` | H posts; H/G observe |
+| `ActivityDefaultsKeys.lastGateStateJSON` | `"activity.lastGateStateJSON"` | F |
+
+---
+
+## Coordination notes
+
+- **Idle-gate agent.** A separate agent ships the device-idle/locked
+  processing gate. The `ProcessingGate` trait + `GateState` struct in this
+  contract are the seam. If their work lands first with a different
+  `GateState` shape, Stream A is responsible for an adapter — but the
+  on-the-wire `GateState` JSON in this contract MUST NOT change without an
+  amendment.
+- **Pause semantics.** Pause stops the *next* claim; in-flight handler
+  runs to completion (no cancellation refactor in scope). Pause + idle gate
+  AND together (whichever is later wins).
+- **Capture pause** triggers a confirm sheet in the UI ("recording will
+  stop"); the pause itself just stops the running capture and refuses
+  restart until `paused_until` passes.
+- **Pause persistence.** SQLite table `paused_work` (Stream B) keyed by
+  `(target, id)` with absolute `resume_at` unix-seconds.
+- **Hidden window** suspends polling (Stream F). UI MUST NOT poll the
+  Rust daemon while `NSWindow.didResignKey`.

--- a/Backend-Rust/api/src/activity/inflight.rs
+++ b/Backend-Rust/api/src/activity/inflight.rs
@@ -1,0 +1,5 @@
+//! Stream D: `MemoryInflightRegistry` — `Arc<RwLock<HashMap<WorkKind, InFlight>>>`.
+//!
+//! TODO(stream-D): implement `InflightRegistry` with a tokio `RwLock` (or
+//! `parking_lot::RwLock`) wrapping `HashMap<WorkKind, InFlight>`.
+//! Trivial; bounded by lock contention.

--- a/Backend-Rust/api/src/activity/mod.rs
+++ b/Backend-Rust/api/src/activity/mod.rs
@@ -1,0 +1,25 @@
+//! Activity surface — live process/task explorer with per-kind pause.
+//!
+//! Phase 0 contract freeze. See `contract.md` in this directory for the
+//! REST + JSON shapes consumed by every Phase 1 stream.
+//!
+//! Module map (one file per Phase 1 stream owner):
+//! - `types`        — serde-serialisable shapes (this PR)
+//! - `traits`       — `PauseStore`, `InflightRegistry`, `ResourceSampler`,
+//!                    `ProcessingGate` (this PR)
+//! - `pause_store`  — Stream B: `SqlPauseStore` impl
+//! - `resources`    — Stream C: `SystemResourceSampler` impl
+//! - `inflight`     — Stream D: `MemoryInflightRegistry` impl
+
+pub mod inflight;
+pub mod pause_store;
+pub mod resources;
+pub mod traits;
+pub mod types;
+
+pub use traits::{InflightRegistry, PauseStore, ProcessingGate, ResourceSampler};
+pub use types::{
+    ActivitySnapshot, CaptureRow, GateState, GateReason, InFlight, InflightUpdate, KindRow,
+    PauseRequest, PauseTarget, ProcessBreakdown, ResourceSample, ResumeRequest, ThermalState,
+    WorkKind,
+};

--- a/Backend-Rust/api/src/activity/pause_store.rs
+++ b/Backend-Rust/api/src/activity/pause_store.rs
@@ -1,0 +1,14 @@
+//! Stream B: `SqlPauseStore` — persistent absolute-time pause storage.
+//!
+//! TODO(stream-B): implement `PauseStore` against a new `paused_work` table
+//! (see `Backend-Rust/migrations/NNNN_paused_work.sql`).
+//!
+//! Schema:
+//! ```sql
+//! CREATE TABLE paused_work (
+//!     target    TEXT NOT NULL,    -- 'kind' | 'capture'
+//!     id        TEXT NOT NULL,    -- WorkKind snake_case or 'audio'/'screen'
+//!     resume_at INTEGER NOT NULL, -- unix seconds, absolute
+//!     PRIMARY KEY (target, id)
+//! );
+//! ```

--- a/Backend-Rust/api/src/activity/resources.rs
+++ b/Backend-Rust/api/src/activity/resources.rs
@@ -1,0 +1,8 @@
+//! Stream C: `SystemResourceSampler` — process-tree + system GPU sampler.
+//!
+//! TODO(stream-C): implement `ResourceSampler` using:
+//! - `libproc` for self + Swift PID + mlx-lm PID CPU/RSS
+//! - PID discovery: try `~/Library/Application Support/InfiniteRecall/{swift,mlxlm}.pid`
+//!   first, fall back to `launchctl list <label>` parsing
+//! - `ioreg -r -c IOAccelerator` shellout for system GPU%
+//! - Cache results for 1 second

--- a/Backend-Rust/api/src/activity/traits.rs
+++ b/Backend-Rust/api/src/activity/traits.rs
@@ -1,0 +1,48 @@
+//! Internal Rust traits implemented by Phase 1 streams B/C/D and the
+//! external idle-gate agent. Stream A wires concrete impls into `AppState`.
+//!
+//! These traits are **the** coupling boundary — implementations live in
+//! sibling modules, but the route handlers and `AppState` only know about
+//! these trait objects.
+
+use std::collections::HashMap;
+
+use chrono::{DateTime, Utc};
+
+use super::types::{GateState, InFlight, PauseTarget, ResourceSample, WorkKind};
+
+/// Persistent absolute-time pause storage. Backed by SQLite (Stream B).
+pub trait PauseStore: Send + Sync {
+    /// Returns the wall-time at which the given target/id resumes,
+    /// or `None` when not paused.
+    fn paused_until(&self, target: PauseTarget, id: &str) -> Option<DateTime<Utc>>;
+
+    /// Pause for `minutes` from now; returns the resolved resume time.
+    fn pause(&self, target: PauseTarget, id: &str, minutes: u32) -> DateTime<Utc>;
+
+    /// Clear any pause row for the given target/id.
+    fn resume(&self, target: PauseTarget, id: &str);
+}
+
+/// Tracks which `WorkKind` is currently mid-handler. Backed by an
+/// in-memory `Arc<RwLock<HashMap>>` (Stream D).
+pub trait InflightRegistry: Send + Sync {
+    /// Snapshot of all currently-executing kinds.
+    fn snapshot(&self) -> HashMap<WorkKind, InFlight>;
+
+    /// Set or clear the in-flight slot for one kind.
+    fn update(&self, kind: WorkKind, in_flight: Option<InFlight>);
+}
+
+/// Polls process-tree CPU/RSS + system GPU. Backed by libproc + ioreg
+/// shellout (Stream C). Implementations are expected to cache for ~1s.
+pub trait ResourceSampler: Send + Sync {
+    fn sample(&self) -> ResourceSample;
+}
+
+/// Read-only view of the device-idle / processing gate. Owned by the
+/// separate idle-gate agent; this trait is the contract for consuming
+/// their state from the snapshot route without coupling to internals.
+pub trait ProcessingGate: Send + Sync {
+    fn current(&self) -> GateState;
+}

--- a/Backend-Rust/api/src/activity/types.rs
+++ b/Backend-Rust/api/src/activity/types.rs
@@ -1,0 +1,166 @@
+//! Serde shapes shared by the REST surface and Phase 1 stream impls.
+//!
+//! These are the wire types the Swift `ActivityModels.swift` mirror is
+//! generated from. **Do not change a field name without updating both
+//! `contract.md` and `Desktop/Sources/Activity/ActivityModels.swift`.**
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// One of the deferred-work kinds the scheduler drains.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkKind {
+    Transcribe,
+    Ocr,
+    Summarize,
+    ExtractMemory,
+    ExtractActionItems,
+}
+
+/// Live capture surfaces (separate from deferred work).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CaptureKind {
+    Audio,
+    Screen,
+}
+
+/// What `Pause`/`Resume` requests target.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PauseTarget {
+    Kind,
+    Capture,
+}
+
+/// macOS thermal pressure (mirrors `NSProcessInfo.ThermalState`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ThermalState {
+    Nominal,
+    Fair,
+    Serious,
+    Critical,
+}
+
+/// Why deferred work is or is not draining.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GateReason {
+    /// Device is idle and we are draining.
+    Idle,
+    /// User is actively using the device.
+    DeviceActive,
+    /// On battery and policy says wait for AC.
+    OnBattery,
+    /// Thermal pressure is too high.
+    Thermal,
+    /// Screen locked / session inactive.
+    Locked,
+    /// User manually paused via the Activity tab.
+    ManualPause,
+    /// No gating reason; trivial baseline.
+    None,
+}
+
+/// Single in-flight task currently executing for a given `WorkKind`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InFlight {
+    /// Human label e.g. `"Transcribing 14:22:01→14:25:00 (en)"`.
+    pub label: String,
+    pub started_at: DateTime<Utc>,
+}
+
+/// One row in the per-kind table.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KindRow {
+    pub kind: WorkKind,
+    pub in_flight: Option<InFlight>,
+    pub queued: u32,
+    pub failed: u32,
+    pub last_done_at: Option<DateTime<Utc>>,
+    pub paused_until: Option<DateTime<Utc>>,
+}
+
+/// One row in the live-capture section.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CaptureRow {
+    pub kind: CaptureKind,
+    pub running: bool,
+    pub paused_until: Option<DateTime<Utc>>,
+}
+
+/// Per-process sample line.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProcessBreakdown {
+    pub name: String,
+    pub pid: i32,
+    pub cpu_percent: f32,
+    pub rss_mb: u32,
+}
+
+/// One sample tick of system resources.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResourceSample {
+    /// Sum of `process_breakdown[*].cpu_percent`.
+    pub cpu_percent: f32,
+    /// Sum of `process_breakdown[*].rss_mb`.
+    pub rss_mb: u32,
+    /// System-wide GPU utilisation, when available (Apple Silicon).
+    pub gpu_system_percent: Option<f32>,
+    pub thermal_state: ThermalState,
+    pub on_battery: bool,
+    pub low_power: bool,
+    pub process_breakdown: Vec<ProcessBreakdown>,
+}
+
+/// Snapshot of the idle/processing gate at sample time.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GateState {
+    /// Whether deferred-work claims are allowed right now.
+    pub allowed: bool,
+    pub reason: GateReason,
+    /// When the current `reason` started.
+    pub since: DateTime<Utc>,
+    /// Optional human-readable resume condition, e.g.
+    /// `"2 min of idle"`, `"AC power"`, `"thermal cooldown"`.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub waiting_for: Option<String>,
+}
+
+/// Top-level GET /v1/activity/snapshot response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ActivitySnapshot {
+    pub kinds: Vec<KindRow>,
+    pub capture: Vec<CaptureRow>,
+    pub resources: ResourceSample,
+    pub processing_gate: GateState,
+    pub generated_at: DateTime<Utc>,
+}
+
+/// POST /v1/activity/pause body.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PauseRequest {
+    pub target: PauseTarget,
+    /// Either a `WorkKind` snake_case string (when `target=kind`) or
+    /// `"audio"` / `"screen"` (when `target=capture`).
+    pub id: String,
+    pub minutes: u32,
+}
+
+/// POST /v1/activity/resume body.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResumeRequest {
+    pub target: PauseTarget,
+    pub id: String,
+}
+
+/// POST /v1/activity/_internal/inflight body (Swift → Rust loopback).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InflightUpdate {
+    /// `WorkKind` snake_case string.
+    pub kind: String,
+    /// `None` clears the slot.
+    pub in_flight: Option<InFlight>,
+}

--- a/Backend-Rust/api/src/lib.rs
+++ b/Backend-Rust/api/src/lib.rs
@@ -5,6 +5,7 @@
 //! `recall` CLI) can depend on shared building blocks like
 //! [`token::token_path`] without re-implementing them.
 
+pub mod activity;
 pub mod auth;
 pub mod db;
 pub mod error;

--- a/Backend-Rust/api/src/routes/activity.rs
+++ b/Backend-Rust/api/src/routes/activity.rs
@@ -1,0 +1,44 @@
+//! Stream A: `/v1/activity/*` route handlers.
+//!
+//! TODO(stream-A): wire concrete impls from B/C/D into `AppState` and
+//! flesh out these handlers. Stubs here exist solely so `cargo build`
+//! passes during Phase 0.
+
+use axum::{extract::State, http::StatusCode, Json};
+
+use crate::activity::types::{
+    ActivitySnapshot, InflightUpdate, PauseRequest, ResumeRequest,
+};
+use crate::state::AppState;
+
+/// `GET /v1/activity/snapshot` — full live snapshot.
+pub async fn snapshot(State(_state): State<AppState>) -> Json<ActivitySnapshot> {
+    unimplemented!("stream A: assemble snapshot from PauseStore + InflightRegistry + ResourceSampler + ProcessingGate")
+}
+
+/// `POST /v1/activity/pause` — pause a kind or live capture for N minutes.
+pub async fn pause(
+    State(_state): State<AppState>,
+    Json(_body): Json<PauseRequest>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    unimplemented!("stream A: call PauseStore::pause and return {{paused_until: iso8601}}")
+}
+
+/// `POST /v1/activity/resume` — clear a pause row.
+pub async fn resume(
+    State(_state): State<AppState>,
+    Json(_body): Json<ResumeRequest>,
+) -> StatusCode {
+    unimplemented!("stream A: call PauseStore::resume and return 204")
+}
+
+/// `POST /v1/activity/_internal/inflight` — Swift → Rust loopback.
+///
+/// **Loopback only.** Auth still required (bearer); reject non-loopback
+/// peer addresses at the middleware layer if/when Stream A adds that.
+pub async fn inflight(
+    State(_state): State<AppState>,
+    Json(_body): Json<InflightUpdate>,
+) -> StatusCode {
+    unimplemented!("stream A: call InflightRegistry::update and return 204")
+}

--- a/Backend-Rust/api/src/routes/mod.rs
+++ b/Backend-Rust/api/src/routes/mod.rs
@@ -13,6 +13,7 @@ use crate::auth::require_bearer;
 use crate::state::AppState;
 
 mod action_items;
+mod activity;
 mod conversations;
 mod health;
 mod memories;

--- a/Desktop/Sources/Activity/ActivityModels.swift
+++ b/Desktop/Sources/Activity/ActivityModels.swift
@@ -1,0 +1,214 @@
+// Activity Tab — Phase 0 contract freeze.
+//
+// Codable mirrors of `Backend-Rust/src/activity/types.rs`. Field names use
+// snake_case on the wire; we map via CodingKeys.
+//
+// **Do not change a field without updating both the Rust type and
+// `Backend-Rust/src/activity/contract.md`.**
+//
+// Owner: Stream F. (Phase 0 ships the types; F flesh-out lives here.)
+
+import Foundation
+
+// MARK: - Enums
+
+public enum WorkKind: String, Codable, CaseIterable, Hashable {
+    case transcribe
+    case ocr
+    case summarize
+    case extractMemory = "extract_memory"
+    case extractActionItems = "extract_action_items"
+}
+
+public enum CaptureKind: String, Codable, CaseIterable, Hashable {
+    case audio
+    case screen
+}
+
+public enum PauseTarget: String, Codable, Hashable {
+    case kind
+    case capture
+}
+
+public enum ThermalState: String, Codable, Hashable {
+    case nominal
+    case fair
+    case serious
+    case critical
+}
+
+public enum GateReason: String, Codable, Hashable {
+    case idle
+    case deviceActive = "device_active"
+    case onBattery = "on_battery"
+    case thermal
+    case locked
+    case manualPause = "manual_pause"
+    case none
+}
+
+// MARK: - Inner shapes
+
+public struct InFlight: Codable, Hashable {
+    public let label: String
+    public let startedAt: Date
+
+    enum CodingKeys: String, CodingKey {
+        case label
+        case startedAt = "started_at"
+    }
+
+    public init(label: String, startedAt: Date) {
+        self.label = label
+        self.startedAt = startedAt
+    }
+}
+
+public struct KindRow: Codable, Hashable {
+    public let kind: WorkKind
+    public let inFlight: InFlight?
+    public let queued: UInt32
+    public let failed: UInt32
+    public let lastDoneAt: Date?
+    public let pausedUntil: Date?
+
+    enum CodingKeys: String, CodingKey {
+        case kind
+        case inFlight = "in_flight"
+        case queued
+        case failed
+        case lastDoneAt = "last_done_at"
+        case pausedUntil = "paused_until"
+    }
+}
+
+public struct CaptureRow: Codable, Hashable {
+    public let kind: CaptureKind
+    public let running: Bool
+    public let pausedUntil: Date?
+
+    enum CodingKeys: String, CodingKey {
+        case kind
+        case running
+        case pausedUntil = "paused_until"
+    }
+}
+
+public struct ProcessBreakdown: Codable, Hashable {
+    public let name: String
+    public let pid: Int32
+    public let cpuPercent: Float
+    public let rssMb: UInt32
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case pid
+        case cpuPercent = "cpu_percent"
+        case rssMb = "rss_mb"
+    }
+}
+
+public struct ResourceSample: Codable, Hashable {
+    public let cpuPercent: Float
+    public let rssMb: UInt32
+    public let gpuSystemPercent: Float?
+    public let thermalState: ThermalState
+    public let onBattery: Bool
+    public let lowPower: Bool
+    public let processBreakdown: [ProcessBreakdown]
+
+    enum CodingKeys: String, CodingKey {
+        case cpuPercent = "cpu_percent"
+        case rssMb = "rss_mb"
+        case gpuSystemPercent = "gpu_system_percent"
+        case thermalState = "thermal_state"
+        case onBattery = "on_battery"
+        case lowPower = "low_power"
+        case processBreakdown = "process_breakdown"
+    }
+}
+
+public struct GateState: Codable, Hashable {
+    public let allowed: Bool
+    public let reason: GateReason
+    public let since: Date
+    public let waitingFor: String?
+
+    enum CodingKeys: String, CodingKey {
+        case allowed
+        case reason
+        case since
+        case waitingFor = "waiting_for"
+    }
+}
+
+// MARK: - Top-level snapshot
+
+public struct ActivitySnapshot: Codable, Hashable {
+    public let kinds: [KindRow]
+    public let capture: [CaptureRow]
+    public let resources: ResourceSample
+    public let processingGate: GateState
+    public let generatedAt: Date
+
+    enum CodingKeys: String, CodingKey {
+        case kinds
+        case capture
+        case resources
+        case processingGate = "processing_gate"
+        case generatedAt = "generated_at"
+    }
+}
+
+// MARK: - Request bodies
+
+public struct PauseRequest: Codable {
+    public let target: PauseTarget
+    public let id: String
+    public let minutes: UInt32
+
+    public init(target: PauseTarget, id: String, minutes: UInt32) {
+        self.target = target
+        self.id = id
+        self.minutes = minutes
+    }
+}
+
+public struct ResumeRequest: Codable {
+    public let target: PauseTarget
+    public let id: String
+
+    public init(target: PauseTarget, id: String) {
+        self.target = target
+        self.id = id
+    }
+}
+
+public struct InflightUpdate: Codable {
+    public let kind: String
+    public let inFlight: InFlight?
+
+    enum CodingKeys: String, CodingKey {
+        case kind
+        case inFlight = "in_flight"
+    }
+
+    public init(kind: String, inFlight: InFlight?) {
+        self.kind = kind
+        self.inFlight = inFlight
+    }
+}
+
+// MARK: - Notification names + UserDefaults keys (shared across streams)
+
+public enum ActivityNotifications {
+    /// Posted when a pause/resume change is observed locally so live capture
+    /// services (Stream H) can react without polling.
+    public static let pauseChanged = Notification.Name("activityPauseChanged")
+}
+
+public enum ActivityDefaultsKeys {
+    /// Local cache of the most recent snapshot's `processing_gate` for snappy
+    /// UI on cold start. Owned by Stream F.
+    public static let lastGateStateJSON = "activity.lastGateStateJSON"
+}

--- a/Desktop/Sources/Activity/ActivityMonitorService.swift
+++ b/Desktop/Sources/Activity/ActivityMonitorService.swift
@@ -1,0 +1,7 @@
+// Activity Tab — Phase 0 stub.
+//
+// TODO: Stream F. `@MainActor ObservableObject` that polls
+// `APIClient.shared.getActivitySnapshot()` on a 1s Timer.publish, suspends
+// on `NSWindow.didResignKey`, resumes on `didBecomeKey`.
+
+import Foundation

--- a/Desktop/Sources/Activity/ActivityPage.swift
+++ b/Desktop/Sources/Activity/ActivityPage.swift
@@ -1,0 +1,7 @@
+// Activity Tab — Phase 0 stub.
+//
+// TODO: Stream E. Full SwiftUI Activity page: 3 stat cards, In-flight
+// section, Live capture section with confirm sheet, Queued section,
+// Empty-state. Reads from `ActivityMonitorService` (Stream F).
+
+import SwiftUI

--- a/Desktop/Sources/Activity/CapturePauseGate.swift
+++ b/Desktop/Sources/Activity/CapturePauseGate.swift
@@ -1,0 +1,9 @@
+// Activity Tab — Phase 0 stub.
+//
+// TODO: Stream H. Singleton observer that polls Rust pause store every 5s
+// and on `ActivityNotifications.pauseChanged`. Exposes:
+//   - `isPaused(_ id: String) -> Bool`
+//   - `pausedUntil(_ id: String) -> Date?`
+// A/H/G read this; F's UI calls through it for snappy local state too.
+
+import Foundation

--- a/Desktop/Sources/Activity/WorkLabels.swift
+++ b/Desktop/Sources/Activity/WorkLabels.swift
@@ -1,0 +1,8 @@
+// Activity Tab — Phase 0 stub.
+//
+// TODO: Stream E. `humanLabel(_ work: PendingWork) -> String` — converts a
+// scheduler `PendingWork` into a user-facing label like
+// `"Transcribing 14:22:01→14:25:00 (en)"`. Used by Stream G when reporting
+// in-flight to Rust and by the UI when rendering rows.
+
+import Foundation


### PR DESCRIPTION
Phase 0 of the Activity Tab parallel build (umbrella #9). Lands the frozen contract — types, traits, REST shapes, file ownership map — plus empty stub files so all 9 Phase 1 streams (A–I) can branch from `origin/gh-10` and compile from t=0.

## Contract version

`136f9faf6bafd199d98954393ede22c0d1998e2d`

Phase 1 stream PRs MUST reference this hash in their PR body as `Contract version: 136f9fa…`. Any divergence requires a `stream 0-contract amendment` issue + re-freeze.

## Files

### Rust (`Backend-Rust/src/activity/`)

- `contract.md` — frozen REST + JSON contract, file ownership map, notification names, UserDefaults keys
- `types.rs` — serde shapes: `ActivitySnapshot`, `KindRow`, `InFlight`, `CaptureRow`, `ResourceSample`, `GateState`, `PauseRequest`, `ResumeRequest`, `InflightUpdate` (+ enums `WorkKind`, `CaptureKind`, `PauseTarget`, `ThermalState`, `GateReason`)
- `traits.rs` — `PauseStore`, `InflightRegistry`, `ResourceSampler`, `ProcessingGate`
- `mod.rs` — re-exports + per-stream module map
- `pause_store.rs` / `resources.rs` / `inflight.rs` — empty placeholders for streams B/C/D (each is a known target file)

### Rust routes

- `Backend-Rust/src/routes/activity.rs` — handler stubs returning `unimplemented!()` for `snapshot`, `pause`, `resume`, `_internal/inflight`

### Swift (`Desktop/Sources/Activity/`)

- `ActivityModels.swift` — full Codable mirrors of every Rust type, plus `ActivityNotifications.pauseChanged` and `ActivityDefaultsKeys.lastGateStateJSON`
- `ActivityMonitorService.swift` — placeholder for Stream F
- `ActivityPage.swift` — placeholder for Stream E
- `WorkLabels.swift` — placeholder for Stream E
- `CapturePauseGate.swift` — placeholder for Stream H

### Wiring

- `Backend-Rust/src/main.rs` — `mod activity;`
- `Backend-Rust/src/routes/mod.rs` — `mod activity;` (routes NOT yet registered with the Router; Stream A wires after extending `AppState`)

## Build verification

- `cargo build -p infinite-recall-api` → green
- `xcrun swift build -c debug --package-path Desktop` → green

## Per-stream reminder

Phase 1 streams: **your base branch is `gh-10`**, NOT `origin/main`. Branch with:
```
git worktree add ../infinite-recall-activity-<your-issue> -b gh-<your-issue> origin/gh-10
```

| Stream | Owns |
|---|---|
| A — routes + AppState wiring | `routes/activity.rs`, `state.rs` |
| B — pause store | `activity/pause_store.rs`, `migrations/NNNN_paused_work.sql` |
| C — resource sampler | `activity/resources.rs`, `Cargo.toml` (libproc) |
| D — inflight registry | `activity/inflight.rs` |
| E — tab shell + nav | `Activity/ActivityPage.swift`, `Activity/WorkLabels.swift`, +SidebarView/DesktopHomeView/OmiApp |
| F — monitor service + APIClient | `Activity/ActivityMonitorService.swift`, `Activity/ActivityModels.swift`, +APIClient |
| G — scheduler in-flight + pause gate | `Power/BatteryAwareScheduler.swift` |
| H — capture pause gates | `Activity/CapturePauseGate.swift`, +Audio/ScreenCaptureService |
| I — tests + smoke | `tests/activity_endpoints.rs`, `Tests/ActivityModelsTests.swift`, `e2e/activity-tab.md` |

## Idle-gate coordination

Searched for an in-flight idle-gate agent (open PRs, recent commits in `Desktop/Sources/Power/`, `IdleGate*`/`ProcessingGate*` files). **Nothing found.** Shipped the plan's default `GateState` shape (`allowed`, `reason`, `since`, `waiting_for`) and `ProcessingGate { fn current() -> GateState }` trait. If/when the idle-gate agent lands, Stream A is responsible for the adapter — but the on-the-wire JSON shape is frozen.

## Out of scope

No handler logic, no DB queries, no sampler internals, no UI. Implementation belongs to streams A–I.

Closes #10. Part of #9.