### PR TITLE
activity: stream I — integration tests + e2e smoke checklist

### DIFF
--- a/Backend-Rust/api/tests/activity_endpoints.rs
+++ b/Backend-Rust/api/tests/activity_endpoints.rs
@@ -1,0 +1,654 @@
+//! Activity Tab — Stream I integration tests.
+//!
+//! These exercise the `/v1/activity/*` HTTP surface against the assembled
+//! axum app, with stub implementations of the four backend traits
+//! (`PauseStore`, `InflightRegistry`, `ResourceSampler`, `ProcessingGate`).
+//!
+//! ## Why everything is gated
+//!
+//! Integration tests in `tests/` need to import the crate as a library
+//! (`use infinite_recall_api::...`). The Phase 0 stub crate is binary-only
+//! (`Backend-Rust/Cargo.toml` declares no `[lib]`), and Stream A owns
+//! `state.rs` / `routes/mod.rs` wiring + `main.rs` constructor. Until Stream A
+//! lands a `lib.rs` exposing `routes::router` and the extended `AppState`,
+//! these tests CANNOT compile against the trait-extended state — there is no
+//! library surface to import.
+//!
+//! Strategy:
+//!   1. Wrap the entire test body in `#[cfg(feature = "activity_test_wiring")]`
+//!      so `cargo test` is a no-op today (the file compiles to zero tests).
+//!   2. Stream I's post-merge follow-up flips the feature on (or, more likely,
+//!      Stream A's `lib.rs` makes the imports valid and we drop the gate).
+//!   3. Each test that further depends on a *specific* downstream stream is
+//!      tagged with a `#[ignore = "stream-X"]` so the operator can see at a
+//!      glance which stream's impl unlocks it.
+//!
+//! ## Pre-flight before flipping the feature on
+//!
+//! When this file is enabled, the following Cargo.toml additions are
+//! required (Stream I's post-merge follow-up will own this single edit
+//! to avoid colliding with Stream C's `libproc` add):
+//!
+//! ```toml
+//! [features]
+//! activity_test_wiring = []
+//!
+//! [dev-dependencies]
+//! tempfile = "3"
+//! tokio = { version = "1", features = ["full", "macros", "rt-multi-thread"] }
+//! ```
+//!
+//! `tower` and `axum` are already in `[dependencies]`.
+//!
+//! ## Verification matrix (mirrors §Verification in the plan)
+//!
+//! | Test                                  | Gated on streams |
+//! |---------------------------------------|------------------|
+//! | `snapshot_returns_200_with_full_shape` | A                |
+//! | `pause_returns_paused_until`           | A + B            |
+//! | `paused_kind_visible_in_snapshot`      | A + B            |
+//! | `pause_persists_across_restart`        | A + B            |
+//! | `resume_clears_pause`                  | A + B            |
+//! | `inflight_loopback_round_trip`         | A + D            |
+//! | `missing_bearer_returns_401`           | A                |
+//! | `pause_request_validation`             | A                |
+//! | `enum_round_trip_via_wire`             | (none — type-only) |
+
+#![cfg(feature = "activity_test_wiring")]
+
+// =====================================================================
+// The block below assumes Stream A has shipped the following:
+//
+//   1. `Backend-Rust/Cargo.toml` declares a `[lib]` with `name = "infinite_recall_api"`
+//      and `path = "src/lib.rs"`.
+//   2. `src/lib.rs` re-exports `routes::router`, `state::AppState`, and the
+//      `activity::traits` module.
+//   3. `AppState` is extended with the four `Arc<dyn ...>` fields named
+//      in `activity/contract.md`: `pause_store`, `inflight`,
+//      `resource_sampler`, `processing_gate`.
+//   4. `routes::router(state)` mounts `/v1/activity/*` behind `require_bearer`,
+//      with `/v1/activity/_internal/inflight` additionally restricted to
+//      loopback peers (or at minimum still authed).
+//
+// Plus the per-test gating noted above for B/C/D.
+// =====================================================================
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, RwLock};
+
+use axum::body::{to_bytes, Body};
+use axum::http::{header, Method, Request, StatusCode};
+use chrono::{DateTime, Duration, Utc};
+use serde_json::{json, Value};
+use tower::ServiceExt; // brings `oneshot` onto Router
+
+use infinite_recall_api::activity::traits::{
+    InflightRegistry, PauseStore, ProcessingGate, ResourceSampler,
+};
+use infinite_recall_api::activity::types::{
+    GateReason, GateState, InFlight, PauseTarget, ProcessBreakdown,
+    ResourceSample, ThermalState, WorkKind,
+};
+use infinite_recall_api::routes;
+use infinite_recall_api::state::AppState;
+
+// ---------------------------------------------------------------------
+// Stub implementations
+// ---------------------------------------------------------------------
+
+/// Minimal in-memory `PauseStore` used when Stream B's SQLite impl is not
+/// the unit under test. For persistence test, use Stream B's `SqlPauseStore`
+/// directly (see `pause_persists_across_restart`).
+struct MemPauseStore {
+    inner: Mutex<HashMap<(PauseTarget, String), DateTime<Utc>>>,
+}
+
+impl MemPauseStore {
+    fn new() -> Self {
+        Self {
+            inner: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+impl PauseStore for MemPauseStore {
+    fn paused_until(&self, target: PauseTarget, id: &str) -> Option<DateTime<Utc>> {
+        self.inner
+            .lock()
+            .unwrap()
+            .get(&(target, id.to_string()))
+            .copied()
+    }
+
+    fn pause(&self, target: PauseTarget, id: &str, minutes: u32) -> DateTime<Utc> {
+        let resume_at = Utc::now() + Duration::minutes(minutes as i64);
+        self.inner
+            .lock()
+            .unwrap()
+            .insert((target, id.to_string()), resume_at);
+        resume_at
+    }
+
+    fn resume(&self, target: PauseTarget, id: &str) {
+        self.inner
+            .lock()
+            .unwrap()
+            .remove(&(target, id.to_string()));
+    }
+}
+
+/// Minimal in-memory `InflightRegistry`.
+struct MemInflight {
+    inner: RwLock<HashMap<WorkKind, InFlight>>,
+}
+
+impl MemInflight {
+    fn new() -> Self {
+        Self {
+            inner: RwLock::new(HashMap::new()),
+        }
+    }
+}
+
+impl InflightRegistry for MemInflight {
+    fn snapshot(&self) -> HashMap<WorkKind, InFlight> {
+        self.inner.read().unwrap().clone()
+    }
+
+    fn update(&self, kind: WorkKind, in_flight: Option<InFlight>) {
+        let mut g = self.inner.write().unwrap();
+        match in_flight {
+            Some(f) => {
+                g.insert(kind, f);
+            }
+            None => {
+                g.remove(&kind);
+            }
+        }
+    }
+}
+
+/// Returns a fixed `ResourceSample` so assertions are deterministic.
+struct FakeSampler;
+impl ResourceSampler for FakeSampler {
+    fn sample(&self) -> ResourceSample {
+        ResourceSample {
+            cpu_percent: 12.5,
+            rss_mb: 256,
+            gpu_system_percent: Some(33.3),
+            thermal_state: ThermalState::Nominal,
+            on_battery: false,
+            low_power: false,
+            process_breakdown: vec![ProcessBreakdown {
+                name: "infinite-recall-api".into(),
+                pid: 4242,
+                cpu_percent: 12.5,
+                rss_mb: 256,
+            }],
+        }
+    }
+}
+
+/// Always-allow gate for stub purposes; tests that need a "blocked" gate
+/// substitute their own.
+struct FakeGate {
+    state: GateState,
+}
+impl FakeGate {
+    fn allow() -> Self {
+        Self {
+            state: GateState {
+                allowed: true,
+                reason: GateReason::None,
+                since: Utc::now(),
+                waiting_for: None,
+            },
+        }
+    }
+}
+impl ProcessingGate for FakeGate {
+    fn current(&self) -> GateState {
+        self.state.clone()
+    }
+}
+
+// ---------------------------------------------------------------------
+// App builder
+// ---------------------------------------------------------------------
+
+const TEST_TOKEN: &str = "test-bearer-token-deadbeef";
+
+/// Build an `AppState` with stub trait impls. The two SQLite pools come
+/// from an `:memory:` DB so we don't touch disk.
+///
+/// NOTE: Stream A is responsible for ensuring `AppState` has a constructor
+/// (or at least public fields) that lets test code populate the four new
+/// `Arc<dyn ...>` slots independently of the real one in `main.rs`.
+fn make_state(
+    pause_store: Arc<dyn PauseStore>,
+    inflight: Arc<dyn InflightRegistry>,
+    sampler: Arc<dyn ResourceSampler>,
+    gate: Arc<dyn ProcessingGate>,
+) -> AppState {
+    let pool = infinite_recall_api::db::open_in_memory_pool()
+        .expect("in-memory pool — Stream A should expose a test helper");
+    AppState {
+        pool,
+        token: TEST_TOKEN.to_string(),
+        pause_store,
+        inflight,
+        resource_sampler: sampler,
+        processing_gate: gate,
+    }
+}
+
+fn make_default_app() -> axum::Router {
+    let state = make_state(
+        Arc::new(MemPauseStore::new()),
+        Arc::new(MemInflight::new()),
+        Arc::new(FakeSampler),
+        Arc::new(FakeGate::allow()),
+    );
+    routes::router(state)
+}
+
+fn auth_header() -> (axum::http::HeaderName, axum::http::HeaderValue) {
+    (
+        header::AUTHORIZATION,
+        format!("Bearer {TEST_TOKEN}").parse().unwrap(),
+    )
+}
+
+async fn json_body(resp: axum::response::Response) -> Value {
+    let bytes = to_bytes(resp.into_body(), 1 << 20).await.unwrap();
+    serde_json::from_slice(&bytes).expect("response body is valid JSON")
+}
+
+// ---------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------
+
+/// §Verification step 6: snapshot returns the full shape with every field
+/// present and correctly typed.
+#[tokio::test]
+#[ignore = "stream-A: needs route handlers wired"]
+async fn snapshot_returns_200_with_full_shape() {
+    let app = make_default_app();
+    let (k, v) = auth_header();
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri("/v1/activity/snapshot")
+        .header(k, v)
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = json_body(resp).await;
+
+    // Top-level shape per contract.md.
+    for required in [
+        "kinds",
+        "capture",
+        "resources",
+        "processing_gate",
+        "generated_at",
+    ] {
+        assert!(
+            body.get(required).is_some(),
+            "missing required field `{required}` in: {body}"
+        );
+    }
+
+    // `kinds` is an array of objects with all six keys.
+    let kinds = body["kinds"].as_array().expect("kinds is an array");
+    for row in kinds {
+        for required in [
+            "kind",
+            "in_flight",
+            "queued",
+            "failed",
+            "last_done_at",
+            "paused_until",
+        ] {
+            assert!(
+                row.get(required).is_some(),
+                "kind row missing `{required}`: {row}"
+            );
+        }
+    }
+
+    // `capture` is an array of {kind, running, paused_until}.
+    let capture = body["capture"].as_array().expect("capture is an array");
+    for row in capture {
+        for required in ["kind", "running", "paused_until"] {
+            assert!(row.get(required).is_some());
+        }
+    }
+
+    // `resources` populated by FakeSampler.
+    let res = &body["resources"];
+    assert_eq!(res["cpu_percent"], json!(12.5));
+    assert_eq!(res["rss_mb"], json!(256));
+    assert_eq!(res["gpu_system_percent"], json!(33.3));
+    assert_eq!(res["thermal_state"], json!("nominal"));
+    assert_eq!(res["on_battery"], json!(false));
+    assert_eq!(res["low_power"], json!(false));
+    assert!(res["process_breakdown"].is_array());
+
+    // `processing_gate` populated by FakeGate::allow.
+    let g = &body["processing_gate"];
+    assert_eq!(g["allowed"], json!(true));
+    assert_eq!(g["reason"], json!("none"));
+    assert!(g["since"].is_string());
+
+    // `generated_at` is ISO-8601 string.
+    assert!(body["generated_at"].is_string());
+}
+
+/// §Verification step 7: POST pause writes the row and returns
+/// `{paused_until: iso8601}`.
+#[tokio::test]
+#[ignore = "stream-A: needs pause handler wired (B's impl unnecessary — uses MemPauseStore)"]
+async fn pause_returns_paused_until() {
+    let app = make_default_app();
+    let (k, v) = auth_header();
+    let body = json!({ "target": "kind", "id": "ocr", "minutes": 1 });
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/v1/activity/pause")
+        .header(k, v)
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = json_body(resp).await;
+    let s = body["paused_until"].as_str().expect("paused_until is a string");
+    let parsed: DateTime<Utc> = s.parse().expect("paused_until is iso8601");
+    let delta = parsed - Utc::now();
+    assert!(
+        delta.num_seconds().abs() <= 70,
+        "paused_until should be ~now+60s; got delta {}s",
+        delta.num_seconds()
+    );
+}
+
+/// After a pause, the kind row in the snapshot reflects `paused_until`.
+#[tokio::test]
+#[ignore = "stream-A"]
+async fn paused_kind_visible_in_snapshot() {
+    // Single AppState shared across the two requests so the pause persists.
+    let pause_store: Arc<dyn PauseStore> = Arc::new(MemPauseStore::new());
+    let state = make_state(
+        pause_store.clone(),
+        Arc::new(MemInflight::new()),
+        Arc::new(FakeSampler),
+        Arc::new(FakeGate::allow()),
+    );
+    let app = routes::router(state);
+    let (k, v) = auth_header();
+
+    // 1. Pause OCR for 1 minute.
+    let pause_req = Request::builder()
+        .method(Method::POST)
+        .uri("/v1/activity/pause")
+        .header(&k, v.clone())
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(json!({"target":"kind","id":"ocr","minutes":1}).to_string()))
+        .unwrap();
+    let resp = app.clone().oneshot(pause_req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // 2. Snapshot should now show ocr row with paused_until ≈ now+60s.
+    let snap_req = Request::builder()
+        .method(Method::GET)
+        .uri("/v1/activity/snapshot")
+        .header(k, v)
+        .body(Body::empty())
+        .unwrap();
+    let snap = json_body(app.oneshot(snap_req).await.unwrap()).await;
+
+    let ocr = snap["kinds"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|row| row["kind"] == "ocr")
+        .expect("snapshot must contain a row for every WorkKind");
+    let pu = ocr["paused_until"].as_str().expect("ocr.paused_until is set");
+    let parsed: DateTime<Utc> = pu.parse().expect("iso8601");
+    let delta = parsed - Utc::now();
+    assert!(
+        delta.num_seconds() > 0 && delta.num_seconds() <= 70,
+        "paused_until should be ~now+60s; got {}s",
+        delta.num_seconds()
+    );
+}
+
+/// §Verification step 9: pause persists across daemon restart.
+/// Uses Stream B's `SqlPauseStore` directly — both lifecycles point at the
+/// same SQLite file path.
+#[tokio::test]
+#[ignore = "stream-B: needs SqlPauseStore + paused_work migration"]
+async fn pause_persists_across_restart() {
+    use infinite_recall_api::activity::pause_store::SqlPauseStore;
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let path = tmp.path().to_path_buf();
+
+    // Lifecycle 1: write a pause then drop everything.
+    {
+        let store = SqlPauseStore::open(&path).expect("open SqlPauseStore");
+        let resume_at = store.pause(PauseTarget::Kind, "ocr", 30);
+        assert!(resume_at > Utc::now());
+        // store dropped here.
+    }
+
+    // Lifecycle 2: re-open the same file; the pause must still be there.
+    {
+        let store = SqlPauseStore::open(&path).expect("re-open SqlPauseStore");
+        let pu = store
+            .paused_until(PauseTarget::Kind, "ocr")
+            .expect("pause must survive restart");
+        let delta = pu - Utc::now();
+        assert!(
+            delta.num_minutes() > 25 && delta.num_minutes() <= 30,
+            "resume time drifted: {}m",
+            delta.num_minutes()
+        );
+    }
+}
+
+/// POST resume clears the pause row.
+#[tokio::test]
+#[ignore = "stream-A"]
+async fn resume_clears_pause() {
+    let pause_store: Arc<dyn PauseStore> = Arc::new(MemPauseStore::new());
+    let state = make_state(
+        pause_store.clone(),
+        Arc::new(MemInflight::new()),
+        Arc::new(FakeSampler),
+        Arc::new(FakeGate::allow()),
+    );
+    let app = routes::router(state);
+    let (k, v) = auth_header();
+
+    pause_store.pause(PauseTarget::Kind, "ocr", 5);
+    assert!(pause_store.paused_until(PauseTarget::Kind, "ocr").is_some());
+
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/v1/activity/resume")
+        .header(k, v)
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(json!({"target":"kind","id":"ocr"}).to_string()))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+    assert!(
+        pause_store.paused_until(PauseTarget::Kind, "ocr").is_none(),
+        "resume must clear the row"
+    );
+}
+
+/// `_internal/inflight` updates the registry; subsequent snapshot reflects it.
+#[tokio::test]
+#[ignore = "stream-A + stream-D"]
+async fn inflight_loopback_round_trip() {
+    let inflight: Arc<dyn InflightRegistry> = Arc::new(MemInflight::new());
+    let state = make_state(
+        Arc::new(MemPauseStore::new()),
+        inflight.clone(),
+        Arc::new(FakeSampler),
+        Arc::new(FakeGate::allow()),
+    );
+    let app = routes::router(state);
+    let (k, v) = auth_header();
+
+    let body = json!({
+        "kind": "transcribe",
+        "in_flight": {
+            "label": "Transcribing 14:22:01→14:25:00 (en)",
+            "started_at": "2026-04-26T14:22:03.812Z"
+        }
+    });
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/v1/activity/_internal/inflight")
+        .header(&k, v.clone())
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+    // Snapshot now shows transcribe.in_flight populated.
+    let snap_req = Request::builder()
+        .method(Method::GET)
+        .uri("/v1/activity/snapshot")
+        .header(k, v)
+        .body(Body::empty())
+        .unwrap();
+    let snap = json_body(app.oneshot(snap_req).await.unwrap()).await;
+    let transcribe = snap["kinds"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|r| r["kind"] == "transcribe")
+        .unwrap();
+    let inf = &transcribe["in_flight"];
+    assert!(!inf.is_null(), "in_flight must be populated after loopback POST");
+    assert_eq!(inf["label"], json!("Transcribing 14:22:01→14:25:00 (en)"));
+
+    // Clearing form: in_flight: null
+    let clear = json!({ "kind": "transcribe", "in_flight": null });
+    let (k2, v2) = auth_header();
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/v1/activity/_internal/inflight")
+        .header(k2, v2)
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(clear.to_string()))
+        .unwrap();
+    let app2 = routes::router(make_state(
+        Arc::new(MemPauseStore::new()),
+        inflight.clone(),
+        Arc::new(FakeSampler),
+        Arc::new(FakeGate::allow()),
+    ));
+    let resp = app2.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+    assert!(inflight.snapshot().get(&WorkKind::Transcribe).is_none());
+}
+
+/// Auth: missing bearer → 401.
+#[tokio::test]
+#[ignore = "stream-A: needs activity routes mounted under require_bearer"]
+async fn missing_bearer_returns_401() {
+    let app = make_default_app();
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri("/v1/activity/snapshot")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+/// Bad pause body → 400 (or 422). Stream A picks the exact code; we accept
+/// any 4xx that signals client error.
+#[tokio::test]
+#[ignore = "stream-A"]
+async fn pause_request_validation() {
+    let app = make_default_app();
+    let (k, v) = auth_header();
+    // Missing `minutes`.
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/v1/activity/pause")
+        .header(k, v)
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(json!({"target":"kind","id":"ocr"}).to_string()))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert!(
+        resp.status().is_client_error(),
+        "expected 4xx for invalid body; got {}",
+        resp.status()
+    );
+}
+
+/// Type-only round trip — no Stream A wiring needed. Sanity check that
+/// the contract.md snake_case wire format matches what serde emits.
+#[tokio::test]
+async fn enum_round_trip_via_wire() {
+    use infinite_recall_api::activity::types as t;
+
+    // Every WorkKind value.
+    for (kind, wire) in [
+        (t::WorkKind::Transcribe, "transcribe"),
+        (t::WorkKind::Ocr, "ocr"),
+        (t::WorkKind::Summarize, "summarize"),
+        (t::WorkKind::ExtractMemory, "extract_memory"),
+        (t::WorkKind::ExtractActionItems, "extract_action_items"),
+    ] {
+        let s = serde_json::to_string(&kind).unwrap();
+        assert_eq!(s, format!("\"{wire}\""));
+        let back: t::WorkKind = serde_json::from_str(&s).unwrap();
+        assert_eq!(kind, back);
+    }
+
+    // Every GateReason value.
+    for (reason, wire) in [
+        (t::GateReason::Idle, "idle"),
+        (t::GateReason::DeviceActive, "device_active"),
+        (t::GateReason::OnBattery, "on_battery"),
+        (t::GateReason::Thermal, "thermal"),
+        (t::GateReason::Locked, "locked"),
+        (t::GateReason::ManualPause, "manual_pause"),
+        (t::GateReason::None, "none"),
+    ] {
+        let s = serde_json::to_string(&reason).unwrap();
+        assert_eq!(s, format!("\"{wire}\""));
+    }
+
+    // Every ThermalState.
+    for (ts, wire) in [
+        (t::ThermalState::Nominal, "nominal"),
+        (t::ThermalState::Fair, "fair"),
+        (t::ThermalState::Serious, "serious"),
+        (t::ThermalState::Critical, "critical"),
+    ] {
+        let s = serde_json::to_string(&ts).unwrap();
+        assert_eq!(s, format!("\"{wire}\""));
+    }
+
+    // PauseTarget.
+    for (pt, wire) in [
+        (t::PauseTarget::Kind, "kind"),
+        (t::PauseTarget::Capture, "capture"),
+    ] {
+        let s = serde_json::to_string(&pt).unwrap();
+        assert_eq!(s, format!("\"{wire}\""));
+    }
+}

--- a/Desktop/Tests/ActivityModelsTests.swift
+++ b/Desktop/Tests/ActivityModelsTests.swift
@@ -1,0 +1,411 @@
+// Activity Tab — Stream I.
+//
+// Codable round-trip tests for the Phase 0 contract types in
+// `Desktop/Sources/Activity/ActivityModels.swift`. The wire format is
+// snake_case JSON shaped per `Backend-Rust/src/activity/contract.md`.
+//
+// What we verify:
+//   1. A canonical fixture matching the contract decodes into our Swift
+//      types with every field present and correctly typed.
+//   2. Re-encoding the decoded value and decoding it again yields a value
+//      equal to the original (round-trip stability).
+//   3. Optional fields are honoured in both directions (nullability,
+//      omission of `waiting_for`, `gpu_system_percent`, etc).
+//   4. Every `GateReason` enum value decodes from its snake_case wire form.
+//   5. Every `WorkKind`, `CaptureKind`, `ThermalState`, `PauseTarget`
+//      enum value decodes from its snake_case wire form.
+//   6. Request bodies (`PauseRequest`, `ResumeRequest`, `InflightUpdate`)
+//      encode to the wire shape Stream A expects.
+
+import XCTest
+@testable import Omi_Computer
+
+final class ActivityModelsTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// Decoder configured for the contract's ISO-8601 timestamps with
+    /// fractional seconds (e.g. `2026-04-26T14:22:03.812Z`).
+    private static func makeDecoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .custom { d in
+            let container = try d.singleValueContainer()
+            let s = try container.decode(String.self)
+            if let date = isoFractional.date(from: s) ?? isoPlain.date(from: s) {
+                return date
+            }
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Unparseable ISO8601: \(s)"
+            )
+        }
+        return decoder
+    }
+
+    private static func makeEncoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .custom { date, encoder in
+            var c = encoder.singleValueContainer()
+            try c.encode(isoFractional.string(from: date))
+        }
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }
+
+    private static let isoFractional: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
+    private static let isoPlain: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
+
+    // MARK: - Fixture (matches §contract.md verbatim)
+
+    /// Verbatim fixture from contract.md — exercises every field with a
+    /// non-default value where possible.
+    private static let fixtureSnapshotJSON = """
+    {
+      "kinds": [
+        {
+          "kind": "transcribe",
+          "in_flight": {
+            "label": "Transcribing 14:22:01→14:25:00 (en)",
+            "started_at": "2026-04-26T14:22:03.812Z"
+          },
+          "queued": 47,
+          "failed": 0,
+          "last_done_at": "2026-04-26T14:21:58.000Z",
+          "paused_until": null
+        },
+        {
+          "kind": "ocr",
+          "in_flight": null,
+          "queued": 12,
+          "failed": 3,
+          "last_done_at": null,
+          "paused_until": "2026-04-26T14:40:00.000Z"
+        }
+      ],
+      "capture": [
+        { "kind": "audio",  "running": true,  "paused_until": null },
+        { "kind": "screen", "running": false, "paused_until": "2026-04-26T14:30:00.000Z" }
+      ],
+      "resources": {
+        "cpu_percent": 142.0,
+        "rss_mb": 2342,
+        "gpu_system_percent": 38.0,
+        "thermal_state": "fair",
+        "on_battery": false,
+        "low_power": false,
+        "process_breakdown": [
+          { "name": "infinite-recall-api", "pid": 1234, "cpu_percent": 12.4, "rss_mb": 84 },
+          { "name": "Infinite Recall",     "pid": 1235, "cpu_percent": 51.2, "rss_mb": 760 },
+          { "name": "mlx-lm.server",       "pid": 1236, "cpu_percent": 78.4, "rss_mb": 1498 }
+        ]
+      },
+      "processing_gate": {
+        "allowed": false,
+        "reason": "device_active",
+        "since": "2026-04-26T14:25:00.000Z",
+        "waiting_for": "2 min of idle"
+      },
+      "generated_at": "2026-04-26T14:25:30.512Z"
+    }
+    """
+
+    // MARK: - Snapshot decode: every field
+
+    func testDecodeSnapshotPopulatesAllFields() throws {
+        let snap = try Self.makeDecoder()
+            .decode(ActivitySnapshot.self, from: Self.fixtureSnapshotJSON.data(using: .utf8)!)
+
+        // Top-level
+        XCTAssertEqual(snap.kinds.count, 2)
+        XCTAssertEqual(snap.capture.count, 2)
+
+        // First kind row — populated in_flight, no pause
+        let transcribe = snap.kinds[0]
+        XCTAssertEqual(transcribe.kind, .transcribe)
+        XCTAssertEqual(transcribe.queued, 47)
+        XCTAssertEqual(transcribe.failed, 0)
+        XCTAssertNotNil(transcribe.lastDoneAt)
+        XCTAssertNil(transcribe.pausedUntil)
+        XCTAssertEqual(transcribe.inFlight?.label, "Transcribing 14:22:01→14:25:00 (en)")
+        XCTAssertNotNil(transcribe.inFlight?.startedAt)
+
+        // Second kind row — empty in_flight, paused
+        let ocr = snap.kinds[1]
+        XCTAssertEqual(ocr.kind, .ocr)
+        XCTAssertNil(ocr.inFlight)
+        XCTAssertEqual(ocr.queued, 12)
+        XCTAssertEqual(ocr.failed, 3)
+        XCTAssertNil(ocr.lastDoneAt)
+        XCTAssertNotNil(ocr.pausedUntil)
+
+        // Capture rows — one running, one paused
+        XCTAssertEqual(snap.capture[0].kind, .audio)
+        XCTAssertTrue(snap.capture[0].running)
+        XCTAssertNil(snap.capture[0].pausedUntil)
+        XCTAssertEqual(snap.capture[1].kind, .screen)
+        XCTAssertFalse(snap.capture[1].running)
+        XCTAssertNotNil(snap.capture[1].pausedUntil)
+
+        // Resources — every field
+        let res = snap.resources
+        XCTAssertEqual(res.cpuPercent, 142.0, accuracy: 0.001)
+        XCTAssertEqual(res.rssMb, 2342)
+        XCTAssertEqual(res.gpuSystemPercent ?? -1, 38.0, accuracy: 0.001)
+        XCTAssertEqual(res.thermalState, .fair)
+        XCTAssertFalse(res.onBattery)
+        XCTAssertFalse(res.lowPower)
+        XCTAssertEqual(res.processBreakdown.count, 3)
+        XCTAssertEqual(res.processBreakdown[2].name, "mlx-lm.server")
+        XCTAssertEqual(res.processBreakdown[2].pid, 1236)
+        XCTAssertEqual(res.processBreakdown[2].cpuPercent, 78.4, accuracy: 0.001)
+        XCTAssertEqual(res.processBreakdown[2].rssMb, 1498)
+
+        // Gate state
+        XCTAssertFalse(snap.processingGate.allowed)
+        XCTAssertEqual(snap.processingGate.reason, .deviceActive)
+        XCTAssertEqual(snap.processingGate.waitingFor, "2 min of idle")
+    }
+
+    // MARK: - Round-trip stability
+
+    func testSnapshotRoundTrip() throws {
+        let decoder = Self.makeDecoder()
+        let encoder = Self.makeEncoder()
+
+        let original = try decoder
+            .decode(ActivitySnapshot.self, from: Self.fixtureSnapshotJSON.data(using: .utf8)!)
+        let reEncoded = try encoder.encode(original)
+        let reDecoded = try decoder.decode(ActivitySnapshot.self, from: reEncoded)
+
+        // Hashable conformance lets us compare without writing field-by-field
+        // assertions, but we keep targeted ones below for debuggability.
+        XCTAssertEqual(original, reDecoded)
+        XCTAssertEqual(original.kinds, reDecoded.kinds)
+        XCTAssertEqual(original.capture, reDecoded.capture)
+        XCTAssertEqual(original.resources, reDecoded.resources)
+        XCTAssertEqual(original.processingGate, reDecoded.processingGate)
+        XCTAssertEqual(original.generatedAt, reDecoded.generatedAt)
+    }
+
+    // MARK: - Optional / variant cases
+
+    func testGpuSystemPercentMayBeNull() throws {
+        // Apple Silicon with GPU sampler unavailable / non-AS hosts.
+        let json = """
+        {
+          "cpu_percent": 8.0,
+          "rss_mb": 100,
+          "gpu_system_percent": null,
+          "thermal_state": "nominal",
+          "on_battery": true,
+          "low_power": true,
+          "process_breakdown": []
+        }
+        """
+        let r = try Self.makeDecoder().decode(ResourceSample.self, from: json.data(using: .utf8)!)
+        XCTAssertNil(r.gpuSystemPercent)
+        XCTAssertTrue(r.onBattery)
+        XCTAssertTrue(r.lowPower)
+        XCTAssertEqual(r.processBreakdown.count, 0)
+    }
+
+    func testGateStateWaitingForMayBeOmitted() throws {
+        // Rust serializes this with `skip_serializing_if = "Option::is_none"`,
+        // so the field can be absent (not just null) on the wire.
+        let json = """
+        { "allowed": true, "reason": "none", "since": "2026-04-26T14:25:00.000Z" }
+        """
+        let g = try Self.makeDecoder().decode(GateState.self, from: json.data(using: .utf8)!)
+        XCTAssertTrue(g.allowed)
+        XCTAssertEqual(g.reason, .none)
+        XCTAssertNil(g.waitingFor)
+    }
+
+    func testGateStateWaitingForExplicitNullDecodes() throws {
+        let json = """
+        { "allowed": true, "reason": "none", "since": "2026-04-26T14:25:00.000Z", "waiting_for": null }
+        """
+        let g = try Self.makeDecoder().decode(GateState.self, from: json.data(using: .utf8)!)
+        XCTAssertNil(g.waitingFor)
+    }
+
+    func testEmptyInFlightMapAndQueuedZero() throws {
+        // The "Up to date" UX state from the plan §UX scenario 5.
+        let json = """
+        {
+          "kind": "summarize",
+          "in_flight": null,
+          "queued": 0,
+          "failed": 0,
+          "last_done_at": null,
+          "paused_until": null
+        }
+        """
+        let row = try Self.makeDecoder().decode(KindRow.self, from: json.data(using: .utf8)!)
+        XCTAssertEqual(row.kind, .summarize)
+        XCTAssertNil(row.inFlight)
+        XCTAssertEqual(row.queued, 0)
+    }
+
+    // MARK: - Enum coverage (every wire value)
+
+    func testGateReasonEveryEnumValueDecodes() throws {
+        let cases: [(String, GateReason)] = [
+            ("idle",          .idle),
+            ("device_active", .deviceActive),
+            ("on_battery",    .onBattery),
+            ("thermal",       .thermal),
+            ("locked",        .locked),
+            ("manual_pause",  .manualPause),
+            ("none",          .none),
+        ]
+        for (wire, expected) in cases {
+            let json = """
+            { "allowed": false, "reason": "\(wire)", "since": "2026-04-26T14:25:00.000Z" }
+            """
+            let g = try Self.makeDecoder().decode(GateState.self, from: json.data(using: .utf8)!)
+            XCTAssertEqual(g.reason, expected, "wire value \(wire) should decode to \(expected)")
+        }
+    }
+
+    func testWorkKindEveryEnumValueRoundTrips() throws {
+        let cases: [(String, WorkKind)] = [
+            ("transcribe",            .transcribe),
+            ("ocr",                   .ocr),
+            ("summarize",             .summarize),
+            ("extract_memory",        .extractMemory),
+            ("extract_action_items",  .extractActionItems),
+        ]
+        for (wire, expected) in cases {
+            let json = """
+            { "kind": "\(wire)", "in_flight": null, "queued": 0, "failed": 0,
+              "last_done_at": null, "paused_until": null }
+            """
+            let row = try Self.makeDecoder().decode(KindRow.self, from: json.data(using: .utf8)!)
+            XCTAssertEqual(row.kind, expected)
+
+            // Encode back — wire representation must match the snake_case input.
+            let encoded = try Self.makeEncoder().encode(row)
+            let str = String(data: encoded, encoding: .utf8) ?? ""
+            XCTAssertTrue(str.contains("\"\(wire)\""),
+                          "encoded form should contain \"\(wire)\"; got: \(str)")
+        }
+    }
+
+    func testCaptureKindEveryEnumValueRoundTrips() throws {
+        for (wire, expected) in [("audio", CaptureKind.audio), ("screen", .screen)] {
+            let json = """
+            { "kind": "\(wire)", "running": true, "paused_until": null }
+            """
+            let row = try Self.makeDecoder().decode(CaptureRow.self, from: json.data(using: .utf8)!)
+            XCTAssertEqual(row.kind, expected)
+        }
+    }
+
+    func testThermalStateEveryEnumValueDecodes() throws {
+        let cases: [(String, ThermalState)] = [
+            ("nominal",  .nominal),
+            ("fair",     .fair),
+            ("serious",  .serious),
+            ("critical", .critical),
+        ]
+        for (wire, expected) in cases {
+            let json = """
+            { "cpu_percent": 0, "rss_mb": 0, "gpu_system_percent": null,
+              "thermal_state": "\(wire)", "on_battery": false, "low_power": false,
+              "process_breakdown": [] }
+            """
+            let r = try Self.makeDecoder().decode(ResourceSample.self, from: json.data(using: .utf8)!)
+            XCTAssertEqual(r.thermalState, expected)
+        }
+    }
+
+    func testPauseTargetEveryEnumValueRoundTrips() throws {
+        for (wire, expected) in [("kind", PauseTarget.kind), ("capture", .capture)] {
+            let json = """
+            { "target": "\(wire)", "id": "ocr", "minutes": 15 }
+            """
+            let req = try Self.makeDecoder().decode(PauseRequest.self, from: json.data(using: .utf8)!)
+            XCTAssertEqual(req.target, expected)
+        }
+    }
+
+    // MARK: - Request bodies serialise to wire shape Stream A expects
+
+    func testPauseRequestEncodesSnakeCase() throws {
+        let req = PauseRequest(target: .kind, id: "ocr", minutes: 15)
+        let data = try Self.makeEncoder().encode(req)
+        let str = String(data: data, encoding: .utf8) ?? ""
+        XCTAssertTrue(str.contains("\"target\":\"kind\""), "got: \(str)")
+        XCTAssertTrue(str.contains("\"id\":\"ocr\""),     "got: \(str)")
+        XCTAssertTrue(str.contains("\"minutes\":15"),     "got: \(str)")
+    }
+
+    func testResumeRequestEncodesSnakeCase() throws {
+        let req = ResumeRequest(target: .capture, id: "audio")
+        let data = try Self.makeEncoder().encode(req)
+        let str = String(data: data, encoding: .utf8) ?? ""
+        XCTAssertTrue(str.contains("\"target\":\"capture\""), "got: \(str)")
+        XCTAssertTrue(str.contains("\"id\":\"audio\""),       "got: \(str)")
+    }
+
+    func testInflightUpdateEncodesNullClearing() throws {
+        // NOTE: Swift's default JSONEncoder OMITS nil optionals rather than
+        // emitting `"in_flight":null`. The Rust receiver in Stream A uses
+        // `serde::Deserialize` on `in_flight: Option<InFlight>`, which treats
+        // an absent field as `None` — so omission and `null` are wire-equivalent.
+        // We assert Swift's actual behaviour here so a future encoder swap
+        // (e.g. to one that emits explicit nulls) is a deliberate change with
+        // a failing test as the heads-up.
+        let cleared = InflightUpdate(kind: "transcribe", inFlight: nil)
+        let data = try Self.makeEncoder().encode(cleared)
+        let str = String(data: data, encoding: .utf8) ?? ""
+        XCTAssertTrue(str.contains("\"kind\":\"transcribe\""), "got: \(str)")
+        // Either omitted (Swift default) or explicit null is acceptable.
+        let omitted = !str.contains("\"in_flight\"")
+        let explicitNull = str.contains("\"in_flight\":null")
+        XCTAssertTrue(omitted || explicitNull,
+                      "expected `in_flight` omitted or null; got: \(str)")
+
+        // Round-trip: the receiver must decode this back to nil.
+        let decoded = try Self.makeDecoder().decode(InflightUpdate.self, from: data)
+        XCTAssertEqual(decoded.kind, "transcribe")
+        XCTAssertNil(decoded.inFlight)
+    }
+
+    func testInflightUpdateEncodesPopulated() throws {
+        let date = Self.isoFractional.date(from: "2026-04-26T14:22:03.812Z")!
+        let upd = InflightUpdate(
+            kind: "transcribe",
+            inFlight: InFlight(label: "Transcribing 14:22:01→14:25:00 (en)", startedAt: date)
+        )
+        let data = try Self.makeEncoder().encode(upd)
+        let str = String(data: data, encoding: .utf8) ?? ""
+        XCTAssertTrue(str.contains("\"kind\":\"transcribe\""))
+        // CodingKeys map startedAt → "started_at" and inFlight → "in_flight".
+        XCTAssertTrue(str.contains("\"in_flight\""), "got: \(str)")
+        XCTAssertTrue(str.contains("\"started_at\""), "got: \(str)")
+        XCTAssertTrue(str.contains("\"label\":\"Transcribing 14:22:01→14:25:00 (en)\""),
+                      "got: \(str)")
+    }
+
+    // MARK: - Notification & defaults constants are stable
+
+    func testNotificationNameMatchesContract() {
+        // contract.md pins this string; G/H rely on it cross-stream.
+        XCTAssertEqual(ActivityNotifications.pauseChanged.rawValue, "activityPauseChanged")
+    }
+
+    func testDefaultsKeyMatchesContract() {
+        XCTAssertEqual(ActivityDefaultsKeys.lastGateStateJSON, "activity.lastGateStateJSON")
+    }
+}

