### PR TITLE
activity: stream F — service + APIClient methods (closes #16)

### DIFF
--- a/Desktop/Sources/APIClient.swift
+++ b/Desktop/Sources/APIClient.swift
@@ -4955,3 +4955,182 @@ extension APIClient {
     return try await patch("v1/tools/action-items/\(id)", body: body, customBaseURL: nil)
   }
 }
+
+// === activity:F ===
+// Activity tab — Stream F. Loopback calls to the local Rust daemon for the
+// Activity surface. These BYPASS `isLocalOnlyMode`'s short-circuit because
+// the Rust daemon runs on 127.0.0.1 and is always reachable; we only want
+// to short-circuit *cloud* (api.omi.me) calls. Headers are built inline so
+// `buildHeaders`'s defensive `localOnlyMode` throw doesn't kill us.
+
+extension APIClient {
+
+  /// Build headers for a Rust-daemon call without `buildHeaders`'s
+  /// `localOnlyMode` short-circuit. Auth is best-effort: if no token is
+  /// available we still send the request (Rust daemon may be configured
+  /// without bearer auth in dev).
+  fileprivate func activityHeaders() async -> [String: String] {
+    var headers: [String: String] = [
+      "Content-Type": "application/json",
+      "X-App-Platform": "macos",
+    ]
+    if let testHeader = testAuthHeader {
+      headers["Authorization"] = testHeader
+    } else {
+      let authService = await MainActor.run { AuthService.shared }
+      if let authHeader = try? await authService.getAuthHeader() {
+        headers["Authorization"] = authHeader
+      }
+    }
+    return headers
+  }
+
+  /// Decoder used for Activity responses — matches the existing custom
+  /// ISO8601-with-fractional-seconds decoder defined on `APIClient.init`.
+  fileprivate static func makeActivityDecoder() -> JSONDecoder {
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .custom { decoder in
+      let container = try decoder.singleValueContainer()
+      let dateString = try container.decode(String.self)
+
+      let isoWithFractional = ISO8601DateFormatter()
+      isoWithFractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+      if let date = isoWithFractional.date(from: dateString) {
+        return date
+      }
+      let iso = ISO8601DateFormatter()
+      if let date = iso.date(from: dateString) {
+        return date
+      }
+      throw DecodingError.dataCorruptedError(
+        in: container, debugDescription: "Invalid date format: \(dateString)")
+    }
+    return decoder
+  }
+
+  /// Encoder for Activity request bodies. Dates are emitted as ISO8601 with
+  /// fractional seconds to match the Rust side.
+  fileprivate static func makeActivityEncoder() -> JSONEncoder {
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .custom { date, encoder in
+      let iso = ISO8601DateFormatter()
+      iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+      var container = encoder.singleValueContainer()
+      try container.encode(iso.string(from: date))
+    }
+    return encoder
+  }
+
+  /// GET /v1/activity/snapshot — full live activity snapshot for the UI.
+  func getActivitySnapshot() async throws -> ActivitySnapshot {
+    let base = rustBackendURL
+    guard !base.isEmpty, let url = URL(string: base + "v1/activity/snapshot") else {
+      throw APIError.invalidResponse
+    }
+    var request = URLRequest(url: url)
+    request.httpMethod = "GET"
+    request.allHTTPHeaderFields = await activityHeaders()
+    request.timeoutInterval = 5
+
+    let (data, response) = try await session.data(for: request)
+    guard let http = response as? HTTPURLResponse else {
+      throw APIError.invalidResponse
+    }
+    if http.statusCode == 401 { throw APIError.unauthorized }
+    guard (200...299).contains(http.statusCode) else {
+      throw APIError.httpError(statusCode: http.statusCode)
+    }
+    return try Self.makeActivityDecoder().decode(ActivitySnapshot.self, from: data)
+  }
+
+  /// POST /v1/activity/pause — pause a kind or capture for `minutes` minutes.
+  /// Returns the absolute resume time the daemon recorded (so UI can render
+  /// a countdown that survives across restart).
+  func pauseActivity(target: String, id: String, minutes: Int) async throws -> Date {
+    let base = rustBackendURL
+    guard !base.isEmpty, let url = URL(string: base + "v1/activity/pause") else {
+      throw APIError.invalidResponse
+    }
+    let body = PauseRequest(
+      target: PauseTarget(rawValue: target) ?? .kind,
+      id: id,
+      minutes: UInt32(max(0, minutes))
+    )
+
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.allHTTPHeaderFields = await activityHeaders()
+    request.httpBody = try Self.makeActivityEncoder().encode(body)
+    request.timeoutInterval = 5
+
+    let (data, response) = try await session.data(for: request)
+    guard let http = response as? HTTPURLResponse else {
+      throw APIError.invalidResponse
+    }
+    if http.statusCode == 401 { throw APIError.unauthorized }
+    guard (200...299).contains(http.statusCode) else {
+      throw APIError.httpError(statusCode: http.statusCode)
+    }
+
+    struct PauseResponse: Decodable {
+      let pausedUntil: Date
+      enum CodingKeys: String, CodingKey { case pausedUntil = "paused_until" }
+    }
+    let decoded = try Self.makeActivityDecoder().decode(PauseResponse.self, from: data)
+    return decoded.pausedUntil
+  }
+
+  /// POST /v1/activity/resume — clear an active pause. 204 on success.
+  func resumeActivity(target: String, id: String) async throws {
+    let base = rustBackendURL
+    guard !base.isEmpty, let url = URL(string: base + "v1/activity/resume") else {
+      throw APIError.invalidResponse
+    }
+    let body = ResumeRequest(
+      target: PauseTarget(rawValue: target) ?? .kind,
+      id: id
+    )
+
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.allHTTPHeaderFields = await activityHeaders()
+    request.httpBody = try Self.makeActivityEncoder().encode(body)
+    request.timeoutInterval = 5
+
+    let (_, response) = try await session.data(for: request)
+    guard let http = response as? HTTPURLResponse else {
+      throw APIError.invalidResponse
+    }
+    if http.statusCode == 401 { throw APIError.unauthorized }
+    guard (200...299).contains(http.statusCode) else {
+      throw APIError.httpError(statusCode: http.statusCode)
+    }
+  }
+
+  /// POST /v1/activity/_internal/inflight — Swift→Rust loopback, called by
+  /// Stream G's drain-loop wrapper to publish in-flight item labels into the
+  /// snapshot. `inFlight = nil` clears the slot.
+  func reportInFlight(kind: String, inFlight: InFlight?) async throws {
+    let base = rustBackendURL
+    guard !base.isEmpty, let url = URL(string: base + "v1/activity/_internal/inflight") else {
+      throw APIError.invalidResponse
+    }
+    let body = InflightUpdate(kind: kind, inFlight: inFlight)
+
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.allHTTPHeaderFields = await activityHeaders()
+    request.httpBody = try Self.makeActivityEncoder().encode(body)
+    request.timeoutInterval = 5
+
+    let (_, response) = try await session.data(for: request)
+    guard let http = response as? HTTPURLResponse else {
+      throw APIError.invalidResponse
+    }
+    if http.statusCode == 401 { throw APIError.unauthorized }
+    guard (200...299).contains(http.statusCode) else {
+      throw APIError.httpError(statusCode: http.statusCode)
+    }
+  }
+}
+// === /activity:F ===

