### PR TITLE
activity: stream H — live capture pause gates (closes #18)

### DIFF
--- a/Desktop/Sources/Activity/CapturePauseGate.swift
+++ b/Desktop/Sources/Activity/CapturePauseGate.swift
@@ -1,32 +1,207 @@
-// Activity Tab — Phase 0 stub.
+// Activity Tab — Stream H. Singleton observer for pause state of live
+// capture services and per-kind work.
 //
-// TODO: Stream H. Singleton observer that polls Rust pause store every 5s
-// and on `ActivityNotifications.pauseChanged`. Exposes:
-//   - `isPaused(_ id: String) -> Bool`
-//   - `pausedUntil(_ id: String) -> Date?`
-// A/H/G read this; F's UI calls through it for snappy local state too.
+// Two refresh triggers:
+//  1. Periodic poll every 5s of the Rust pause store via APIClient (best
+//     effort — falls back to last-known map if the snapshot fetch is not
+//     available yet, e.g. before Stream F lands `getActivitySnapshot`).
+//  2. Local NotificationCenter observer on
+//     `ActivityNotifications.pauseChanged`, posted by Stream F's UI when
+//     the user toggles a pause so live capture services react instantly
+//     instead of waiting for the next 5s tick.
+//
+// Consumers (AudioCaptureService, ScreenCaptureService, the future
+// scheduler in Stream G, Stream F's UI) call `isPaused(target:id:)` to
+// gate work. Keys are stored as `"<target>/<id>"` so a single dictionary
+// covers both `"capture"` and `"kind"` namespaces.
 
 import Foundation
+import Combine
 
-// === activity:G stub ===
-// Minimal no-op singleton so Stream G's pause-gate check compiles before
-// Stream H lands the real polling implementation. Stream H MUST replace this
-// entire `// === activity:G stub ===` block with the real `CapturePauseGate`.
-public final class CapturePauseGate: @unchecked Sendable {
-    public static let shared = CapturePauseGate()
+@MainActor
+final class CapturePauseGate: ObservableObject {
+    static let shared = CapturePauseGate()
+
+    /// Map of `"<target>/<id>"` → absolute resume timestamp. An entry is
+    /// only present while the pause is in the future; expired entries are
+    /// pruned on read so consumers always see a truthful state.
+    @Published private(set) var pauses: [String: Date] = [:]
+
+    private var pollTimer: Timer?
+    private var observer: NSObjectProtocol?
+    private var isStarted = false
+
     private init() {}
 
-    /// No-op until Stream H lands. Always returns false (= not paused).
-    /// Signature accepts `target: PauseTarget` and an `id: String` so the
-    /// caller in BatteryAwareScheduler can pass `target: .kind, id: kind.rawValue`
-    /// and the Stream H replacement will be source-compatible.
-    public func isPaused(target: PauseTarget, id: String) -> Bool {
-        return false
+    // MARK: - Lifecycle
+
+    /// Begin polling the Rust pause store and observing pause-change
+    /// notifications. Idempotent.
+    func start() {
+        guard !isStarted else { return }
+        isStarted = true
+
+        // Local notification: snappy refresh when the UI changes pause state.
+        observer = NotificationCenter.default.addObserver(
+            forName: ActivityNotifications.pauseChanged,
+            object: nil,
+            queue: .main
+        ) { [weak self] note in
+            // Hop to the MainActor explicitly — the observer block is
+            // not actor-isolated even though `queue: .main` runs it on the
+            // main thread.
+            Task { @MainActor in
+                self?.handlePauseNotification(note)
+            }
+        }
+
+        // 5s background poll. Use a Timer scheduled on the main runloop so
+        // it interleaves cleanly with UI updates.
+        let timer = Timer(timeInterval: 5.0, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                await self?.refreshFromBackend()
+            }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        pollTimer = timer
+
+        // Kick off an initial refresh so the gate isn't "open" for 5s on
+        // cold start when a pause is already live in the Rust store.
+        Task { @MainActor in
+            await self.refreshFromBackend()
+        }
     }
 
-    /// No-op until Stream H lands. Always returns nil.
-    public func pausedUntil(target: PauseTarget, id: String) -> Date? {
+    /// Stop polling and detach the notification observer. Safe to call
+    /// from any state.
+    func stop() {
+        pollTimer?.invalidate()
+        pollTimer = nil
+        if let observer {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        observer = nil
+        isStarted = false
+    }
+
+    // MARK: - Reads
+
+    /// Returns true iff the given (target, id) pair is paused at this
+    /// instant. Expired entries are pruned as a side effect.
+    func isPaused(target: String, id: String) -> Bool {
+        return pausedUntil(target: target, id: id) != nil
+    }
+
+    /// Returns the absolute resume timestamp for the (target, id) pair if
+    /// it is currently paused, else nil. Prunes expired entries.
+    func pausedUntil(target: String, id: String) -> Date? {
+        let key = Self.cacheKey(target: target, id: id)
+        guard let until = pauses[key] else { return nil }
+        if until > Date() {
+            return until
+        }
+        // Expired — drop it so future reads don't keep returning a stale
+        // truthy value.
+        pauses.removeValue(forKey: key)
         return nil
     }
+
+    // MARK: - Writes (used by UI for optimistic local updates)
+
+    /// Optimistically record a pause locally. Stream F's UI can call this
+    /// the instant the user taps "Pause" so consumers see the gate flip
+    /// before the backend round-trip completes. The next backend refresh
+    /// will overwrite this with the authoritative value.
+    func recordLocalPause(target: String, id: String, until: Date) {
+        let key = Self.cacheKey(target: target, id: id)
+        pauses[key] = until
+        NotificationCenter.default.post(
+            name: ActivityNotifications.pauseChanged,
+            object: nil,
+            userInfo: ["target": target, "id": id, "until": until]
+        )
+    }
+
+    /// Optimistically clear a pause locally (mirror of recordLocalPause).
+    func clearLocalPause(target: String, id: String) {
+        let key = Self.cacheKey(target: target, id: id)
+        pauses.removeValue(forKey: key)
+        NotificationCenter.default.post(
+            name: ActivityNotifications.pauseChanged,
+            object: nil,
+            userInfo: ["target": target, "id": id]
+        )
+    }
+
+    // MARK: - Internals
+
+    private static func cacheKey(target: String, id: String) -> String {
+        return "\(target)/\(id)"
+    }
+
+    private func handlePauseNotification(_ note: Notification) {
+        // Apply any inline hint from the notification payload first so the
+        // gate flips synchronously from the publisher's perspective …
+        if let target = note.userInfo?["target"] as? String,
+           let id = note.userInfo?["id"] as? String {
+            let key = Self.cacheKey(target: target, id: id)
+            if let until = note.userInfo?["until"] as? Date {
+                pauses[key] = until
+            } else {
+                // No `until` → treat as resume.
+                pauses.removeValue(forKey: key)
+            }
+        }
+        // …then refresh from the backend so we re-converge on the
+        // authoritative state.
+        Task { @MainActor in
+            await self.refreshFromBackend()
+        }
+    }
+
+    /// Pull the latest `ActivitySnapshot` and refresh the local map.
+    /// Resilient to the API method being absent (Stream F still in
+    /// flight) — uses dynamic dispatch via `APIClient.shared` and
+    /// silently no-ops if the call throws or the symbol is unavailable.
+    private func refreshFromBackend() async {
+        guard let snapshot = await Self.fetchSnapshotIfAvailable() else {
+            return
+        }
+        var next: [String: Date] = [:]
+        let now = Date()
+
+        for row in snapshot.capture {
+            if let until = row.pausedUntil, until > now {
+                next[Self.cacheKey(target: "capture", id: row.kind.rawValue)] = until
+            }
+        }
+        for row in snapshot.kinds {
+            if let until = row.pausedUntil, until > now {
+                next[Self.cacheKey(target: "kind", id: row.kind.rawValue)] = until
+            }
+        }
+
+        if next != pauses {
+            pauses = next
+        }
+    }
+
+    /// Bridge to APIClient that tolerates the absence of
+    /// `getActivitySnapshot()` (Stream F may not have landed yet on this
+    /// branch). Returns nil on any failure.
+    private static func fetchSnapshotIfAvailable() async -> ActivitySnapshot? {
+        // Stream F is expected to add `func getActivitySnapshot() async
+        // throws -> ActivitySnapshot` to APIClient. Until then this gate
+        // just runs notification-only; the optimistic local write path
+        // (recordLocalPause / clearLocalPause) keeps the UX correct.
+        #if ACTIVITY_API_AVAILABLE
+        do {
+            return try await APIClient.shared.getActivitySnapshot()
+        } catch {
+            return nil
+        }
+        #else
+        return nil
+        #endif
+    }
 }
-// === /activity:G stub ===

--- a/Desktop/Sources/AudioCaptureService.swift
+++ b/Desktop/Sources/AudioCaptureService.swift
@@ -48,6 +48,14 @@ class AudioCaptureService: @unchecked Sendable {
     /// Used by the silent-mic fallback path to bind directly to the built-in mic.
     private let overrideDeviceID: AudioDeviceID?
 
+    // === activity:H ===
+    /// Mid-flight observer token: when the user pauses audio capture while
+    /// it is already running, we want to tear down the live mic instead of
+    /// only blocking the *next* startCapture() call. The observer is
+    /// registered on the first startCapture() and removed on stopCapture().
+    private var pauseObserver: NSObjectProtocol?
+    // === /activity:H ===
+
     /// Default initializer — opens the system default input device.
     init() {
         self.overrideDeviceID = nil
@@ -141,6 +149,24 @@ class AudioCaptureService: @unchecked Sendable {
             log("AudioCapture: Already capturing")
             return
         }
+
+        // === activity:H ===
+        // Block start while audio capture is paused via the Activity tab.
+        // The gate is MainActor-isolated; hop briefly to read it.
+        let pauseInfo: (paused: Bool, until: Date?) = await MainActor.run {
+            let gate = CapturePauseGate.shared
+            return (gate.isPaused(target: "capture", id: "audio"),
+                    gate.pausedUntil(target: "capture", id: "audio"))
+        }
+        if pauseInfo.paused {
+            log("AudioCapture: paused until \(String(describing: pauseInfo.until)) — skipping start")
+            return
+        }
+        // Register the mid-flight observer on first start. NotificationCenter
+        // de-dupes by token, but we still keep the token so stopCapture()
+        // can detach cleanly.
+        await MainActor.run { self.installPauseObserverIfNeeded() }
+        // === /activity:H ===
 
         self.onAudioChunk = onAudioChunk
         self.onAudioLevel = onAudioLevel
@@ -262,9 +288,44 @@ class AudioCaptureService: @unchecked Sendable {
         installPropertyListeners()
     }
 
+    // === activity:H ===
+    /// Install (idempotently) a NotificationCenter observer that tears
+    /// down a live capture session when the user pauses audio capture
+    /// from the Activity tab. Pause covers *next-claim* for deferred
+    /// work, but for live capture the user expects the mic to actually
+    /// stop — see UX scenario 3 in the plan ("recording will stop").
+    @MainActor
+    private func installPauseObserverIfNeeded() {
+        guard pauseObserver == nil else { return }
+        pauseObserver = NotificationCenter.default.addObserver(
+            forName: ActivityNotifications.pauseChanged,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self else { return }
+            // Re-check the gate; only stop if we're now paused.
+            let paused = CapturePauseGate.shared.isPaused(target: "capture", id: "audio")
+            if paused {
+                log("AudioCapture: pause notification received while capturing — stopping mic")
+                self.stopCapture()
+            }
+        }
+    }
+    // === /activity:H ===
+
     /// Stop capturing audio
     func stopCapture() {
         guard isCapturing else { return }
+
+        // === activity:H ===
+        // Detach the pause observer so a subsequent start() can re-install
+        // it cleanly, and so we don't leak observer closures across a
+        // start/stop cycle initiated for non-pause reasons.
+        if let token = pauseObserver {
+            NotificationCenter.default.removeObserver(token)
+            pauseObserver = nil
+        }
+        // === /activity:H ===
 
         removePropertyListeners()
 

--- a/Desktop/Sources/Power/BatteryAwareScheduler.swift
+++ b/Desktop/Sources/Power/BatteryAwareScheduler.swift
@@ -295,10 +295,12 @@ public final class BatteryAwareScheduler: ObservableObject {
       //    it claimed and break — the sweeper reclaims after lease expiry,
       //    and the next drain past the pause window will pick it up.
       //
-      //    NOTE: Until Stream H lands the real CapturePauseGate, this always
-      //    returns false (no-op). The check is intentionally ADDITIVE to the
-      //    device-idle / battery / thermal gates — it does NOT replace them.
-      if CapturePauseGate.shared.isPaused(target: .kind, id: work.kind.rawValue) {
+      //    The check is intentionally ADDITIVE to the device-idle / battery /
+      //    thermal gates — it does NOT replace them.
+      let isUserPaused = await MainActor.run {
+        CapturePauseGate.shared.isPaused(target: "kind", id: work.kind.rawValue)
+      }
+      if isUserPaused {
         log("BatteryAwareScheduler: user-paused \(work.kind.rawValue), leaving claimed")
         break
       }

--- a/Desktop/Sources/ScreenCaptureService.swift
+++ b/Desktop/Sources/ScreenCaptureService.swift
@@ -683,6 +683,13 @@ final class ScreenCaptureService: Sendable {
 
   /// Async capture - main entry point
   func captureActiveWindowAsync() async -> Data? {
+    // === activity:H ===
+    if await Self.isScreenPaused() {
+      let until = await Self.screenPausedUntil()
+      log("ScreenCapture: paused until \(String(describing: until)) — skipping start")
+      return nil
+    }
+    // === /activity:H ===
     let (_, _, windowID) = await Self.getActiveWindowInfoAsync()
     guard let windowID else {
       log("No active window ID found")
@@ -820,6 +827,13 @@ final class ScreenCaptureService: Sendable {
   }
 
   func captureActiveWindowCGImage() async -> CGImage? {
+    // === activity:H ===
+    if await Self.isScreenPaused() {
+      let until = await Self.screenPausedUntil()
+      log("ScreenCapture: paused until \(String(describing: until)) — skipping start")
+      return nil
+    }
+    // === /activity:H ===
     let (_, _, windowID) = await Self.getActiveWindowInfoAsync()
     guard let windowID else {
       log("No active window ID found")
@@ -887,6 +901,20 @@ final class ScreenCaptureService: Sendable {
 
   /// Capture the active window and return as JPEG data (synchronous - legacy)
   func captureActiveWindow() -> Data? {
+    // === activity:H ===
+    // Synchronous entry point: cannot await the MainActor-bound gate.
+    // Use a non-blocking best-effort read via DispatchQueue.main.sync,
+    // skipping the gate if we're already on the main thread (to avoid
+    // deadlock) — the async paths above provide the primary enforcement.
+    if !Thread.isMainThread {
+      let paused = DispatchQueue.main.sync { CapturePauseGate.shared.isPaused(target: "capture", id: "screen") }
+      if paused {
+        let until = DispatchQueue.main.sync { CapturePauseGate.shared.pausedUntil(target: "capture", id: "screen") }
+        log("ScreenCapture: paused until \(String(describing: until)) — skipping start")
+        return nil
+      }
+    }
+    // === /activity:H ===
     guard let windowID = Self.getActiveWindowID() else {
       log("No active window ID found")
       return nil
@@ -985,4 +1013,21 @@ final class ScreenCaptureService: Sendable {
       properties: [.compressionFactor: jpegQuality]
     )
   }
+
+  // === activity:H ===
+  /// Bridge helper: read the Activity tab's pause gate (MainActor-isolated)
+  /// from a Sendable context. Used by the async capture entry points.
+  private static func isScreenPaused() async -> Bool {
+    return await MainActor.run {
+      CapturePauseGate.shared.isPaused(target: "capture", id: "screen")
+    }
+  }
+
+  /// Bridge helper for the resume timestamp. See `isScreenPaused`.
+  private static func screenPausedUntil() async -> Date? {
+    return await MainActor.run {
+      CapturePauseGate.shared.pausedUntil(target: "capture", id: "screen")
+    }
+  }
+  // === /activity:H ===
 }


### PR DESCRIPTION
## Summary
Stream H of the Activity Tab parallel build (parent #9, contract Phase 0 #20).

Flesh out the `CapturePauseGate` singleton (Phase 0 placeholder) into a real notification-driven pause observer, and gate the live capture services so user-initiated pauses from the Activity tab actually stop the mic / screen grabber instead of only deferring next-claim.

### Files touched
- `Desktop/Sources/Activity/CapturePauseGate.swift` — full singleton: `pauses[String:Date]` keyed by `"<target>/<id>"`, 5s poll + `ActivityNotifications.pauseChanged` observer, optimistic `recordLocalPause` / `clearLocalPause` so the UI flips the gate before the backend round-trip, expired-entry pruning on read. Backend refresh is gated behind `ACTIVITY_API_AVAILABLE` so it cleanly no-ops until Stream F lands `APIClient.getActivitySnapshot()`.
- `Desktop/Sources/AudioCaptureService.swift` — `startCapture()` early-returns when `isPaused(target: "capture", id: "audio")`; installs a one-shot mid-flight observer that calls `stopCapture()` when a pause arrives while the mic is live (UX scenario 4 — "recording will stop"); observer torn down in `stopCapture()`. All edits bracketed `// === activity:H ===`.
- `Desktop/Sources/ScreenCaptureService.swift` — gates the three public capture entry points (`captureActiveWindowAsync`, `captureActiveWindowCGImage`, `captureActiveWindow`). The class has no `startCapture()`; these three are the actual live-capture entry points. Sync legacy path uses `DispatchQueue.main.sync` only when off-main to avoid deadlock; async paths bridge to the MainActor-bound gate via `MainActor.run`.

### Contract
`136f9faf6bafd199d98954393ede22c0d1998e2d`

### UX scenario covered (from plan)
> 4. "Pause Audio · 5 min" → confirm sheet ("recording will stop") → mic stops.

The confirm sheet itself is Stream E/F's responsibility; this PR ensures that **once** the pause is recorded (either via `recordLocalPause` or via the `pauseChanged` notification), the mic and screen grabber actually stop / refuse to start.

## Test plan
- [x] `xcrun swift build -c debug --package-path Desktop` — clean (no errors in any of the three touched files; pre-existing unrelated `OmiApp.swift` Sendable warnings remain).
- [ ] Manual smoke after Stream F lands: pause Audio → mic level flatlines within 1s; resume → mic resumes on next start.
- [ ] Manual smoke: pause Screen → no JPEGs returned from `captureActiveWindowAsync`; resume → frames return.
- [ ] Quit + relaunch within pause window → `pauses` map is empty until first 5s poll re-hydrates from Rust pause store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)