### PR TITLE
activity: post-merge wiring + test enablement

### DIFF
--- a/Backend-Rust/Cargo.lock
+++ b/Backend-Rust/Cargo.lock
@@ -403,6 +403,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -830,9 +836,11 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "tower 0.4.13",
+ "tower 0.5.3",
  "tower-http 0.5.2",
  "tracing",
  "tracing-subscriber",
@@ -945,6 +953,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1453,6 +1467,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1680,6 +1707,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Backend-Rust/api/Cargo.toml
+++ b/Backend-Rust/api/Cargo.toml
@@ -47,3 +47,15 @@ dirs = "5"
 # === activity:stream-C resource sampler ===
 # macOS process-tree CPU/RSS sampler used by Activity Tab.
 libproc = "0.14"
+
+[features]
+# Enables the Activity Tab integration test wiring (Stream I, issue #19).
+# When on, the gated tests in `tests/activity_endpoints.rs` compile and
+# run against the real `infinite_recall_api::routes::router` library
+# surface (now exposed by `lib.rs`).
+activity_test_wiring = []
+
+[dev-dependencies]
+tempfile = "3"
+# Pulled in for `ServiceExt::oneshot` used by the activity_endpoints tests.
+tower = { version = "0.5", features = ["util"] }

--- a/Backend-Rust/api/src/db.rs
+++ b/Backend-Rust/api/src/db.rs
@@ -84,6 +84,22 @@ pub fn open_read_write_pool(path: &Path) -> Result<SqlitePool> {
     Ok(pool)
 }
 
+/// Test-only in-memory pool. Used by `tests/activity_endpoints.rs` (Stream I)
+/// to construct an `AppState` without touching the on-disk Omi DB. Gated
+/// behind `activity_test_wiring` so it never compiles into release builds.
+#[cfg(any(test, feature = "activity_test_wiring"))]
+pub fn open_in_memory_pool() -> Result<SqlitePool> {
+    let manager = SqliteConnectionManager::memory();
+    let pool = Pool::builder()
+        .max_size(1)
+        .build(manager)
+        .context("building r2d2 in-memory pool")?;
+    let conn = pool.get().context("checking out initial in-memory connection")?;
+    conn.query_row("SELECT 1", [], |_| Ok(()))
+        .context("smoke-testing in-memory connection")?;
+    Ok(pool)
+}
+
 /// Helper: run a closure on a blocking thread with a pooled connection.
 /// Most rusqlite calls are blocking; we offload to the tokio blocking pool
 /// so the async runtime stays responsive. Works for both read and write

--- a/Backend-Rust/api/tests/activity_endpoints.rs
+++ b/Backend-Rust/api/tests/activity_endpoints.rs
@@ -80,7 +80,7 @@ use axum::body::{to_bytes, Body};
 use axum::http::{header, Method, Request, StatusCode};
 use chrono::{DateTime, Duration, Utc};
 use serde_json::{json, Value};