--- a/Desktop/Sources/Activity/ActivityModels.swift
+++ b/Desktop/Sources/Activity/ActivityModels.swift
@@ -80,6 +80,22 @@ public struct KindRow: Codable, Hashable {
         case lastDoneAt = "last_done_at"
         case pausedUntil = "paused_until"
     }
+
+    public init(
+        kind: WorkKind,
+        inFlight: InFlight?,
+        queued: UInt32,
+        failed: UInt32,
+        lastDoneAt: Date?,
+        pausedUntil: Date?
+    ) {
+        self.kind = kind
+        self.inFlight = inFlight
+        self.queued = queued
+        self.failed = failed
+        self.lastDoneAt = lastDoneAt
+        self.pausedUntil = pausedUntil
+    }
 }
 
 public struct CaptureRow: Codable, Hashable {
@@ -91,6 +107,12 @@ public struct CaptureRow: Codable, Hashable {
         case kind
         case running
         case pausedUntil = "paused_until"
+    }
+
+    public init(kind: CaptureKind, running: Bool, pausedUntil: Date?) {
+        self.kind = kind
+        self.running = running
+        self.pausedUntil = pausedUntil
     }
 }
 
@@ -105,6 +127,13 @@ public struct ProcessBreakdown: Codable, Hashable {
         case pid
         case cpuPercent = "cpu_percent"
         case rssMb = "rss_mb"
+    }
+
+    public init(name: String, pid: Int32, cpuPercent: Float, rssMb: UInt32) {
+        self.name = name
+        self.pid = pid
+        self.cpuPercent = cpuPercent
+        self.rssMb = rssMb
     }
 }
 