--- a/e2e/activity-tab.md
+++ b/e2e/activity-tab.md
@@ -1,0 +1,256 @@
+# Activity Tab — Manual Smoke Checklist
+
+> Owner: Stream I.
+> Source plan: `~/.claude/plans/for-ir-can-we-majestic-island.md` §Verification.
+> Companion automated tests:
+> - `Backend-Rust/tests/activity_endpoints.rs` (Rust integration)
+> - `Desktop/Tests/ActivityModelsTests.swift` (Swift Codable round-trip)
+>
+> Run this checklist after every PR that touches the Activity surface
+> (streams A–H) plus the post-merge sanity pass for the umbrella issue.
+> Each item maps to a numbered §Verification step from the plan.
+
+---
+
+## Setup (once per session)
+
+```bash
+# 1. Build the daemon
+cd ~/src/infinite-recall
+cd Backend-Rust && cargo build --release && cd ..
+
+# 2. Start the daemon (point at a clean DB so pause-state assertions are deterministic)
+export INFINITE_RECALL_DB="$HOME/Library/Application Support/Omi/users/anonymous/omi.db"
+./Backend-Rust/target/release/infinite-recall-api &
+DAEMON_PID=$!
+
+# 3. Capture the bearer token + bound port
+TOKEN="$(cat "$HOME/Library/Application Support/InfiniteRecall/api-token.txt")"
+PORT=7331   # default; check INFINITE_RECALL_BIND if overridden
+
+# 4. Build + launch the Swift app
+OMI_APP_NAME="Infinite Recall" \
+  OMI_SKIP_BACKEND=1 OMI_SKIP_AUTH=1 OMI_SKIP_TUNNEL=1 OMI_SKIP_PYTHON=1 \
+  ./run.sh --yolo
+```
+
+Daemon logs go to stderr; app logs to `/private/tmp/omi-dev.log`.
+
+Tear down at the end:
+
+```bash
+kill "$DAEMON_PID" 2>/dev/null
+osascript -e 'tell application "Infinite Recall" to quit'
+```
+
+---
+
+## Checklist
+
+### Build sanity (Verification §1, §2)
+
+- [ ] **§1** Swift package compiles clean.
+  ```bash
+  xcrun swift build -c debug --package-path Desktop
+  ```
+  Expected: `Build complete!`. Zero errors. Warnings are fine but not new ones from the activity Swift files.
+
+- [ ] **§2** Rust activity tests pass.
+  ```bash
+  cd Backend-Rust && cargo test --features activity_test_wiring activity_endpoints
+  ```
+  Expected (post-Stream-A merge): all tests in `activity_endpoints.rs` pass; `0 ignored`. If any are still ignored, the printed reason names the missing stream.
+
+### App launches with Activity tab (Verification §3, §4)
+
+- [ ] **§3** App launches with the dev `run.sh` invocation (see Setup).
+  Expected: window opens straight to main UI; no auth prompts; no Sentry/Firebase activity in console.
+
+- [ ] **§4** `agent-swift` connects and Cmd+7 opens Activity.
+  ```bash
+  agent-swift connect --bundle-id com.omi.infinite-recall
+  ```
+  Press `Cmd+7`. Expected: sidebar selects the **Activity** row (icon
+  `gauge.with.dots.needle.50percent`); main pane renders the Activity page
+  with three stat cards, an In-flight section, a Live capture section, and
+  an Empty state placeholder for the Queued section.
+
+### In-flight populates ≤1s after work starts (Verification §5)
+
+- [ ] **§5** Trigger a transcription job and confirm an in-flight row appears
+      within ~1 second.
+  Repro: speak into the mic for ~5s while audio capture is on, then stop.
+  When the scheduler picks the segment up:
+  - Activity tab's "In flight" section shows
+    `Transcribing HH:MM:SS→HH:MM:SS (en)` (or the active locale).
+  - The row appears within one 1-second tick of the scheduler claiming the
+    work — not on next-window-focus.
+  - When the handler completes, the row disappears within one tick.
+
+### Snapshot endpoint shape over the wire (Verification §6)
+
+- [ ] **§6** `curl` returns the full snapshot shape.
+  ```bash
+  curl -s -H "Authorization: Bearer $TOKEN" \
+    "http://127.0.0.1:$PORT/v1/activity/snapshot" | jq .
+  ```
+  Expected fields (exact JSON keys, all required):
+  - `kinds[]` — one row per `WorkKind`. Every row has
+    `kind, in_flight, queued, failed, last_done_at, paused_until`.
+  - `capture[]` — exactly two rows: `audio` and `screen`. Each has
+    `kind, running, paused_until`.
+  - `resources` — `cpu_percent (number), rss_mb (int), gpu_system_percent
+    (number|null), thermal_state (one of nominal/fair/serious/critical),
+    on_battery (bool), low_power (bool), process_breakdown[] (array of
+    {name, pid, cpu_percent, rss_mb})`.
+  - `processing_gate` — `allowed (bool), reason (one of idle/device_active/
+    on_battery/thermal/locked/manual_pause/none), since (iso8601),
+    waiting_for (string|null|absent)`.
+  - `generated_at` — iso8601.
+
+  Sample (truncated):
+  ```json
+  {
+    "kinds": [
+      { "kind": "transcribe", "in_flight": null, "queued": 0, "failed": 0,
+        "last_done_at": "2026-04-26T14:21:58.000Z", "paused_until": null },
+      ...
+    ],
+    "capture": [
+      { "kind": "audio",  "running": true, "paused_until": null },
+      { "kind": "screen", "running": true, "paused_until": null }
+    ],
+    "resources": { "cpu_percent": 12.4, "rss_mb": 256,
+      "gpu_system_percent": 33.3, "thermal_state": "nominal",
+      "on_battery": false, "low_power": false,
+      "process_breakdown": [ {"name":"infinite-recall-api","pid":4242,
+        "cpu_percent":12.4,"rss_mb":256} ] },
+    "processing_gate": { "allowed": true, "reason": "none",
+      "since": "2026-04-26T14:25:00Z" },
+    "generated_at": "2026-04-26T14:25:30.512Z"
+  }
+  ```
+
+### Pause OCR routes around the OCR drain (Verification §7)
+
+- [ ] **§7a** Click "Pause OCR · 1 min" in the UI.
+  Expected: row dims; countdown `Resumes HH:MM` appears; UI updates
+  optimistically without waiting on the next 1s tick.
+
+- [ ] **§7b** Confirm the daemon log skips OCR while paused.
+  ```bash
+  tail -f /private/tmp/omi-dev.log | grep -i ocr
+  ```
+  Expected for ~60s: no new `claim ocr` / `dispatch ocr` lines. Other kinds
+  (transcribe, summarize) continue to drain normally.
+
+- [ ] **§7c** After ~60s, OCR resumes automatically.
+  Expected: countdown disappears; OCR drain lines reappear in the log
+  within one tick.
+
+### Pause Audio capture (Verification §8)
+
+- [ ] **§8a** Click "Pause Audio · 5 min" in the UI.
+  Expected: a confirm sheet appears: "Pausing audio will stop recording
+  until <time>. Continue?" (wording may vary; sheet must mention the
+  recording-stop side-effect).
+
+- [ ] **§8b** Confirm the sheet.
+  Expected:
+  - Mic indicator stops; sidebar `AudioLevelNavItem` flatlines.
+  - Capture section row for `audio` shows `running: false` with a
+    `paused_until` countdown.
+  - `curl .../v1/activity/snapshot | jq '.capture[] | select(.kind=="audio")'`
+    returns the same `running: false` + `paused_until`.
+
+- [ ] **§8c** Cancel the sheet.
+  Expected: nothing changes; capture continues.
+
+### Pause persistence across daemon restart (Verification §9)
+
+- [ ] **§9** Pause OCR for 30 minutes via UI; quit IR (and the daemon);
+      relaunch ~10 minutes later. Expected:
+  - Activity tab opens with the OCR row already paused.
+  - Countdown shows ~20 minutes remaining (original wall-time, not 30 from
+    relaunch).
+  - `curl` confirms `paused_until` is the same iso8601 timestamp it was
+    pre-quit (within clock skew).
+
+### Hidden-window polling suspends (Verification §10)
+
+- [ ] **§10a** While Activity tab is visible, observe daemon access log:
+  ```bash
+  tail -f ~/Library/Logs/InfiniteRecall/access.log 2>/dev/null \
+    || RUST_LOG=tower_http=debug ./Backend-Rust/target/release/infinite-recall-api 2>&1 \
+       | grep --line-buffered '/v1/activity/snapshot'
+  ```
+  Expected: roughly one `GET /v1/activity/snapshot` per second.
+
+- [ ] **§10b** Hide the IR window (`Cmd+H` or click another app).
+      Wait 30 seconds.
+      Expected: zero new snapshot fetches in that window.
+
+- [ ] **§10c** Bring the window back to focus.
+      Expected: snapshot fetches resume within one second.
+
+### Empty-state and gate messaging (Plan §UX scenarios 5, 6, 7)
+
+- [ ] **UX 2 (most common)** With keyboard activity within last 2 minutes:
+      banner reads `Waiting for idle — N items queued. Resumes after 2 min idle.`
+      No new in-flight rows appear while gate is `device_active`.
+
+- [ ] **UX 5** Empty queue + idle: banner reads
+      `Up to date — 0 queued.` (or similar).
+
+- [ ] **UX 7** On battery: banner reads
+      `Waiting for AC power — N items queued.` and `processing_gate.reason`
+      from `curl` is `on_battery`.
+
+### Loopback `_internal/inflight` is reachable (sanity)
+
+- [ ] Manually POST a fake in-flight update and confirm the snapshot updates.
+  ```bash
+  curl -sS -X POST -H "Authorization: Bearer $TOKEN" \
+       -H "Content-Type: application/json" \
+       -d '{"kind":"transcribe","in_flight":{"label":"manual probe","started_at":"2026-04-26T14:22:03.812Z"}}' \
+       "http://127.0.0.1:$PORT/v1/activity/_internal/inflight" -o /dev/null -w "%{http_code}\n"
+  # Expected: 204
+  curl -s -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:$PORT/v1/activity/snapshot" \
+    | jq '.kinds[] | select(.kind=="transcribe") | .in_flight'
+  # Expected: { "label": "manual probe", "started_at": "..." }
+  ```
+  Then clear it:
+  ```bash
+  curl -sS -X POST -H "Authorization: Bearer $TOKEN" \
+       -H "Content-Type: application/json" \
+       -d '{"kind":"transcribe","in_flight":null}' \
+       "http://127.0.0.1:$PORT/v1/activity/_internal/inflight" -o /dev/null -w "%{http_code}\n"
+  # Expected: 204; subsequent snapshot has transcribe.in_flight == null
+  ```
+
+### Auth (defensive)
+
+- [ ] Activity routes 401 without a bearer.
+  ```bash
+  curl -s -o /dev/null -w "%{http_code}\n" \
+    "http://127.0.0.1:$PORT/v1/activity/snapshot"
+  # Expected: 401
+  ```
+
+- [ ] Activity routes 401 with a wrong bearer.
+  ```bash
+  curl -s -o /dev/null -w "%{http_code}\n" \
+    -H "Authorization: Bearer wrong-token" \
+    "http://127.0.0.1:$PORT/v1/activity/snapshot"
+  # Expected: 401
+  ```
+
+---
+
+## Sign-off
+
+- [ ] All boxes above checked.
+- [ ] No new errors in `/private/tmp/omi-dev.log` during the run
+      (ignore pre-existing noise).
+- [ ] Tester: ___________________________  Date: ___________
+- [ ] PR / commit SHA: __________________