-use tower::ServiceExt; // brings `oneshot` onto Router
+use tower::util::ServiceExt; // brings `oneshot` onto Router
 
 use infinite_recall_api::activity::traits::{
     InflightRegistry, PauseStore, ProcessingGate, ResourceSampler,
@@ -232,13 +232,18 @@ fn make_state(
 ) -> AppState {
     let pool = infinite_recall_api::db::open_in_memory_pool()
         .expect("in-memory pool — Stream A should expose a test helper");
+    let write_pool = infinite_recall_api::db::open_in_memory_pool()
+        .expect("in-memory write pool");
+    let (pause_tx, _pause_rx) = tokio::sync::broadcast::channel(64);
     AppState {
         pool,
+        write_pool,
         token: TEST_TOKEN.to_string(),
         pause_store,
         inflight,
         resource_sampler: sampler,
         processing_gate: gate,
+        pause_tx,
     }
 }
 
@@ -271,7 +276,6 @@ async fn json_body(resp: axum::response::Response) -> Value {
 /// §Verification step 6: snapshot returns the full shape with every field
 /// present and correctly typed.
 #[tokio::test]
-#[ignore = "stream-A: needs route handlers wired"]
 async fn snapshot_returns_200_with_full_shape() {
     let app = make_default_app();
     let (k, v) = auth_header();
@@ -349,7 +353,6 @@ async fn snapshot_returns_200_with_full_shape() {
 /// §Verification step 7: POST pause writes the row and returns
 /// `{paused_until: iso8601}`.
 #[tokio::test]
-#[ignore = "stream-A: needs pause handler wired (B's impl unnecessary — uses MemPauseStore)"]
 async fn pause_returns_paused_until() {
     let app = make_default_app();
     let (k, v) = auth_header();
@@ -377,7 +380,6 @@ async fn pause_returns_paused_until() {
 
 /// After a pause, the kind row in the snapshot reflects `paused_until`.
 #[tokio::test]
-#[ignore = "stream-A"]
 async fn paused_kind_visible_in_snapshot() {
     // Single AppState shared across the two requests so the pause persists.
     let pause_store: Arc<dyn PauseStore> = Arc::new(MemPauseStore::new());
@@ -430,7 +432,6 @@ async fn paused_kind_visible_in_snapshot() {
 /// Uses Stream B's `SqlPauseStore` directly — both lifecycles point at the
 /// same SQLite file path.
 #[tokio::test]
-#[ignore = "stream-B: needs SqlPauseStore + paused_work migration"]
 async fn pause_persists_across_restart() {
     use infinite_recall_api::activity::pause_store::SqlPauseStore;
     let tmp = tempfile::NamedTempFile::new().unwrap();
@@ -461,7 +462,6 @@ async fn pause_persists_across_restart() {
 
 /// POST resume clears the pause row.
 #[tokio::test]
-#[ignore = "stream-A"]
 async fn resume_clears_pause() {
     let pause_store: Arc<dyn PauseStore> = Arc::new(MemPauseStore::new());
     let state = make_state(
@@ -493,7 +493,6 @@ async fn resume_clears_pause() {
 
 /// `_internal/inflight` updates the registry; subsequent snapshot reflects it.
 #[tokio::test]
-#[ignore = "stream-A + stream-D"]
 async fn inflight_loopback_round_trip() {
     let inflight: Arc<dyn InflightRegistry> = Arc::new(MemInflight::new());
     let state = make_state(
@@ -563,7 +562,6 @@ async fn inflight_loopback_round_trip() {
 
 /// Auth: missing bearer → 401.
 #[tokio::test]
-#[ignore = "stream-A: needs activity routes mounted under require_bearer"]
 async fn missing_bearer_returns_401() {
     let app = make_default_app();
     let req = Request::builder()
@@ -578,7 +576,6 @@ async fn missing_bearer_returns_401() {
 /// Bad pause body → 400 (or 422). Stream A picks the exact code; we accept
 /// any 4xx that signals client error.
 #[tokio::test]
-#[ignore = "stream-A"]
 async fn pause_request_validation() {
     let app = make_default_app();
     let (k, v) = auth_header();


### PR DESCRIPTION
## Summary

Post-merge follow-up after the 10 Activity Tab parallel-build PRs (#20-#29) all landed. Enables Stream I's integration tests against the now-merged api/src/activity surface.

- Adds [features] activity_test_wiring and tempfile + tower 0.5 (util) to api/Cargo.toml dev-deps
- Adds db::open_in_memory_pool() gated to tests/feature
- Patches api/tests/activity_endpoints.rs: ServiceExt import path, AppState init now includes write_pool + pause_tx, drops the per-stream #[ignore] attributes (all streams landed)

lib.rs already exposed pub mod activity from PR #20, so no lib.rs change needed beyond confirmation.

## Test plan

- [x] cargo build -p infinite-recall-api: green
- [x] cargo test -p infinite-recall-api --features activity_test_wiring: 29 lib tests + 9 activity_endpoints tests pass
- [x] xcrun swift build -c debug --package-path Desktop: green

🤖 Generated with [Claude Code](https://claude.com/claude-code)