@@ -126,6 +155,24 @@ public struct ResourceSample: Codable, Hashable {
         case lowPower = "low_power"
         case processBreakdown = "process_breakdown"
     }
+
+    public init(
+        cpuPercent: Float,
+        rssMb: UInt32,
+        gpuSystemPercent: Float?,
+        thermalState: ThermalState,
+        onBattery: Bool,
+        lowPower: Bool,
+        processBreakdown: [ProcessBreakdown]
+    ) {
+        self.cpuPercent = cpuPercent
+        self.rssMb = rssMb
+        self.gpuSystemPercent = gpuSystemPercent
+        self.thermalState = thermalState
+        self.onBattery = onBattery
+        self.lowPower = lowPower
+        self.processBreakdown = processBreakdown
+    }
 }
 
 public struct GateState: Codable, Hashable {
@@ -139,6 +186,13 @@ public struct GateState: Codable, Hashable {
         case reason
         case since
         case waitingFor = "waiting_for"
+    }
+
+    public init(allowed: Bool, reason: GateReason, since: Date, waitingFor: String?) {
+        self.allowed = allowed
+        self.reason = reason
+        self.since = since
+        self.waitingFor = waitingFor
     }
 }
 
@@ -157,6 +211,20 @@ public struct ActivitySnapshot: Codable, Hashable {
         case resources
         case processingGate = "processing_gate"
         case generatedAt = "generated_at"
+    }
+
+    public init(
+        kinds: [KindRow],
+        capture: [CaptureRow],
+        resources: ResourceSample,
+        processingGate: GateState,
+        generatedAt: Date
+    ) {
+        self.kinds = kinds
+        self.capture = capture
+        self.resources = resources
+        self.processingGate = processingGate
+        self.generatedAt = generatedAt
     }
 }
 

--- a/Desktop/Sources/Activity/ActivityMonitorService.swift
+++ b/Desktop/Sources/Activity/ActivityMonitorService.swift
@@ -1,7 +1,234 @@
-// Activity Tab — Phase 0 stub.
+// Activity Tab — Stream F.
 //
-// TODO: Stream F. `@MainActor ObservableObject` that polls
-// `APIClient.shared.getActivitySnapshot()` on a 1s Timer.publish, suspends
-// on `NSWindow.didResignKey`, resumes on `didBecomeKey`.
+// `ActivityMonitorService` polls the local Rust daemon at 1 Hz while the IR
+// window is key, exposing the latest `ActivitySnapshot` to SwiftUI via
+// `@Published`. Polling is suspended while the window is hidden / not key
+// (per Phase 0 contract: "Hidden window suspends polling. UI MUST NOT poll
+// the Rust daemon while NSWindow.didResignKey").
+//
+// Pause/resume + capture pause/resume are funneled through this service so
+// it can:
+//   1. Optimistically mutate the local snapshot for instant UI feedback
+//      (set/clear `paused_until` on the affected row).
+//   2. Post `ActivityNotifications.pauseChanged` so Stream H's
+//      `CapturePauseGate` (and live capture services) can react without
+//      polling.
+//
+// Owner: Stream F.
 
+import AppKit
+import Combine
 import Foundation