### PR DESCRIPTION
## Summary

Stream I deliverables for the Activity Tab umbrella (#9):

- **`Backend-Rust/tests/activity_endpoints.rs`** — 9 Rust integration tests
  against `/v1/activity/*` covering snapshot shape, pause/resume, restart
  persistence, inflight loopback, auth, and validation. Gated behind a
  `cfg(feature = "activity_test_wiring")` so `cargo test` is a clean no-op
  today. Each test is `#[ignore]`-tagged with the stream(s) it depends on so
  the unlock path is self-documenting.
- **`Desktop/Tests/ActivityModelsTests.swift`** — 17 passing Codable
  round-trip tests against the Phase 0 contract. Verifies every enum
  variant on the wire (snake_case), nullability of optional fields, and
  request body shapes. Also pins the
  `ActivityNotifications.pauseChanged` / `ActivityDefaultsKeys.lastGateStateJSON`
  string constants that streams G/H/F depend on.
- **`e2e/activity-tab.md`** — manual smoke checklist mirroring
  §Verification 1–10 from the plan, with `curl` probes, expected JSON
  payloads, log-grep patterns, and pass/fail boxes. One section per UX
  scenario from the plan.

Closes #19. Part of #9.

## Why everything Rust-side is gated today

Phase 0 (#10) shipped a binary-only crate (no `lib.rs`). Integration tests
in `tests/` need a library import path. Stream A owns `state.rs`, the
extended `AppState`, and is the natural place for `lib.rs` to land. Rather
than reach into Stream A's territory, this PR ships fully-formed tests
behind `cfg(feature = "activity_test_wiring")`. Once the umbrella feature
lands, a follow-up commit on this branch (or a tiny stacked PR) flips the
feature flag and adds `tempfile` to `[dev-dependencies]`.

## Stream-by-stream gating matrix

| Test                                  | Unlocks when |
|---------------------------------------|--------------|
| `enum_round_trip_via_wire`            | already runs (type-only, but still feature-gated for now) |
| `snapshot_returns_200_with_full_shape`| Stream A     |
| `pause_returns_paused_until`          | Stream A     |
| `paused_kind_visible_in_snapshot`     | Stream A     |
| `pause_persists_across_restart`       | Stream B (`SqlPauseStore`) |
| `resume_clears_pause`                 | Stream A     |
| `inflight_loopback_round_trip`        | Stream A + Stream D |
| `missing_bearer_returns_401`          | Stream A     |
| `pause_request_validation`            | Stream A     |

## Verified locally

```bash
xcrun swift build -c debug --package-path Desktop                                     # clean
xcrun swift test    --package-path Desktop --filter ActivityModelsTests               # 17/17 pass
cd Backend-Rust && cargo test --test activity_endpoints                               # 0 tests (gate off)
cd Backend-Rust && cargo test --no-run                                                # clean
```

## Test plan

- [x] Swift Codable suite passes (17/17, `xcrun swift test --filter ActivityModelsTests`)
- [x] Rust integration test binary compiles (cfg-gated to zero tests)
- [x] Whole repo `cargo build` clean (no Cargo.toml mutation — Stream C owns that file)
- [ ] After Stream A merges + adds `lib.rs`: flip `activity_test_wiring` feature on, add `tempfile` to dev-deps, drop the gate, run full suite green.
- [ ] After all streams merge: run `e2e/activity-tab.md` end-to-end on a real machine; sign-off line at the bottom.

## Coordination notes

- I did NOT touch `Cargo.toml` — Stream C owns that single edit. The feature
  + dev-dep additions documented in the test file's module doc go in
  Stream I's *post-merge* commit.
- I did NOT touch any production Swift or Rust file. If a test reveals a
  bug in any other stream's PR, I'll file a fresh issue and comment on
  that stream's PR rather than patch in-place here.
- The Swift tests caught one wire concern worth surfacing: Swift's default
  `JSONEncoder` *omits* nil optionals rather than emitting `"in_flight":null`.
  Stream A's `serde::Deserialize` on `Option<InFlight>` handles both — the
  test pins this behaviour with both an omission and a null acceptance
  assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)