### PR TITLE
activity: stream B — pause store + migration (closes #12)

### DIFF
--- a/Backend-Rust/api/migrations/0001_paused_work.sql
+++ b/Backend-Rust/api/migrations/0001_paused_work.sql
@@ -1,0 +1,17 @@
+-- Stream B (issue #12, parent #9, contract 136f9faf6bafd199d98954393ede22c0d1998e2d).
+-- Persistent absolute-time pause storage for the Activity tab.
+--
+-- One row per (target, id) pair currently paused. `resume_at` is the wall-time
+-- (unix epoch seconds, UTC) at which the pause expires. Rows past that time
+-- are treated as not-paused and may be deleted opportunistically.
+--
+-- target ∈ {'kind','capture'}
+-- id     = WorkKind snake_case (e.g. 'transcribe','ocr',...) when target='kind'
+--          OR 'audio'/'screen'                                when target='capture'
+
+CREATE TABLE IF NOT EXISTS paused_work (
+    target    TEXT    NOT NULL,
+    id        TEXT    NOT NULL,
+    resume_at INTEGER NOT NULL,
+    PRIMARY KEY (target, id)
+);

--- a/Backend-Rust/api/src/activity/pause_store.rs
+++ b/Backend-Rust/api/src/activity/pause_store.rs
@@ -1,14 +1,362 @@
 //! Stream B: `SqlPauseStore` — persistent absolute-time pause storage.
 //!
-//! TODO(stream-B): implement `PauseStore` against a new `paused_work` table
-//! (see `Backend-Rust/migrations/NNNN_paused_work.sql`).
+//! Implements the [`PauseStore`] trait against a writable SQLite database
+//! containing the `paused_work` table (see
+//! `Backend-Rust/api/migrations/0001_paused_work.sql`).
 //!
 //! Schema:
 //! ```sql
 //! CREATE TABLE paused_work (
 //!     target    TEXT NOT NULL,    -- 'kind' | 'capture'
 //!     id        TEXT NOT NULL,    -- WorkKind snake_case or 'audio'/'screen'
-//!     resume_at INTEGER NOT NULL, -- unix seconds, absolute
+//!     resume_at INTEGER NOT NULL, -- unix seconds, absolute, UTC
 //!     PRIMARY KEY (target, id)
 //! );
 //! ```
+//!
+//! This module owns its own writable connection pool because the main
+//! `crate::db` pool is opened **read-only** against the GRDB-managed
+//! `omi.db`. Activity-tab pause state is daemon-owned and lives in a
+//! separate file (`activity.db`) so it never collides with the Swift
+//! app's writes.
+
+use std::path::Path;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, TimeZone, Utc};
+use r2d2::Pool;
+use r2d2_sqlite::SqliteConnectionManager;
+use rusqlite::params;
+
+use super::traits::PauseStore;
+use super::types::PauseTarget;
+
+/// Inline migration source. Kept in lockstep with
+/// `Backend-Rust/api/migrations/0001_paused_work.sql` so the binary can
+/// bootstrap an empty `activity.db` without a separate runner.
+const MIGRATION_0001: &str = include_str!("../../migrations/0001_paused_work.sql");
+
+type WritablePool = Pool<SqliteConnectionManager>;
+
+/// SQLite-backed `PauseStore`.
+///
+/// Cloning is cheap — the inner connection pool is `Arc`-shared.
+#[derive(Clone)]
+pub struct SqlPauseStore {
+    pool: Arc<WritablePool>,
+}
+
+impl SqlPauseStore {
+    /// Open (or create) the activity SQLite database at `path` and run
+    /// the embedded migration. Suitable for production use; the daemon
+    /// should pass `~/Library/Application Support/InfiniteRecall/activity.db`.
+    pub fn open(path: &Path) -> Result<Self> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating parent dir {}", parent.display()))?;
+        }
+        let manager = SqliteConnectionManager::file(path);
+        Self::from_manager(manager)
+    }
+
+    /// Open an in-memory database. Intended for tests.
+    pub fn open_in_memory() -> Result<Self> {
+        // `memory()` gives each connection its own private DB, which is
+        // useless for a pool. Use a shared-cache URI so all pooled
+        // connections see the same in-memory schema.
+        let manager = SqliteConnectionManager::file("file::memory:?cache=shared")
+            .with_flags(rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE
+                | rusqlite::OpenFlags::SQLITE_OPEN_CREATE
+                | rusqlite::OpenFlags::SQLITE_OPEN_URI
+                | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX);
+        Self::from_manager(manager)
+    }
+
+    fn from_manager(manager: SqliteConnectionManager) -> Result<Self> {
+        let pool = Pool::builder()
+            .max_size(4)
+            .build(manager)
+            .context("building writable r2d2 pool")?;
+        {
+            let conn = pool.get().context("checking out initial connection")?;
+            // WAL keeps readers + the single writer playing nicely.
+            // Errors here are non-fatal: in-memory DBs reject WAL.
+            let _ = conn.pragma_update(None, "journal_mode", "WAL");
+            conn.execute_batch(MIGRATION_0001)
+                .context("running 0001_paused_work migration")?;
+        }
+        Ok(Self {
+            pool: Arc::new(pool),
+        })
+    }
+}
+
+fn target_str(target: PauseTarget) -> &'static str {
+    match target {
+        PauseTarget::Kind => "kind",
+        PauseTarget::Capture => "capture",
+    }
+}
+
+fn now_unix_secs() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+fn from_unix_secs(secs: i64) -> DateTime<Utc> {
+    Utc.timestamp_opt(secs, 0)
+        .single()
+        .unwrap_or_else(Utc::now)
+}
+
+impl PauseStore for SqlPauseStore {
+    fn paused_until(&self, target: PauseTarget, id: &str) -> Option<DateTime<Utc>> {
+        let conn = self.pool.get().ok()?;
+        let t = target_str(target);
+        let now = now_unix_secs();
+
+        let row: rusqlite::Result<i64> = conn.query_row(
+            "SELECT resume_at FROM paused_work WHERE target = ?1 AND id = ?2",
+            params![t, id],
+            |r| r.get(0),
+        );
+        match row {
+            Ok(resume_at) if resume_at > now => Some(from_unix_secs(resume_at)),
+            Ok(_expired) => {
+                // Opportunistic GC of expired rows. Failure is non-fatal —
+                // the row is already semantically clear.
+                let _ = conn.execute(
+                    "DELETE FROM paused_work WHERE target = ?1 AND id = ?2 AND resume_at <= ?3",
+                    params![t, id, now],
+                );
+                None
+            }
+            Err(rusqlite::Error::QueryReturnedNoRows) => None,
+            Err(e) => {
+                tracing::warn!(error = %e, target = t, id = id, "paused_until query failed");
+                None
+            }
+        }
+    }
+
+    fn pause(&self, target: PauseTarget, id: &str, minutes: u32) -> DateTime<Utc> {
+        let resume_at_secs = now_unix_secs().saturating_add(i64::from(minutes) * 60);
+        let resume_at = from_unix_secs(resume_at_secs);
+        let conn = match self.pool.get() {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::error!(error = %e, "pause: pool checkout failed; returning resume time without persisting");
+                return resume_at;
+            }
+        };
+        let t = target_str(target);
+        if let Err(e) = conn.execute(
+            "INSERT INTO paused_work (target, id, resume_at) VALUES (?1, ?2, ?3)
+             ON CONFLICT(target, id) DO UPDATE SET resume_at = excluded.resume_at",
+            params![t, id, resume_at_secs],
+        ) {
+            tracing::error!(error = %e, target = t, id = id, "pause upsert failed");
+        }
+        resume_at
+    }
+
+    fn resume(&self, target: PauseTarget, id: &str) {
+        let conn = match self.pool.get() {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::error!(error = %e, "resume: pool checkout failed");
+                return;
+            }
+        };
+        let t = target_str(target);
+        if let Err(e) = conn.execute(
+            "DELETE FROM paused_work WHERE target = ?1 AND id = ?2",
+            params![t, id],
+        ) {
+            tracing::error!(error = %e, target = t, id = id, "resume delete failed");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::thread;
+
+    /// Each test gets its own shared-cache in-memory DB by salting the
+    /// URI with a unique counter — otherwise tests would alias rows.
+    static URI_COUNTER: AtomicU32 = AtomicU32::new(0);
+
+    fn fresh_store() -> SqlPauseStore {
+        let n = URI_COUNTER.fetch_add(1, Ordering::SeqCst);
+        let uri = format!("file:pause_store_test_{n}?mode=memory&cache=shared");
+        let manager = SqliteConnectionManager::file(&uri).with_flags(
+            rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE
+                | rusqlite::OpenFlags::SQLITE_OPEN_CREATE
+                | rusqlite::OpenFlags::SQLITE_OPEN_URI
+                | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        );
+        SqlPauseStore::from_manager(manager).expect("open in-memory store")
+    }
+
+    #[test]
+    fn pause_then_read_back_returns_resume_time() {
+        let store = fresh_store();
+        let returned = store.pause(PauseTarget::Kind, "ocr", 15);
+        let observed = store
+            .paused_until(PauseTarget::Kind, "ocr")
+            .expect("paused row should be returned");
+        // Compare to the second — `pause` and `paused_until` both round to seconds.
+        assert_eq!(observed.timestamp(), returned.timestamp());
+        // Sanity: ~15 minutes from now (+/- a couple of seconds for clock drift).
+        let now = now_unix_secs();
+        assert!(observed.timestamp() >= now + 15 * 60 - 2);
+        assert!(observed.timestamp() <= now + 15 * 60 + 2);
+    }
+
+    #[test]
+    fn unpaused_target_returns_none() {
+        let store = fresh_store();
+        assert!(store
+            .paused_until(PauseTarget::Capture, "audio")
+            .is_none());
+    }
+
+    #[test]
+    fn expired_pause_returns_none_and_is_gced() {
+        let store = fresh_store();
+        // Insert a row with a past resume_at directly, simulating a
+        // pause that elapsed while the daemon was down.
+        let conn = store.pool.get().unwrap();
+        conn.execute(
+            "INSERT INTO paused_work (target, id, resume_at) VALUES ('kind', 'transcribe', ?1)",
+            params![now_unix_secs() - 10],
+        )
+        .unwrap();
+        drop(conn);
+
+        assert!(store
+            .paused_until(PauseTarget::Kind, "transcribe")
+            .is_none());
+
+        // Opportunistic GC should have removed the row.
+        let conn = store.pool.get().unwrap();
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM paused_work WHERE target='kind' AND id='transcribe'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 0, "expired row should have been opportunistically deleted");
+    }
+
+    #[test]
+    fn pause_then_resume_clears_row() {
+        let store = fresh_store();
+        store.pause(PauseTarget::Kind, "summarize", 30);
+        assert!(store
+            .paused_until(PauseTarget::Kind, "summarize")
+            .is_some());
+
+        store.resume(PauseTarget::Kind, "summarize");
+        assert!(store
+            .paused_until(PauseTarget::Kind, "summarize")
+            .is_none());
+    }
+
+    #[test]
+    fn pause_overwrite_extends_resume_time() {
+        let store = fresh_store();
+        let short = store.pause(PauseTarget::Capture, "screen", 1);
+        let longer = store.pause(PauseTarget::Capture, "screen", 60);
+        assert!(longer.timestamp() > short.timestamp());
+
+        let observed = store
+            .paused_until(PauseTarget::Capture, "screen")
+            .expect("row should still exist after overwrite");
+        assert_eq!(observed.timestamp(), longer.timestamp());
+
+        // Exactly one row per (target,id) — primary key prevents dupes.
+        let conn = store.pool.get().unwrap();
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM paused_work", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn resume_on_unpaused_target_is_noop() {
+        let store = fresh_store();
+        // Should not panic or error.
+        store.resume(PauseTarget::Kind, "extract_memory");
+        assert!(store
+            .paused_until(PauseTarget::Kind, "extract_memory")
+            .is_none());
+    }
+
+    #[test]
+    fn kind_and_capture_targets_are_independent() {
+        let store = fresh_store();
+        store.pause(PauseTarget::Kind, "audio", 10);
+        // Same id, different target — must be a separate row.
+        assert!(store
+            .paused_until(PauseTarget::Capture, "audio")
+            .is_none());
+        assert!(store.paused_until(PauseTarget::Kind, "audio").is_some());
+    }
+
+    #[test]
+    fn concurrent_reads_are_safe() {
+        let store = fresh_store();
+        store.pause(PauseTarget::Kind, "ocr", 5);
+        let store_arc = Arc::new(store);
+
+        let handles: Vec<_> = (0..8)
+            .map(|_| {
+                let s = Arc::clone(&store_arc);
+                thread::spawn(move || {
+                    for _ in 0..50 {
+                        let r = s.paused_until(PauseTarget::Kind, "ocr");
+                        assert!(r.is_some(), "concurrent reader saw missing row");
+                    }
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().unwrap();
+        }
+    }
+
+    #[test]
+    fn concurrent_writers_keep_single_row_per_key() {
+        let store = Arc::new(fresh_store());
+        let handles: Vec<_> = (0..8)
+            .map(|i| {
+                let s = Arc::clone(&store);
+                thread::spawn(move || {
+                    for _ in 0..20 {
+                        s.pause(PauseTarget::Kind, "ocr", i + 1);
+                    }
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().unwrap();
+        }
+        let conn = store.pool.get().unwrap();
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM paused_work WHERE target='kind' AND id='ocr'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1, "primary key should keep exactly one row");
+    }
+}


### PR DESCRIPTION
Closes #12. Part of #9. Contract version: 136f9faf6bafd199d98954393ede22c0d1998e2d.

## Files
- `Backend-Rust/src/activity/pause_store.rs` — `SqlPauseStore` impl of the Phase 0 `PauseStore` trait. Owns its own writable r2d2/rusqlite pool (separate from the read-only `omi.db` pool) with WAL enabled. Embeds the migration via `include_str!` so the daemon can bootstrap an empty `activity.db`.
- `Backend-Rust/migrations/0001_paused_work.sql` — `CREATE TABLE paused_work (target TEXT, id TEXT, resume_at INTEGER UNIX-SECONDS, PRIMARY KEY (target,id))`.

## Behavior
- `paused_until(target,id)` — returns `None` for missing **or** expired rows. Expired rows are GC'd opportunistically on read.
- `pause(target,id,minutes)` — `INSERT ... ON CONFLICT(target,id) DO UPDATE SET resume_at = excluded.resume_at`. Returns the absolute resume `DateTime<Utc>`.
- `resume(target,id)` — `DELETE` (idempotent).

## Tests
`cargo test -p infinite-recall-api pause_store` — 9 tests, all green:
- pause then read back returns matching resume time
- unpaused target returns `None`
- expired pause returns `None` and is opportunistically GC'd
- pause then resume clears the row
- pause overwrite extends resume time and keeps a single row
- resume on unpaused target is a no-op
- `Kind` and `Capture` targets with the same `id` are independent
- 8 concurrent reader threads see consistent state
- 8 concurrent writer threads converge to exactly one row per key

## Notes for the wiring stream (A)
- `SqlPauseStore::open(&Path)` is the production constructor. Recommend `~/Library/Application Support/InfiniteRecall/activity.db` per CLAUDE.md.
- The struct is `Clone` (cheap, `Arc`-shared internally) and ready to wrap as `Arc<dyn PauseStore>`.