+
+@MainActor
+public final class ActivityMonitorService: ObservableObject {
+    public static let shared = ActivityMonitorService()
+
+    @Published public private(set) var snapshot: ActivitySnapshot?
+    @Published public private(set) var lastError: String?
+
+    private var timer: Timer?
+    private var isStarted: Bool = false
+    private var isFetching: Bool = false
+    private var keyObserver: NSObjectProtocol?
+    private var resignObserver: NSObjectProtocol?
+
+    private init() {}
+
+    deinit {
+        if let keyObserver { NotificationCenter.default.removeObserver(keyObserver) }
+        if let resignObserver { NotificationCenter.default.removeObserver(resignObserver) }
+        timer?.invalidate()
+    }
+
+    // MARK: - Lifecycle
+
+    /// Begin polling. Idempotent. Wires up window-key observers so polling
+    /// suspends when the IR window is hidden/inactive.
+    public func start() {
+        guard !isStarted else { return }
+        isStarted = true
+
+        keyObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didBecomeKeyNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.handleBecameKey()
+            }
+        }
+        resignObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didResignKeyNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.handleResignedKey()
+            }
+        }
+
+        // If a window is already key at start time, begin polling immediately
+        // (no 1s delay before the first sample).
+        if NSApp?.keyWindow != nil {
+            startTimerIfNeeded(immediateFetch: true)
+        }
+    }
+
+    /// Stop polling and tear down observers.
+    public func stop() {
+        isStarted = false
+        timer?.invalidate()
+        timer = nil
+        if let keyObserver {
+            NotificationCenter.default.removeObserver(keyObserver)
+            self.keyObserver = nil
+        }
+        if let resignObserver {
+            NotificationCenter.default.removeObserver(resignObserver)
+            self.resignObserver = nil
+        }
+    }
+
+    // MARK: - Public actions
+
+    /// Pause a `WorkKind` row for `minutes` minutes. Optimistically updates
+    /// the local snapshot and posts `pauseChanged`.
+    public func pauseKind(_ kind: WorkKind, minutes: Int) async {
+        await pause(target: .kind, id: kind.rawValue, minutes: minutes)
+    }
+
+    /// Pause a capture row (audio/screen) for `minutes` minutes. UI is
+    /// expected to have already shown the confirm sheet for `audio`.
+    public func pauseCapture(_ capture: CaptureKind, minutes: Int) async {
+        await pause(target: .capture, id: capture.rawValue, minutes: minutes)
+    }
+
+    /// Resume a previously paused row.
+    public func resume(target: PauseTarget, id: String) async {
+        do {
+            try await APIClient.shared.resumeActivity(target: target.rawValue, id: id)
+            applyOptimisticPause(target: target, id: id, until: nil)
+            postPauseChanged()
+            await fetchOnce()
+        } catch {
+            lastError = "resume failed: \(error.localizedDescription)"
+        }
+    }
+
+    // MARK: - Private
+
+    private func pause(target: PauseTarget, id: String, minutes: Int) async {
+        do {
+            let until = try await APIClient.shared.pauseActivity(
+                target: target.rawValue,
+                id: id,
+                minutes: minutes
+            )
+            applyOptimisticPause(target: target, id: id, until: until)
+            postPauseChanged()
+            await fetchOnce()
+        } catch {
+            lastError = "pause failed: \(error.localizedDescription)"
+        }
+    }
+
+    private func handleBecameKey() {
+        guard isStarted else { return }
+        startTimerIfNeeded(immediateFetch: true)
+    }
+
+    private func handleResignedKey() {
+        guard isStarted else { return }
+        // If another IR window is still key, keep polling.
+        if NSApp?.keyWindow != nil { return }
+        timer?.invalidate()
+        timer = nil
+    }
+
+    private func startTimerIfNeeded(immediateFetch: Bool) {
+        if timer != nil {
+            if immediateFetch { Task { await self.fetchOnce() } }
+            return
+        }
+        let t = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                await self?.fetchOnce()
+            }
+        }
+        // Ensure the timer fires while menus / drags hold the run loop.
+        RunLoop.main.add(t, forMode: .common)
+        timer = t
+        if immediateFetch {
+            Task { await self.fetchOnce() }
+        }
+    }
+
+    private func fetchOnce() async {
+        guard !isFetching else { return }
+        isFetching = true
+        defer { isFetching = false }
+        do {
+            let snap = try await APIClient.shared.getActivitySnapshot()
+            self.snapshot = snap
+            self.lastError = nil
+        } catch {
+            self.lastError = "snapshot failed: \(error.localizedDescription)"
+        }
+    }
+
+    /// Mutate `snapshot` in place to set/clear `paused_until` on the affected
+    /// row. Caller passes `until = nil` to clear (resume). No-op if there is
+    /// no current snapshot or the id doesn't resolve to a known kind/capture.
+    private func applyOptimisticPause(target: PauseTarget, id: String, until: Date?) {
+        guard let current = snapshot else { return }
+
+        switch target {
+        case .kind:
+            guard let kind = WorkKind(rawValue: id) else { return }
+            let updatedKinds = current.kinds.map { row -> KindRow in
+                guard row.kind == kind else { return row }
+                return KindRow(
+                    kind: row.kind,
+                    inFlight: row.inFlight,
+                    queued: row.queued,
+                    failed: row.failed,
+                    lastDoneAt: row.lastDoneAt,
+                    pausedUntil: until
+                )
+            }
+            self.snapshot = ActivitySnapshot(
+                kinds: updatedKinds,
+                capture: current.capture,
+                resources: current.resources,
+                processingGate: current.processingGate,
+                generatedAt: current.generatedAt
+            )
+
+        case .capture:
+            guard let cap = CaptureKind(rawValue: id) else { return }
+            let updatedCapture = current.capture.map { row -> CaptureRow in
+                guard row.kind == cap else { return row }
+                return CaptureRow(
+                    kind: row.kind,
+                    running: row.running,
+                    pausedUntil: until
+                )
+            }
+            self.snapshot = ActivitySnapshot(
+                kinds: current.kinds,
+                capture: updatedCapture,
+                resources: current.resources,
+                processingGate: current.processingGate,
+                generatedAt: current.generatedAt
+            )
+        }
+    }
+
+    private func postPauseChanged() {
+        NotificationCenter.default.post(
+            name: ActivityNotifications.pauseChanged,
+            object: nil
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Stream F of the Activity Tab parallel build (umbrella #9, Phase 0 PR #20).
Fleshes out the Phase 0 placeholders for the Swift side of the Activity
surface so Streams A/E/G/H have a working service + APIClient methods to
target.

### What's in here

- **`ActivityMonitorService`** (`Desktop/Sources/Activity/ActivityMonitorService.swift`)
  - `@MainActor final class … : ObservableObject`, singleton `.shared`
  - `@Published var snapshot: ActivitySnapshot?`
  - `start()` / `stop()` lifecycle; idempotent
  - 1 Hz `Timer` while `NSApp.keyWindow != nil`; suspends on
    `NSWindow.didResignKeyNotification`, resumes on
    `didBecomeKeyNotification` with an **immediate fetch** (no 1s delay)
  - `pauseKind(_:minutes:)`, `pauseCapture(_:minutes:)`,
    `resume(target:id:)` — call APIClient, optimistically mutate the
    local snapshot's `paused_until`, then post
    `ActivityNotifications.pauseChanged` so `CapturePauseGate` (Stream H)
    refreshes without polling
- **`APIClient` additions** (`Desktop/Sources/APIClient.swift`,
  append-only inside `// === activity:F === / // === /activity:F ===`)
  - `getActivitySnapshot() async throws -> ActivitySnapshot`
  - `pauseActivity(target:id:minutes:) async throws -> Date`
  - `resumeActivity(target:id:) async throws`
  - `reportInFlight(kind:inFlight:) async throws`
  - All target `rustBackendURL + "v1/activity/…"`. Bearer auth via
    `AuthService.getAuthHeader()`. Custom date decoder matches the
    ISO8601-with-fractional-seconds strategy used by the rest of the
    file. **Bypasses `isLocalOnlyMode`** — the Rust daemon is on
    127.0.0.1, so the cloud short-circuit doesn't apply
- **`ActivityModels`** (`Desktop/Sources/Activity/ActivityModels.swift`)
  - Adds public memberwise inits to `KindRow`, `CaptureRow`,
    `ProcessBreakdown`, `ResourceSample`, `GateState`,
    `ActivitySnapshot` so consumers can rebuild snapshots for
    optimistic UI updates without Codable round-trips. Wire format
    (CodingKeys + enum cases) is unchanged

### Contract

- **Contract hash:** `136f9faf6bafd199d98954393ede22c0d1998e2d`
- File: `Backend-Rust/src/activity/contract.md` (Phase 0)

### Verification

- `xcrun swift build -c debug --package-path Desktop` — Build complete.
- E2E coverage lands with Stream A (route handlers) + Stream I (tests).

## Test plan

- [ ] Stream A wiring + B/C/D concrete impls land → run app, open
      Activity tab (Stream E), confirm 1 Hz updates
- [ ] Hide IR window → verify no `getActivitySnapshot` log lines until
      window becomes key again
- [ ] Pause OCR 1 min via UI → row dims instantly (optimistic), Rust
      confirms within 1s, `pauseChanged` fires for `CapturePauseGate`
- [ ] Pause Audio via UI → confirm sheet → row updates → mic stops

Closes #16. Part of #9.

Generated with [Claude Code](https://claude.com/claude-code)