### PR TITLE
fix(activity): singleton fixes (S1/S4/S6/S7) — auth, async sampler, observable failures

### DIFF
--- a/Backend-Rust/api/src/activity/gate.rs
+++ b/Backend-Rust/api/src/activity/gate.rs
@@ -2,6 +2,10 @@
 //! idle-gate agent (separate stream not yet shipped). Until then we ship
 //! an "always-allowed" stub so `ActivityState` can be constructed and the
 //! snapshot endpoint returns a stable shape.
+//!
+//! Consensus-fix C4: report the stub status via `GateReason::Stub` and
+//! `waiting_for: "real gate not wired"` so the UI can render an honest
+//! "Gate not yet wired (#32)" instead of "Idle processing — running".
 
 use chrono::Utc;
 
@@ -9,16 +13,17 @@ use super::traits::ProcessingGate;
 use super::types::{GateReason, GateState};
 
 /// Always-allowed gate. No idle/thermal throttling enforced; the snapshot
-/// will report `allowed: true` and `reason: None`.
+/// reports `allowed: true` with `reason: Stub` so consumers can detect the
+/// placeholder and surface it as such in the UI.
 pub struct AlwaysAllowedGate;
 
 impl ProcessingGate for AlwaysAllowedGate {
     fn current(&self) -> GateState {
         GateState {
             allowed: true,
-            reason: GateReason::None,
+            reason: GateReason::Stub,
             since: Utc::now(),
-            waiting_for: None,
+            waiting_for: Some("real gate not wired".to_string()),
         }
     }
 }

--- a/Backend-Rust/api/src/activity/pause_store.rs
+++ b/Backend-Rust/api/src/activity/pause_store.rs
@@ -30,7 +30,7 @@ use r2d2::Pool;
 use r2d2_sqlite::SqliteConnectionManager;
 use rusqlite::params;
 
-use super::traits::PauseStore;
+use super::traits::{PauseStore, PauseStoreError};
 use super::types::PauseTarget;
 
 /// Inline migration source. Kept in lockstep with
@@ -143,42 +143,47 @@ impl PauseStore for SqlPauseStore {
         }
     }
 
-    fn pause(&self, target: PauseTarget, id: &str, minutes: u32) -> DateTime<Utc> {
+    fn pause(
+        &self,
+        target: PauseTarget,
+        id: &str,
+        minutes: u32,
+    ) -> Result<DateTime<Utc>, PauseStoreError> {
         let resume_at_secs = now_unix_secs().saturating_add(i64::from(minutes) * 60);
         let resume_at = from_unix_secs(resume_at_secs);
-        let conn = match self.pool.get() {
-            Ok(c) => c,
-            Err(e) => {
-                tracing::error!(error = %e, "pause: pool checkout failed; returning resume time without persisting");
-                return resume_at;
-            }
-        };
         let t = target_str(target);
-        if let Err(e) = conn.execute(
+        let conn = self.pool.get().map_err(|e| {
+            tracing::error!(error = %e, "pause: pool checkout failed");
+            PauseStoreError::from(e)
+        })?;
+        conn.execute(
             "INSERT INTO paused_work (target, id, resume_at) VALUES (?1, ?2, ?3)
              ON CONFLICT(target, id) DO UPDATE SET resume_at = excluded.resume_at",
             params![t, id, resume_at_secs],
-        ) {
+        )
+        .map_err(|e| {
             tracing::error!(error = %e, target = t, id = id, "pause upsert failed");
-        }
-        resume_at
+            PauseStoreError::from(e)
+        })?;
+        Ok(resume_at)
     }
 
-    fn resume(&self, target: PauseTarget, id: &str) {
-        let conn = match self.pool.get() {
-            Ok(c) => c,
-            Err(e) => {
-                tracing::error!(error = %e, "resume: pool checkout failed");
-                return;
-            }
-        };
+    fn resume(&self, target: PauseTarget, id: &str) -> Result<bool, PauseStoreError> {
         let t = target_str(target);
-        if let Err(e) = conn.execute(
-            "DELETE FROM paused_work WHERE target = ?1 AND id = ?2",
-            params![t, id],
-        ) {
-            tracing::error!(error = %e, target = t, id = id, "resume delete failed");
-        }
+        let conn = self.pool.get().map_err(|e| {
+            tracing::error!(error = %e, "resume: pool checkout failed");
+            PauseStoreError::from(e)
+        })?;
+        let affected = conn
+            .execute(
+                "DELETE FROM paused_work WHERE target = ?1 AND id = ?2",
+                params![t, id],
+            )
+            .map_err(|e| {
+                tracing::error!(error = %e, target = t, id = id, "resume delete failed");
+                PauseStoreError::from(e)
+            })?;
+        Ok(affected > 0)
     }
 }
 
@@ -207,7 +212,7 @@ mod tests {
     #[test]
     fn pause_then_read_back_returns_resume_time() {
         let store = fresh_store();
-        let returned = store.pause(PauseTarget::Kind, "ocr", 15);
+        let returned = store.pause(PauseTarget::Kind, "ocr", 15).expect("pause ok");
         let observed = store
             .paused_until(PauseTarget::Kind, "ocr")
             .expect("paused row should be returned");
@@ -259,12 +264,13 @@ mod tests {
     #[test]
     fn pause_then_resume_clears_row() {
         let store = fresh_store();
-        store.pause(PauseTarget::Kind, "summarize", 30);
+        store.pause(PauseTarget::Kind, "summarize", 30).expect("pause ok");
         assert!(store
             .paused_until(PauseTarget::Kind, "summarize")
             .is_some());
 
-        store.resume(PauseTarget::Kind, "summarize");
+        let was_paused = store.resume(PauseTarget::Kind, "summarize").expect("resume ok");
+        assert!(was_paused, "resume should report row was deleted");
         assert!(store
             .paused_until(PauseTarget::Kind, "summarize")
             .is_none());
@@ -273,8 +279,8 @@ mod tests {
     #[test]
     fn pause_overwrite_extends_resume_time() {
         let store = fresh_store();
-        let short = store.pause(PauseTarget::Capture, "screen", 1);
-        let longer = store.pause(PauseTarget::Capture, "screen", 60);
+        let short = store.pause(PauseTarget::Capture, "screen", 1).expect("pause ok");
+        let longer = store.pause(PauseTarget::Capture, "screen", 60).expect("pause ok");
         assert!(longer.timestamp() > short.timestamp());
 
         let observed = store
@@ -293,8 +299,9 @@ mod tests {
     #[test]
     fn resume_on_unpaused_target_is_noop() {
         let store = fresh_store();
-        // Should not panic or error.
-        store.resume(PauseTarget::Kind, "extract_memory");
+        // Should not panic or error; should report no row was deleted.
+        let was_paused = store.resume(PauseTarget::Kind, "extract_memory").expect("resume ok");
+        assert!(!was_paused, "resume of un-paused target should report false");
         assert!(store
             .paused_until(PauseTarget::Kind, "extract_memory")
             .is_none());
@@ -303,7 +310,7 @@ mod tests {
     #[test]
     fn kind_and_capture_targets_are_independent() {
         let store = fresh_store();
-        store.pause(PauseTarget::Kind, "audio", 10);
+        store.pause(PauseTarget::Kind, "audio", 10).expect("pause ok");
         // Same id, different target — must be a separate row.
         assert!(store
             .paused_until(PauseTarget::Capture, "audio")
@@ -314,7 +321,7 @@ mod tests {
     #[test]
     fn concurrent_reads_are_safe() {
         let store = fresh_store();
-        store.pause(PauseTarget::Kind, "ocr", 5);
+        store.pause(PauseTarget::Kind, "ocr", 5).expect("pause ok");
         let store_arc = Arc::new(store);
 
         let handles: Vec<_> = (0..8)
@@ -341,7 +348,7 @@ mod tests {
                 let s = Arc::clone(&store);
                 thread::spawn(move || {
                     for _ in 0..20 {
-                        s.pause(PauseTarget::Kind, "ocr", i + 1);
+                        s.pause(PauseTarget::Kind, "ocr", i + 1).expect("pause ok");
                     }
                 })
             })

--- a/Backend-Rust/api/src/activity/resources.rs
+++ b/Backend-Rust/api/src/activity/resources.rs
@@ -428,48 +428,105 @@ fn map_pmset_therm(stdout: &str) -> ThermalState {
 // Power (battery / low-power)
 // ---------------------------------------------------------------------------
 
+/// Consensus-fix C5 (interim): replacing `pmset` shellout with
+/// `IOPSCopyPowerSourcesInfo` is the long-term goal (issue #32 follow-up),
+/// but until that lands we ship a fail-closed parse: any unrecognised /
+/// localised pmset output reports `(on_battery: true, low_power: true)`,
+/// which makes the scheduler's `allowHeavyWork` conservatively block
+/// rather than letting Whisper run wide-open on a non-English Mac.
+///
+/// Each fallback emits a `tracing::warn!` so the conservative branch is
+/// observable in logs.
 fn sample_power() -> (bool, bool) {
     let on_battery = match Command::new("pmset").args(["-g", "batt"]).output() {
         Ok(o) if o.status.success() => {
             let s = String::from_utf8_lossy(&o.stdout);
-            parse_on_battery(&s)
+            match parse_on_battery_safe(&s) {
+                Some(v) => v,
+                None => {
+                    tracing::warn!(
+                        component = "activity.resources.power",
+                        "pmset -g batt output not recognised — failing closed (on_battery=true)"
+                    );
+                    true
+                }
+            }
         }
-        _ => false,
+        other => {
+            tracing::warn!(
+                component = "activity.resources.power",
+                status = ?other.as_ref().map(|o| o.status),
+                "pmset -g batt failed — failing closed (on_battery=true)"
+            );
+            true
+        }
     };
     let low_power = match Command::new("pmset").args(["-g"]).output() {
         Ok(o) if o.status.success() => {
             let s = String::from_utf8_lossy(&o.stdout);
-            parse_low_power(&s)
+            match parse_low_power_safe(&s) {
+                Some(v) => v,
+                None => {
+                    tracing::warn!(
+                        component = "activity.resources.power",
+                        "pmset -g output missing lowpowermode — failing closed (low_power=true)"
+                    );
+                    true
+                }
+            }
         }
-        _ => false,
+        other => {
+            tracing::warn!(
+                component = "activity.resources.power",
+                status = ?other.as_ref().map(|o| o.status),
+                "pmset -g failed — failing closed (low_power=true)"
+            );
+            true
+        }
     };
     (on_battery, low_power)
 }
 
-fn parse_on_battery(stdout: &str) -> bool {
-    // First line is e.g. `Now drawing from 'Battery Power'` or `'AC Power'`.
+/// Parse the first line of `pmset -g batt`. Returns `None` (→ fail-closed)
+/// when the English literals "Battery Power" / "AC Power" are absent
+/// (locale shifted, format change, etc.).
+fn parse_on_battery_safe(stdout: &str) -> Option<bool> {
     for line in stdout.lines() {
         if line.contains("Battery Power") {
-            return true;
+            return Some(true);
         }
         if line.contains("AC Power") {
-            return false;
+            return Some(false);
         }
     }
-    false
+    None
 }
 
-fn parse_low_power(stdout: &str) -> bool {
+/// Parse `pmset -g` for `lowpowermode N`. Returns `None` (→ fail-closed)
+/// when the key is absent.
+fn parse_low_power_safe(stdout: &str) -> Option<bool> {
     for line in stdout.lines() {
         let l = line.trim();
         if let Some(rest) = l.strip_prefix("lowpowermode") {
             let rest = rest.trim_start_matches([' ', '=']).trim();
             if let Ok(v) = rest.parse::<u32>() {
-                return v != 0;
+                return Some(v != 0);
             }
         }
     }
-    false
+    None
+}
+
+// Legacy non-safe wrappers retained for the unit tests asserting the
+// fail-closed default (None → true).
+#[cfg(test)]
+fn parse_on_battery(stdout: &str) -> bool {
+    parse_on_battery_safe(stdout).unwrap_or(true)
+}
+
+#[cfg(test)]
+fn parse_low_power(stdout: &str) -> bool {
+    parse_low_power_safe(stdout).unwrap_or(true)
 }
 
 // ---------------------------------------------------------------------------
@@ -576,15 +633,34 @@ mod tests {
 
     #[test]
     fn parses_pmset_battery() {
-        assert!(parse_on_battery("Now drawing from 'Battery Power'\n -InternalBattery-0	75%"));
-        assert!(!parse_on_battery("Now drawing from 'AC Power'\n -InternalBattery-0	100%"));
+        // Recognised English literals → exact value.
+        assert_eq!(
+            parse_on_battery_safe("Now drawing from 'Battery Power'\n -InternalBattery-0	75%"),
+            Some(true)
+        );
+        assert_eq!(
+            parse_on_battery_safe("Now drawing from 'AC Power'\n -InternalBattery-0	100%"),
+            Some(false)
+        );
+        // Unrecognised → None (caller fails closed).
+        assert_eq!(parse_on_battery_safe("Source: 'Réseau'"), None);
     }
 
     #[test]
     fn parses_low_power_mode() {
-        assert!(parse_low_power(" lowpowermode         1\n other line"));
-        assert!(!parse_low_power(" lowpowermode         0\n other line"));
-        assert!(!parse_low_power("nothing here"));
+        assert_eq!(parse_low_power_safe(" lowpowermode         1\n other line"), Some(true));
+        assert_eq!(parse_low_power_safe(" lowpowermode         0\n other line"), Some(false));
+        // Missing → None (caller fails closed).
+        assert_eq!(parse_low_power_safe("nothing here"), None);
+    }
+
+    /// Consensus-fix C5: when the parse fails, `sample_power` MUST report
+    /// `(true, true)` — failing closed prevents heavy ML from running on
+    /// battery just because pmset spoke a different language.
+    #[test]
+    fn unrecognised_pmset_output_fails_closed() {
+        assert!(parse_on_battery("nothing useful")); // legacy wrapper
+        assert!(parse_low_power("nothing useful")); // legacy wrapper
     }
 
     #[test]

--- a/Backend-Rust/api/src/activity/resources.rs
+++ b/Backend-Rust/api/src/activity/resources.rs
@@ -41,7 +41,13 @@ const MLX_LABEL_CANDIDATES: &[&str] = &[
 ];
 
 /// How long to hold a sample in cache before re-sampling.
-const CACHE_TTL: Duration = Duration::from_secs(1);
+///
+/// Singleton-fixer S4: bumped 1s → 2s. The sampler costs ~300ms per
+/// miss (250ms CPU-delta sleep + ~5 subprocess forks). With the Swift
+/// Activity tab polling at 1Hz, a 1s TTL meant a cache miss every tick;
+/// 2s halves that to every other tick without any user-visible staleness
+/// (CPU/RSS/GPU are coarse readouts, not real-time meters).
+const CACHE_TTL: Duration = Duration::from_secs(2);
 
 /// Window over which we measure CPU% deltas.
 const CPU_SAMPLE_WINDOW: Duration = Duration::from_millis(250);
@@ -161,6 +167,10 @@ impl ResourceSampler for SystemResourceSampler {
 /// Returns `[(name, pid)]` for self + Swift app + mlx-lm if found.
 ///
 /// Order is meaningful so tests / logs are stable: `api`, `swift`, `mlx`.
+///
+/// Singleton-fixer S7: each discovery path emits a structured tracing
+/// breadcrumb so the next contributor can tell whether a missing pid is
+/// "no pidfile yet" vs "launchctl label renamed" vs "stale pidfile".
 fn discover_pids(support_dir_override: Option<&std::path::Path>) -> Vec<(String, i32)> {
     let mut out: Vec<(String, i32)> = Vec::with_capacity(3);
 
@@ -171,15 +181,47 @@ fn discover_pids(support_dir_override: Option<&std::path::Path>) -> Vec<(String,
         .map(|p| p.to_path_buf())
         .unwrap_or_else(default_support_dir);
 
-    if let Some(pid) = read_pidfile(&support_dir.join("swift.pid"))
-        .or_else(|| pid_from_launchctl_any(SWIFT_LABEL_CANDIDATES))
-    {
+    let swift_pidfile = support_dir.join("swift.pid");
+    if let Some(pid) = read_pidfile(&swift_pidfile) {
+        tracing::debug!(
+            component = "activity.discover",
+            target = "swift",
+            via = "pidfile",
+            path = %swift_pidfile.display(),
+            pid,
+            "discovered pid via pidfile"
+        );
+        out.push(("swift".to_string(), pid));
+    } else if let Some(pid) = pid_from_launchctl_any(SWIFT_LABEL_CANDIDATES, "swift") {
+        tracing::debug!(
+            component = "activity.discover",
+            target = "swift",
+            via = "launchctl",
+            pid,
+            "discovered pid via launchctl"
+        );
         out.push(("swift".to_string(), pid));
     }
 
-    if let Some(pid) = read_pidfile(&support_dir.join("mlxlm.pid"))
-        .or_else(|| pid_from_launchctl_any(MLX_LABEL_CANDIDATES))
-    {
+    let mlx_pidfile = support_dir.join("mlxlm.pid");
+    if let Some(pid) = read_pidfile(&mlx_pidfile) {
+        tracing::debug!(
+            component = "activity.discover",
+            target = "mlx",
+            via = "pidfile",
+            path = %mlx_pidfile.display(),
+            pid,
+            "discovered pid via pidfile"
+        );
+        out.push(("mlx-lm".to_string(), pid));
+    } else if let Some(pid) = pid_from_launchctl_any(MLX_LABEL_CANDIDATES, "mlx") {
+        tracing::debug!(
+            component = "activity.discover",
+            target = "mlx",
+            via = "launchctl",
+            pid,
+            "discovered pid via launchctl"
+        );
         out.push(("mlx-lm".to_string(), pid));
     }
 
@@ -192,31 +234,93 @@ fn default_support_dir() -> PathBuf {
         .join("Library/Application Support/InfiniteRecall")
 }
 
-/// Reads a single integer pid from the given file. Returns `None` if the file
-/// does not exist, is unreadable, or does not contain a positive integer.
+/// Reads a single integer pid from the given file. Returns `None` if the
+/// file is missing, unreadable, contains garbage, or names a dead pid.
+///
+/// Singleton-fixer S7: each failure mode emits a `tracing::debug!` so the
+/// "why didn't we discover this pid?" question is answerable from logs.
+/// `debug` (not `warn`) because pidfile-missing is normal at first launch
+/// before the Swift app + mlx-lm have been started by the user.
 fn read_pidfile(path: &std::path::Path) -> Option<i32> {
-    let raw = std::fs::read_to_string(path).ok()?;
-    let pid: i32 = raw.trim().parse().ok()?;
+    let raw = match std::fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            tracing::debug!(
+                component = "activity.discover.pidfile",
+                path = %path.display(),
+                reason = "missing",
+                "pidfile not present"
+            );
+            return None;
+        }
+        Err(e) => {
+            tracing::debug!(
+                component = "activity.discover.pidfile",
+                path = %path.display(),
+                reason = "unreadable",
+                error = %e,
+                "pidfile read failed"
+            );
+            return None;
+        }
+    };
+    let pid: i32 = match raw.trim().parse() {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::debug!(
+                component = "activity.discover.pidfile",
+                path = %path.display(),
+                reason = "unparseable",
+                contents = %raw.trim(),
+                error = %e,
+                "pidfile contents not an integer"
+            );
+            return None;
+        }
+    };
     if pid <= 0 {
+        tracing::debug!(
+            component = "activity.discover.pidfile",
+            path = %path.display(),
+            reason = "unparseable",
+            pid,
+            "pidfile contains non-positive pid"
+        );
         return None;
     }
     if !pid_alive(pid) {
+        tracing::debug!(
+            component = "activity.discover.pidfile",
+            path = %path.display(),
+            reason = "stale",
+            pid,
+            "pidfile points at a dead pid"
+        );
         return None;
     }
     Some(pid)
 }
 
-/// Tries each candidate label until one returns a live pid.
-fn pid_from_launchctl_any(labels: &[&str]) -> Option<i32> {
+/// Tries each candidate label until one returns a live pid. If none match,
+/// emits a single `tracing::warn!` listing the candidates we tried so the
+/// next person who renames a launchd label sees an actionable breadcrumb.
+fn pid_from_launchctl_any(labels: &[&str], target: &str) -> Option<i32> {
     for label in labels {
         if let Some(pid) = pid_from_launchctl(label) {
             return Some(pid);
         }
     }
+    tracing::warn!(
+        component = "activity.discover",
+        target,
+        labels = ?labels,
+        "no launchctl entry found for {target} (tried all candidate labels)"
+    );
     None
 }
 
-/// Parses `launchctl list <label>` for a `"PID" = <int>;` line.
+/// Parses `launchctl list <label>` for a `"PID" = <int>;` (legacy) or
+/// `pid = N` (newer macOS) line.
 fn pid_from_launchctl(label: &str) -> Option<i32> {
     let out = Command::new("launchctl")
         .args(["list", label])
@@ -229,17 +333,38 @@ fn pid_from_launchctl(label: &str) -> Option<i32> {
     parse_launchctl_pid(&stdout)
 }
 
+/// Parse a `launchctl list <label>` stdout buffer for the service pid.
+///
+/// Tolerates two known formats:
+///   - Legacy plist-ish:  `"PID" = 12345;`
+///   - Newer key/value:   `pid = 12345`  (or `pid = 12345;`)
+///
+/// Singleton-fixer S7 / Broad reviewer MED-14.
 fn parse_launchctl_pid(stdout: &str) -> Option<i32> {
     for line in stdout.lines() {
         let line = line.trim();
-        // Expected shape: `"PID" = 12345;`
-        if let Some(rest) = line.strip_prefix("\"PID\"") {
-            let rest = rest.trim_start_matches([' ', '=']).trim();
-            let rest = rest.trim_end_matches(';').trim();
-            if let Ok(pid) = rest.parse::<i32>() {
-                if pid > 0 {
-                    return Some(pid);
-                }
+
+        // Legacy `"PID" = N;`
+        let rest_legacy = line.strip_prefix("\"PID\"");
+
+        // Newer `pid = N` (case-insensitive — newer launchctl prints lowercase).
+        let rest_new = line
+            .strip_prefix("pid")
+            .or_else(|| line.strip_prefix("PID"));
+        // Guard: only accept the bare-key form when the next char is `=` or
+        // whitespace, so we don't grab e.g. `pidsignal = 9`.
+        let rest_new = rest_new.filter(|tail| {
+            tail.chars().next().map_or(false, |c| c == '=' || c.is_whitespace())
+        });
+
+        let rest = rest_legacy.or(rest_new);
+        let Some(rest) = rest else { continue };
+
+        let rest = rest.trim_start_matches([' ', '\t', '=']).trim();
+        let rest = rest.trim_end_matches(';').trim();
+        if let Ok(pid) = rest.parse::<i32>() {
+            if pid > 0 {
+                return Some(pid);
             }
         }
     }
@@ -617,6 +742,22 @@ mod tests {
     fn parses_launchctl_pid_missing() {
         let stdout = r#"{ "Label" = "x"; }"#;
         assert_eq!(parse_launchctl_pid(stdout), None);
+    }
+
+    /// Singleton-fixer S7 / Broad reviewer MED-14: tolerate the newer
+    /// `launchctl print` / `launchctl list` lowercase-key format. Without
+    /// this, after Apple flips the format the next contributor sees pid
+    /// discovery silently regressing to "self-only" with zero log signal.
+    #[test]
+    fn parses_launchctl_pid_new_format() {
+        let stdout = "  pid = 12345\n  state = running\n";
+        assert_eq!(parse_launchctl_pid(stdout), Some(12345));
+        // Trailing semicolon variant.
+        let stdout2 = "pid = 6789;";
+        assert_eq!(parse_launchctl_pid(stdout2), Some(6789));
+        // Must not match e.g. `pidsignal = 9` — that's a different field.
+        let stdout3 = "pidsignal = 9";
+        assert_eq!(parse_launchctl_pid(stdout3), None);
     }
 
     #[test]

--- a/Backend-Rust/api/src/activity/traits.rs
+++ b/Backend-Rust/api/src/activity/traits.rs
@@ -6,10 +6,57 @@
 //! these trait objects.
 
 use std::collections::HashMap;
+use std::fmt;
 
 use chrono::{DateTime, Utc};
 
 use super::types::{GateState, InFlight, PauseTarget, ResourceSample, WorkKind};
+
+/// Errors surfaced by `PauseStore` writes (consensus-fix C3).
+///
+/// Pre-fix, `pause()` and `resume()` swallowed every SQLite / pool error
+/// and returned a value as if the write had succeeded — so the UI rendered
+/// optimistic state that quietly reverted on the next snapshot poll.
+/// Routes now translate this into 5xx so the Swift side can show the
+/// failure to the user instead of silently rolling back.
+#[derive(Debug)]
+pub enum PauseStoreError {
+    Storage(rusqlite::Error),
+    Pool(r2d2::Error),
+    Unknown(String),
+}
+
+impl fmt::Display for PauseStoreError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PauseStoreError::Storage(e) => write!(f, "pause store storage error: {e}"),
+            PauseStoreError::Pool(e) => write!(f, "pause store pool error: {e}"),
+            PauseStoreError::Unknown(s) => write!(f, "pause store error: {s}"),
+        }
+    }
+}
+
+impl std::error::Error for PauseStoreError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            PauseStoreError::Storage(e) => Some(e),
+            PauseStoreError::Pool(e) => Some(e),
+            PauseStoreError::Unknown(_) => None,
+        }
+    }
+}
+
+impl From<rusqlite::Error> for PauseStoreError {
+    fn from(e: rusqlite::Error) -> Self {
+        PauseStoreError::Storage(e)
+    }
+}
+
+impl From<r2d2::Error> for PauseStoreError {
+    fn from(e: r2d2::Error) -> Self {
+        PauseStoreError::Pool(e)
+    }
+}
 
 /// Persistent absolute-time pause storage. Backed by SQLite (Stream B).
 pub trait PauseStore: Send + Sync {
@@ -18,10 +65,19 @@ pub trait PauseStore: Send + Sync {
     fn paused_until(&self, target: PauseTarget, id: &str) -> Option<DateTime<Utc>>;
 
     /// Pause for `minutes` from now; returns the resolved resume time.
-    fn pause(&self, target: PauseTarget, id: &str, minutes: u32) -> DateTime<Utc>;
+    /// Errors propagate so the route can surface a 5xx instead of silently
+    /// returning a "successful" resume time on a failed write.
+    fn pause(
+        &self,
+        target: PauseTarget,
+        id: &str,
+        minutes: u32,
+    ) -> Result<DateTime<Utc>, PauseStoreError>;
 
-    /// Clear any pause row for the given target/id.
-    fn resume(&self, target: PauseTarget, id: &str);
+    /// Clear any pause row for the given target/id. Returns `true` iff a
+    /// row was actually deleted, so the route can decide whether to fan
+    /// out a `pauseChanged` notification.
+    fn resume(&self, target: PauseTarget, id: &str) -> Result<bool, PauseStoreError>;
 }
 
 /// Tracks which `WorkKind` is currently mid-handler. Backed by an

--- a/Backend-Rust/api/src/activity/types.rs
+++ b/Backend-Rust/api/src/activity/types.rs
@@ -62,6 +62,11 @@ pub enum GateReason {
     ManualPause,
     /// No gating reason; trivial baseline.
     None,
+    /// `AlwaysAllowedGate` placeholder is in use — the real `ProcessingGate`
+    /// owned by the idle-gate agent has not been wired yet (issue #32).
+    /// Consensus-fix C4: surface this so the UI doesn't gaslight users with
+    /// "Idle processing — running" when in reality no work drains.
+    Stub,
 }
 
 /// Single in-flight task currently executing for a given `WorkKind`.

--- a/Backend-Rust/api/src/lib.rs
+++ b/Backend-Rust/api/src/lib.rs
@@ -63,6 +63,12 @@ pub async fn run() -> Result<()> {
         Arc::new(activity::resources::SystemResourceSampler::new());
     let processing_gate: Arc<dyn activity::ProcessingGate> =
         Arc::new(activity::gate::AlwaysAllowedGate);
+    // Consensus-fix C4: leave a single, grep-able boot breadcrumb so anyone
+    // staring at the Activity tab can confirm we are still on the stub.
+    tracing::warn!(
+        component = "activity.gate",
+        "AlwaysAllowedGate active — real ProcessingGate not yet wired (issue #32)"
+    );
     let (pause_tx, _pause_rx) = tokio::sync::broadcast::channel(64);
     // === /activity:A ===
 

--- a/Backend-Rust/api/src/routes/activity.rs
+++ b/Backend-Rust/api/src/routes/activity.rs
@@ -51,12 +51,31 @@ fn capture_id(c: CaptureKind) -> &'static str {
 }
 
 /// `GET /v1/activity/snapshot` — full live snapshot.
-pub async fn snapshot(State(state): State<AppState>) -> Json<ActivitySnapshot> {
+pub async fn snapshot(
+    State(state): State<AppState>,
+) -> Result<Json<ActivitySnapshot>, (StatusCode, String)> {
     // Pull each piece independently. Sampler + gate are expected to cache
     // their own work; pause_store is a cheap SQLite point-lookup; inflight
     // is an in-memory RwLock read.
     let inflight_map = state.inflight.snapshot();
-    let resources = state.resource_sampler.sample();
+
+    // Singleton-fixer S4: `SystemResourceSampler::sample()` blocks the
+    // calling thread for ~300ms on a cache miss (it `thread::sleep(250ms)`
+    // for the CPU-delta window plus ~5 sync subprocess forks for ioreg /
+    // sysctl / pmset). With the sampler's 2s cache TTL and the Swift
+    // poller hitting `/snapshot` at 1Hz, on the old `.sample()`-on-the-
+    // tokio-worker path every other tick stalled an entire runtime
+    // worker. Move the sample to a blocking pool so the async runtime
+    // stays free to serve the rest of the daemon.
+    let sampler = state.resource_sampler.clone();
+    let resources = tokio::task::spawn_blocking(move || sampler.sample())
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("resource sampler join error: {e}"),
+            )
+        })?;
     let processing_gate = state.processing_gate.current();
 
     let kinds: Vec<KindRow> = ALL_KINDS
@@ -92,13 +111,13 @@ pub async fn snapshot(State(state): State<AppState>) -> Json<ActivitySnapshot> {
         })
         .collect();
 
-    Json(ActivitySnapshot {
+    Ok(Json(ActivitySnapshot {
         kinds,
         capture,
         resources,
         processing_gate,
         generated_at: Utc::now(),
-    })
+    }))
 }
 
 /// Resolve a `PauseRequest`/`ResumeRequest` `id` against its `target`. The

--- a/Backend-Rust/api/src/routes/activity.rs
+++ b/Backend-Rust/api/src/routes/activity.rs
@@ -9,10 +9,11 @@
 //! impls are owned by Streams B/C/D and the idle-gate agent — the Phase 0
 //! contract (`activity/contract.md`) is the source of truth.
 
-use axum::{extract::State, http::StatusCode, Json};
+use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
 use chrono::Utc;
 use serde_json::json;
 
+use crate::activity::traits::PauseStoreError;
 use crate::activity::types::{
     ActivitySnapshot, CaptureKind, CaptureRow, InflightUpdate, KindRow, PauseRequest, PauseTarget,
     ResumeRequest, WorkKind,
@@ -122,19 +123,33 @@ fn validate_target_id(target: PauseTarget, id: &str) -> Result<(), StatusCode> {
     }
 }
 
+/// Map `PauseStoreError` to a 5xx response with structured JSON detail
+/// (consensus-fix C3) so the Swift caller can show the real failure
+/// instead of silently rolling back optimistic UI state.
+fn pause_store_error_response(e: PauseStoreError) -> (StatusCode, Json<serde_json::Value>) {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(json!({
+            "error": "pause_store_failure",
+            "detail": e.to_string(),
+        })),
+    )
+}
+
 /// `POST /v1/activity/pause` — pause a kind or live capture for N minutes.
 pub async fn pause(
     State(state): State<AppState>,
     Json(body): Json<PauseRequest>,
-) -> Result<Json<serde_json::Value>, StatusCode> {
+) -> Result<Json<serde_json::Value>, axum::response::Response> {
     if body.minutes == 0 {
-        return Err(StatusCode::BAD_REQUEST);
+        return Err(StatusCode::BAD_REQUEST.into_response());
     }
-    validate_target_id(body.target, &body.id)?;
+    validate_target_id(body.target, &body.id).map_err(|s| s.into_response())?;
 
     let resume_at = state
         .pause_store
-        .pause(body.target, &body.id, body.minutes);
+        .pause(body.target, &body.id, body.minutes)
+        .map_err(|e| pause_store_error_response(e).into_response())?;
 
     // Best-effort fanout. No subscribers = ok; the Swift poller still
     // refreshes on its 1s tick.
@@ -153,16 +168,23 @@ pub async fn pause(
 pub async fn resume(
     State(state): State<AppState>,
     Json(body): Json<ResumeRequest>,
-) -> Result<StatusCode, StatusCode> {
-    validate_target_id(body.target, &body.id)?;
+) -> Result<StatusCode, axum::response::Response> {
+    validate_target_id(body.target, &body.id).map_err(|s| s.into_response())?;
 
-    state.pause_store.resume(body.target, &body.id);
+    let was_paused = state
+        .pause_store
+        .resume(body.target, &body.id)
+        .map_err(|e| pause_store_error_response(e).into_response())?;
 
-    let _ = state.pause_tx.send(PauseChange {
-        target: body.target,
-        id: body.id.clone(),
-        paused_until: None,
-    });
+    // Only fan out a notification if a row was actually deleted — otherwise
+    // we'd wake every Swift poller for every UI Cmd-R no-op.
+    if was_paused {
+        let _ = state.pause_tx.send(PauseChange {
+            target: body.target,
+            id: body.id.clone(),
+            paused_until: None,
+        });
+    }
 
     Ok(StatusCode::NO_CONTENT)
 }

--- a/Backend-Rust/api/tests/activity_endpoints.rs
+++ b/Backend-Rust/api/tests/activity_endpoints.rs
@@ -83,7 +83,7 @@ use serde_json::{json, Value};
 use tower::util::ServiceExt; // brings `oneshot` onto Router
 
 use infinite_recall_api::activity::traits::{
-    InflightRegistry, PauseStore, ProcessingGate, ResourceSampler,
+    InflightRegistry, PauseStore, PauseStoreError, ProcessingGate, ResourceSampler,
 };
 use infinite_recall_api::activity::types::{
     GateReason, GateState, InFlight, PauseTarget, ProcessBreakdown,
@@ -120,20 +120,28 @@ impl PauseStore for MemPauseStore {
             .copied()
     }
 
-    fn pause(&self, target: PauseTarget, id: &str, minutes: u32) -> DateTime<Utc> {
+    fn pause(
+        &self,
+        target: PauseTarget,
+        id: &str,
+        minutes: u32,
+    ) -> Result<DateTime<Utc>, PauseStoreError> {
         let resume_at = Utc::now() + Duration::minutes(minutes as i64);
         self.inner
             .lock()
             .unwrap()
             .insert((target, id.to_string()), resume_at);
-        resume_at
+        Ok(resume_at)
     }
 
-    fn resume(&self, target: PauseTarget, id: &str) {
-        self.inner
+    fn resume(&self, target: PauseTarget, id: &str) -> Result<bool, PauseStoreError> {
+        let removed = self
+            .inner
             .lock()
             .unwrap()
-            .remove(&(target, id.to_string()));
+            .remove(&(target, id.to_string()))
+            .is_some();
+        Ok(removed)
     }
 }
 
@@ -440,7 +448,9 @@ async fn pause_persists_across_restart() {
     // Lifecycle 1: write a pause then drop everything.
     {
         let store = SqlPauseStore::open(&path).expect("open SqlPauseStore");
-        let resume_at = store.pause(PauseTarget::Kind, "ocr", 30);
+        let resume_at = store
+            .pause(PauseTarget::Kind, "ocr", 30)
+            .expect("pause should persist");
         assert!(resume_at > Utc::now());
         // store dropped here.
     }
@@ -473,7 +483,9 @@ async fn resume_clears_pause() {
     let app = routes::router(state);
     let (k, v) = auth_header();
 
-    pause_store.pause(PauseTarget::Kind, "ocr", 5);
+    pause_store
+        .pause(PauseTarget::Kind, "ocr", 5)
+        .expect("pause ok");
     assert!(pause_store.paused_until(PauseTarget::Kind, "ocr").is_some());
 
     let req = Request::builder()

--- a/Desktop/Sources/APIClient.swift
+++ b/Desktop/Sources/APIClient.swift
@@ -4966,10 +4966,19 @@ extension APIClient {
 extension APIClient {
 
   /// Build headers for a Rust-daemon call without `buildHeaders`'s
-  /// `localOnlyMode` short-circuit. Auth is best-effort: if no token is
-  /// available we still send the request (Rust daemon may be configured
-  /// without bearer auth in dev).
-  fileprivate func activityHeaders() async -> [String: String] {
+  /// `localOnlyMode` short-circuit.
+  ///
+  /// Singleton-fixer S1: read the bearer token from the daemon's local
+  /// file (`~/Library/Application Support/InfiniteRecall/api-token.txt`)
+  /// instead of `AuthService.getAuthHeader()`, which throws `notSignedIn`
+  /// in this Firebase-stripped fork. The previous `try?` swallowed that
+  /// throw, so every Activity tab call shipped without an `Authorization`
+  /// header and the daemon returned 401 every time.
+  ///
+  /// Throws `LocalDaemonToken.TokenError` if the daemon hasn't written
+  /// its token yet. The Activity service catches this and surfaces it via
+  /// `ActivityMonitorService.lastError` instead of silently 401-looping.
+  fileprivate func activityHeaders() throws -> [String: String] {
     var headers: [String: String] = [
       "Content-Type": "application/json",
       "X-App-Platform": "macos",
@@ -4977,10 +4986,8 @@ extension APIClient {
     if let testHeader = testAuthHeader {
       headers["Authorization"] = testHeader
     } else {
-      let authService = await MainActor.run { AuthService.shared }
-      if let authHeader = try? await authService.getAuthHeader() {
-        headers["Authorization"] = authHeader
-      }
+      let token = try LocalDaemonToken.read()
+      headers["Authorization"] = "Bearer \(token)"
     }
     return headers
   }
@@ -5029,7 +5036,7 @@ extension APIClient {
     }
     var request = URLRequest(url: url)
     request.httpMethod = "GET"
-    request.allHTTPHeaderFields = await activityHeaders()
+    request.allHTTPHeaderFields = try activityHeaders()
     request.timeoutInterval = 5
 
     let (data, response) = try await session.data(for: request)
@@ -5059,7 +5066,7 @@ extension APIClient {
 
     var request = URLRequest(url: url)
     request.httpMethod = "POST"
-    request.allHTTPHeaderFields = await activityHeaders()
+    request.allHTTPHeaderFields = try activityHeaders()
     request.httpBody = try Self.makeActivityEncoder().encode(body)
     request.timeoutInterval = 5
 
@@ -5093,7 +5100,7 @@ extension APIClient {
 
     var request = URLRequest(url: url)
     request.httpMethod = "POST"
-    request.allHTTPHeaderFields = await activityHeaders()
+    request.allHTTPHeaderFields = try activityHeaders()
     request.httpBody = try Self.makeActivityEncoder().encode(body)
     request.timeoutInterval = 5
 
@@ -5119,7 +5126,7 @@ extension APIClient {
 
     var request = URLRequest(url: url)
     request.httpMethod = "POST"
-    request.allHTTPHeaderFields = await activityHeaders()
+    request.allHTTPHeaderFields = try activityHeaders()
     request.httpBody = try Self.makeActivityEncoder().encode(body)
     request.timeoutInterval = 5
 

--- a/Desktop/Sources/Activity/ActivityModels.swift
+++ b/Desktop/Sources/Activity/ActivityModels.swift
@@ -45,6 +45,10 @@ public enum GateReason: String, Codable, Hashable {
     case locked
     case manualPause = "manual_pause"
     case none
+    /// `AlwaysAllowedGate` placeholder is in use — real `ProcessingGate`
+    /// not yet wired (issue #32). Consensus-fix C4: surface honestly in
+    /// the UI instead of pretending idle processing is running.
+    case stub
 }
 
 // MARK: - Inner shapes

--- a/Desktop/Sources/Activity/ActivityMonitorService.swift
+++ b/Desktop/Sources/Activity/ActivityMonitorService.swift
@@ -105,19 +105,32 @@ public final class ActivityMonitorService: ObservableObject {
     }
 
     /// Resume a previously paused row.
+    /// Consensus-fix C3: only mutate local state after the backend write
+    /// succeeds. Previously we wrote optimistically and the next snapshot
+    /// poll silently reverted on backend failure.
     public func resume(target: PauseTarget, id: String) async {
         do {
             try await APIClient.shared.resumeActivity(target: target.rawValue, id: id)
             applyOptimisticPause(target: target, id: id, until: nil)
             postPauseChanged()
+            self.lastError = nil
             await fetchOnce()
         } catch {
-            lastError = "resume failed: \(error.localizedDescription)"
+            self.lastError = userFacingErrorMessage(action: "Resume", error: error)
         }
+    }
+
+    /// Clear the user-visible error banner. Bound to the dismiss button in
+    /// `ActivityPage.errorBanner`.
+    public func clearLastError() {
+        self.lastError = nil
     }
 
     // MARK: - Private
 
+    /// Consensus-fix C3: write to local state ONLY after the round-trip
+    /// returns success. On failure we set `lastError` and leave the
+    /// snapshot untouched so the UI never silently rolls back.
     private func pause(target: PauseTarget, id: String, minutes: Int) async {
         do {
             let until = try await APIClient.shared.pauseActivity(
@@ -127,10 +140,34 @@ public final class ActivityMonitorService: ObservableObject {
             )
             applyOptimisticPause(target: target, id: id, until: until)
             postPauseChanged()
+            self.lastError = nil
             await fetchOnce()
         } catch {
-            lastError = "pause failed: \(error.localizedDescription)"
+            self.lastError = userFacingErrorMessage(action: "Pause", error: error)
         }
+    }
+
+    /// Convert an `APIError` (or any `Error`) into a one-line user-readable
+    /// banner string. Surfaces the route's `pause_store_failure` detail
+    /// when present so users see "Couldn't pause: pause store storage error
+    /// — disk full" rather than just "HTTP 500".
+    private func userFacingErrorMessage(action: String, error: Error) -> String {
+        let detail: String
+        if let apiErr = error as? APIError {
+            switch apiErr {
+            case .unauthorized:
+                detail = "the local API rejected the request"
+            case .httpError(let code):
+                detail = "the local API returned HTTP \(code)"
+            case .invalidResponse:
+                detail = "the local API returned an invalid response"
+            default:
+                detail = error.localizedDescription
+            }
+        } else {
+            detail = error.localizedDescription
+        }
+        return "\(action) failed: \(detail)"
     }
 
     private func handleBecameKey() {

--- a/Desktop/Sources/Activity/ActivityPage.swift
+++ b/Desktop/Sources/Activity/ActivityPage.swift
@@ -35,6 +35,9 @@ struct ActivityPage: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
                 gateBanner
+                if let err = service.lastError {
+                    errorBanner(err)
+                }
                 resourceCards
                 inFlightSection
                 liveCaptureSection
@@ -50,11 +53,58 @@ struct ActivityPage: View {
         .background(OmiColors.backgroundPrimary)
         .navigationTitle("Activity")
         .onReceive(tickTimer) { now in tick = now }
+        // === activity:C1 ===
+        // Polling lifecycle: start when the tab is visible, stop on
+        // disappear so we don't hammer the daemon while hidden (per UX
+        // scenario 9 in the plan). CapturePauseGate is owned by OmiApp.
+        .task {
+            service.start()
+        }
+        .onDisappear {
+            service.stop()
+        }
+        // === /activity:C1 ===
         .sheet(item: $captureToConfirm) { kind in
             captureConfirmSheet(kind: kind)
         }
         .accessibilityIdentifier("activity_page")
     }
+
+    // === activity:C3 ===
+    /// Small dismissible banner under the header for the most recent
+    /// pause/resume/snapshot failure surfaced by `ActivityMonitorService`.
+    private func errorBanner(_ message: String) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .scaledFont(size: 14)
+                .foregroundColor(OmiColors.error)
+            Text(message)
+                .scaledFont(size: 12)
+                .foregroundColor(OmiColors.textPrimary)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer()
+            Button {
+                service.clearLastError()
+            } label: {
+                Image(systemName: "xmark")
+                    .scaledFont(size: 11)
+                    .foregroundColor(OmiColors.textTertiary)
+            }
+            .buttonStyle(.borderless)
+            .accessibilityLabel("Dismiss error")
+        }
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(OmiColors.error.opacity(0.1))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10)
+                        .stroke(OmiColors.error.opacity(0.35), lineWidth: 1)
+                )
+        )
+        .accessibilityIdentifier("activity_error_banner")
+    }
+    // === /activity:C3 ===
 
     // MARK: Snapshot accessors
 
@@ -118,6 +168,14 @@ struct ActivityPage: View {
             )
         }
         switch gate.reason {
+        case .stub:
+            // Consensus-fix C4: honest copy when AlwaysAllowedGate is wired.
+            return BannerInfo(
+                icon: "wrench.adjustable",
+                title: "Gate not yet wired (#32)",
+                detail: "Activity scheduling will start once the real ProcessingGate ships.",
+                color: OmiColors.textTertiary
+            )
         case .idle, .none:
             if gate.allowed {
                 return BannerInfo(
@@ -556,6 +614,8 @@ struct ActivityPage: View {
                 return ("Up to date — 0 queued", "Manually paused.")
             case .idle, .none:
                 return ("Up to date — 0 queued", "Idle processing standing by.")
+            case .stub:
+                return ("Up to date — 0 queued", "Gate not yet wired (#32).")
             }
         }()
         return VStack(spacing: 6) {

--- a/Desktop/Sources/Activity/ActivityReportLogger.swift
+++ b/Desktop/Sources/Activity/ActivityReportLogger.swift
@@ -1,0 +1,60 @@
+// Singleton-fixer S6: rate-limited error logger for the Swift→Rust
+// in-flight reporting path.
+//
+// `BatteryAwareScheduler` posts to `/v1/activity/_internal/inflight`
+// every time a unit of work starts and finishes. The previous code wrapped
+// every call in `Task { try? await ... }` — every HTTP failure was
+// silently swallowed. Combined with the S1 401 bug, the user saw no
+// in-flight rows AND no log breadcrumb explaining why.
+//
+// This logger:
+//   - logs the FIRST failure of a (context, error message) pair immediately,
+//   - then suppresses identical errors for 60s,
+//   - on the next allowed log, appends "(N suppressed in last 60s)".
+//
+// We keep the data structure small — at most a handful of distinct
+// (context, error message) pairs ever appear in practice — so we don't
+// bother with eviction.
+
+import Foundation
+
+@MainActor
+final class ActivityReportLogger {
+  static let shared = ActivityReportLogger()
+
+  /// Window during which identical errors are suppressed after the first
+  /// log. Tuned to "user can read a notification before another one fires"
+  /// without being so long that an hour-long outage logs only once.
+  private static let suppressionWindow: TimeInterval = 60
+
+  private var lastLogged: [String: Date] = [:]
+  private var suppressed: [String: Int] = [:]
+
+  private init() {}
+
+  /// Log an error from an Activity-tab background reporter. Identical
+  /// (context, error description) pairs within the suppression window are
+  /// counted but not emitted, then summarised on the next allowed log.
+  func log(error: Error, context: String) {
+    let key = "\(context)|\(error.localizedDescription)"
+    let now = Date()
+
+    if let last = lastLogged[key],
+      now.timeIntervalSince(last) < Self.suppressionWindow
+    {
+      suppressed[key, default: 0] += 1
+      return
+    }
+
+    let count = suppressed.removeValue(forKey: key) ?? 0
+    let suffix = count > 0 ? " (\(count) suppressed in last 60s)" : ""
+    logError("\(context): \(error.localizedDescription)\(suffix)", error: error)
+    lastLogged[key] = now
+  }
+
+  /// Test/diagnostic hook: forget all suppression state.
+  func resetForTesting() {
+    lastLogged.removeAll()
+    suppressed.removeAll()
+  }
+}

--- a/Desktop/Sources/Activity/CapturePauseGate.swift
+++ b/Desktop/Sources/Activity/CapturePauseGate.swift
@@ -2,34 +2,43 @@
 // capture services and per-kind work.
 //
 // Two refresh triggers:
-//  1. Periodic poll every 5s of the Rust pause store via APIClient (best
-//     effort — falls back to last-known map if the snapshot fetch is not
-//     available yet, e.g. before Stream F lands `getActivitySnapshot`).
+//  1. Periodic poll every 5s of the Rust pause store via APIClient.
 //  2. Local NotificationCenter observer on
 //     `ActivityNotifications.pauseChanged`, posted by Stream F's UI when
 //     the user toggles a pause so live capture services react instantly
 //     instead of waiting for the next 5s tick.
 //
 // Consumers (AudioCaptureService, ScreenCaptureService, the future
-// scheduler in Stream G, Stream F's UI) call `isPaused(target:id:)` to
-// gate work. Keys are stored as `"<target>/<id>"` so a single dictionary
-// covers both `"capture"` and `"kind"` namespaces.
+// scheduler in Stream G, Stream F's UI) call `isPaused(target:id:)` (or
+// `isPausedSync` from non-isolated contexts) to gate work. Keys are stored
+// as `"<target>/<id>"` so a single dictionary covers both `"capture"` and
+// `"kind"` namespaces.
 
 import Foundation
 import Combine
+import os
 
-@MainActor
 final class CapturePauseGate: ObservableObject {
     static let shared = CapturePauseGate()
 
     /// Map of `"<target>/<id>"` → absolute resume timestamp. An entry is
     /// only present while the pause is in the future; expired entries are
     /// pruned on read so consumers always see a truthful state.
-    @Published private(set) var pauses: [String: Date] = [:]
+    ///
+    /// MainActor-isolated for SwiftUI publishing. Synchronous, non-isolated
+    /// callers (e.g. `ScreenCaptureService.captureActiveWindow()`) must use
+    /// `isPausedSync` / `pausedUntilSync`, which read the lock-protected
+    /// `mirror` without hopping to the main thread (consensus-fix C6).
+    @MainActor @Published private(set) var pauses: [String: Date] = [:]
 
-    private var pollTimer: Timer?
-    private var observer: NSObjectProtocol?
-    private var isStarted = false
+    /// Lock-protected mirror of `pauses` for read-side use from non-isolated
+    /// contexts. Every write to `pauses` MUST also write through to `mirror`
+    /// so the two stay in sync. See `isPausedSync` for the intended consumer.
+    private let mirror = OSAllocatedUnfairLock<[String: Date]>(initialState: [:])
+
+    @MainActor private var pollTimer: Timer?
+    @MainActor private var observer: NSObjectProtocol?
+    @MainActor private var isStarted = false
 
     private init() {}
 
@@ -37,6 +46,7 @@ final class CapturePauseGate: ObservableObject {
 
     /// Begin polling the Rust pause store and observing pause-change
     /// notifications. Idempotent.
+    @MainActor
     func start() {
         guard !isStarted else { return }
         isStarted = true
@@ -74,6 +84,7 @@ final class CapturePauseGate: ObservableObject {
 
     /// Stop polling and detach the notification observer. Safe to call
     /// from any state.
+    @MainActor
     func stop() {
         pollTimer?.invalidate()
         pollTimer = nil
@@ -84,16 +95,18 @@ final class CapturePauseGate: ObservableObject {
         isStarted = false
     }
 
-    // MARK: - Reads
+    // MARK: - Reads (MainActor — for SwiftUI)
 
     /// Returns true iff the given (target, id) pair is paused at this
     /// instant. Expired entries are pruned as a side effect.
+    @MainActor
     func isPaused(target: String, id: String) -> Bool {
         return pausedUntil(target: target, id: id) != nil
     }
 
     /// Returns the absolute resume timestamp for the (target, id) pair if
     /// it is currently paused, else nil. Prunes expired entries.
+    @MainActor
     func pausedUntil(target: String, id: String) -> Date? {
         let key = Self.cacheKey(target: target, id: id)
         guard let until = pauses[key] else { return nil }
@@ -103,7 +116,30 @@ final class CapturePauseGate: ObservableObject {
         // Expired — drop it so future reads don't keep returning a stale
         // truthy value.
         pauses.removeValue(forKey: key)
+        mirror.withLock { $0.removeValue(forKey: key) }
         return nil
+    }
+
+    // MARK: - Reads (nonisolated — for sync capture entry points)
+
+    /// Nonisolated read for callers that cannot hop to the MainActor (e.g.
+    /// `ScreenCaptureService.captureActiveWindow()`, NotificationCenter
+    /// observer closures). Reads the lock-protected `mirror`. Expired
+    /// entries are pruned in-place so future reads stay truthful.
+    nonisolated func isPausedSync(target: String, id: String) -> Bool {
+        return pausedUntilSync(target: target, id: id) != nil
+    }
+
+    /// Nonisolated counterpart to `pausedUntil`. See `isPausedSync`.
+    nonisolated func pausedUntilSync(target: String, id: String) -> Date? {
+        let key = Self.cacheKey(target: target, id: id)
+        let now = Date()
+        return mirror.withLock { dict -> Date? in
+            guard let until = dict[key] else { return nil }
+            if until > now { return until }
+            dict.removeValue(forKey: key)
+            return nil
+        }
     }
 
     // MARK: - Writes (used by UI for optimistic local updates)
@@ -112,9 +148,11 @@ final class CapturePauseGate: ObservableObject {
     /// the instant the user taps "Pause" so consumers see the gate flip
     /// before the backend round-trip completes. The next backend refresh
     /// will overwrite this with the authoritative value.
+    @MainActor
     func recordLocalPause(target: String, id: String, until: Date) {
         let key = Self.cacheKey(target: target, id: id)
         pauses[key] = until
+        mirror.withLock { $0[key] = until }
         NotificationCenter.default.post(
             name: ActivityNotifications.pauseChanged,
             object: nil,
@@ -123,9 +161,11 @@ final class CapturePauseGate: ObservableObject {
     }
 
     /// Optimistically clear a pause locally (mirror of recordLocalPause).
+    @MainActor
     func clearLocalPause(target: String, id: String) {
         let key = Self.cacheKey(target: target, id: id)
         pauses.removeValue(forKey: key)
+        mirror.withLock { $0.removeValue(forKey: key) }
         NotificationCenter.default.post(
             name: ActivityNotifications.pauseChanged,
             object: nil,
@@ -139,6 +179,7 @@ final class CapturePauseGate: ObservableObject {
         return "\(target)/\(id)"
     }
 
+    @MainActor
     private func handlePauseNotification(_ note: Notification) {
         // Apply any inline hint from the notification payload first so the
         // gate flips synchronously from the publisher's perspective …
@@ -147,9 +188,11 @@ final class CapturePauseGate: ObservableObject {
             let key = Self.cacheKey(target: target, id: id)
             if let until = note.userInfo?["until"] as? Date {
                 pauses[key] = until
+                mirror.withLock { $0[key] = until }
             } else {
                 // No `until` → treat as resume.
                 pauses.removeValue(forKey: key)
+                mirror.withLock { $0.removeValue(forKey: key) }
             }
         }
         // …then refresh from the backend so we re-converge on the
@@ -160,11 +203,16 @@ final class CapturePauseGate: ObservableObject {
     }
 
     /// Pull the latest `ActivitySnapshot` and refresh the local map.
-    /// Resilient to the API method being absent (Stream F still in
-    /// flight) — uses dynamic dispatch via `APIClient.shared` and
-    /// silently no-ops if the call throws or the symbol is unavailable.
+    /// Stream F has shipped `getActivitySnapshot()` so we always call it.
+    /// Errors are logged so the failure is observable; we fall back to the
+    /// last-known map (consensus-fix C2 — no more silent #else return nil).
+    @MainActor
     private func refreshFromBackend() async {
-        guard let snapshot = await Self.fetchSnapshotIfAvailable() else {
+        let snapshot: ActivitySnapshot
+        do {
+            snapshot = try await Self.fetchSnapshot()
+        } catch {
+            logError("CapturePauseGate snapshot fetch failed", error: error)
             return
         }
         var next: [String: Date] = [:]
@@ -183,25 +231,15 @@ final class CapturePauseGate: ObservableObject {
 
         if next != pauses {
             pauses = next
+            // Write-through so non-isolated readers see the authoritative
+            // state without waiting for individual notification fanouts.
+            mirror.withLock { $0 = next }
         }
     }
 
-    /// Bridge to APIClient that tolerates the absence of
-    /// `getActivitySnapshot()` (Stream F may not have landed yet on this
-    /// branch). Returns nil on any failure.
-    private static func fetchSnapshotIfAvailable() async -> ActivitySnapshot? {
-        // Stream F is expected to add `func getActivitySnapshot() async
-        // throws -> ActivitySnapshot` to APIClient. Until then this gate
-        // just runs notification-only; the optimistic local write path
-        // (recordLocalPause / clearLocalPause) keeps the UX correct.
-        #if ACTIVITY_API_AVAILABLE
-        do {
-            return try await APIClient.shared.getActivitySnapshot()
-        } catch {
-            return nil
-        }
-        #else
-        return nil
-        #endif
+    /// Throwing fetch — Stream F shipped `getActivitySnapshot()` so the call
+    /// always exists; no compile-time feature flag is needed.
+    private static func fetchSnapshot() async throws -> ActivitySnapshot {
+        return try await APIClient.shared.getActivitySnapshot()
     }
 }

--- a/Desktop/Sources/Activity/LocalDaemonToken.swift
+++ b/Desktop/Sources/Activity/LocalDaemonToken.swift
@@ -1,0 +1,108 @@
+// Singleton-fixer S1: read the local Rust daemon's bearer token from disk.
+//
+// The Rust daemon at `Backend-Rust/api/src/token.rs::token_path()` writes
+// the token to:
+//   ~/Library/Application Support/InfiniteRecall/api-token.txt
+// (mode 0600; honours `INFINITE_RECALL_TOKEN_PATH` if set).
+//
+// The previous `activityHeaders()` implementation called
+// `AuthService.shared.getAuthHeader()`, which throws `notSignedIn` in this
+// fork (Firebase removed). The throw was swallowed by `try?`, so requests
+// went out with NO `Authorization` header and the daemon's `authed`
+// middleware (`Backend-Rust/api/src/auth.rs`) returned 401 for every
+// Activity tab call. Tests use a hardcoded `TEST_TOKEN` so CI never saw
+// the bug. This helper reads the same on-disk file the daemon generates
+// and caches it in memory (token is regenerated only on file delete + the
+// daemon restart, so caching across an app session is safe).
+
+import Foundation
+
+/// Reads the local Rust daemon's bearer token from disk.
+///
+/// Thread-safe via `os_unfair_lock`-equivalent NSLock. The cache is keyed
+/// on the resolved file path so an env-var override (e.g. tests setting
+/// `INFINITE_RECALL_TOKEN_PATH`) bypasses a stale cached value from the
+/// default path.
+enum LocalDaemonToken {
+
+  /// Errors surfaced when the daemon token can't be read.
+  enum TokenError: LocalizedError {
+    case fileMissing(URL)
+    case unreadable(URL, underlying: Error)
+    case empty(URL)
+
+    var errorDescription: String? {
+      switch self {
+      case .fileMissing(let url):
+        return
+          "daemon token unavailable — is the backend running? (no file at \(url.path))"
+      case .unreadable(let url, let err):
+        return "daemon token at \(url.path) unreadable: \(err.localizedDescription)"
+      case .empty(let url):
+        return "daemon token at \(url.path) is empty"
+      }
+    }
+  }
+
+  // Single in-memory cache. We deliberately do NOT invalidate on a timer:
+  // the daemon writes the token once on first launch and never rotates it
+  // within an app session. If the file is deleted out from under us, the
+  // next 401 from the daemon will surface in `ActivityMonitorService.lastError`
+  // and the user can fix it.
+  private static let lock = NSLock()
+  private static var cachedToken: String?
+  private static var cachedFromPath: String?
+
+  /// Resolve the token file URL. Mirrors `token::token_path()` on the Rust side.
+  static var tokenFileURL: URL {
+    if let override = ProcessInfo.processInfo.environment["INFINITE_RECALL_TOKEN_PATH"],
+      !override.isEmpty
+    {
+      return URL(fileURLWithPath: override)
+    }
+    let home = FileManager.default.homeDirectoryForCurrentUser
+    return home.appendingPathComponent(
+      "Library/Application Support/InfiniteRecall/api-token.txt")
+  }
+
+  /// Read the daemon token from disk (cached in memory after first read).
+  /// Throws a typed `TokenError` so callers can render a useful message
+  /// rather than silently 401-looping.
+  static func read() throws -> String {
+    let url = tokenFileURL
+    let path = url.path
+
+    lock.lock()
+    defer { lock.unlock() }
+
+    if let cached = cachedToken, cachedFromPath == path, !cached.isEmpty {
+      return cached
+    }
+
+    guard FileManager.default.fileExists(atPath: path) else {
+      throw TokenError.fileMissing(url)
+    }
+    let data: Data
+    do {
+      data = try Data(contentsOf: url)
+    } catch {
+      throw TokenError.unreadable(url, underlying: error)
+    }
+    let raw = String(data: data, encoding: .utf8) ?? ""
+    let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmed.isEmpty {
+      throw TokenError.empty(url)
+    }
+    cachedToken = trimmed
+    cachedFromPath = path
+    return trimmed
+  }
+
+  /// Test/diagnostic hook: clear the in-memory cache.
+  static func resetCache() {
+    lock.lock()
+    defer { lock.unlock() }
+    cachedToken = nil
+    cachedFromPath = nil
+  }
+}

--- a/Desktop/Sources/AudioCaptureService.swift
+++ b/Desktop/Sources/AudioCaptureService.swift
@@ -303,8 +303,10 @@ class AudioCaptureService: @unchecked Sendable {
             queue: .main
         ) { [weak self] _ in
             guard let self else { return }
-            // Re-check the gate; only stop if we're now paused.
-            let paused = CapturePauseGate.shared.isPaused(target: "capture", id: "audio")
+            // Re-check the gate via the nonisolated sync API (consensus-fix
+            // C6) — the observer block is not actor-isolated, so calling
+            // the @MainActor `isPaused` would race / require a hop.
+            let paused = CapturePauseGate.shared.isPausedSync(target: "capture", id: "audio")
             if paused {
                 log("AudioCapture: pause notification received while capturing — stopping mic")
                 self.stopCapture()

--- a/Desktop/Sources/OmiApp.swift
+++ b/Desktop/Sources/OmiApp.swift
@@ -383,6 +383,16 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     // on battery and drains on AC.
     PowerWorkBridge.shared.start()
 
+    // === activity:C1 ===
+    // CapturePauseGate must run for the lifetime of the app: capture
+    // services consult it on every start/mid-flight, regardless of whether
+    // the Activity tab is visible. ActivityMonitorService is started on a
+    // per-tab basis from ActivityPage so polling pauses when hidden.
+    Task { @MainActor in
+      CapturePauseGate.shared.start()
+    }
+    // === /activity:C1 ===
+
     // Recover any pending/failed transcription sessions from previous runs
     Task {
       await TranscriptionRetryService.shared.recoverPendingTranscriptions()
@@ -1278,6 +1288,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
     // Stop recurring task scheduler
     RecurringTaskScheduler.shared.stop()
+
+    // === activity:C1 ===
+    // Tear down the always-on capture pause gate alongside the rest of
+    // the app-level singletons.
+    Task { @MainActor in
+      CapturePauseGate.shared.stop()
+      ActivityMonitorService.shared.stop()
+    }
+    // === /activity:C1 ===
 
     // Mark clean shutdown so next launch skips expensive DB integrity check
     RewindDatabase.markCleanShutdown()

--- a/Desktop/Sources/Power/BatteryAwareScheduler.swift
+++ b/Desktop/Sources/Power/BatteryAwareScheduler.swift
@@ -311,11 +311,20 @@ public final class BatteryAwareScheduler: ObservableObject {
       let inflightLabel = WorkLabels.humanLabel(work)
       let inflightEntry = InFlight(label: inflightLabel, startedAt: Date())
       self.inFlight[work.kind] = inflightEntry
+      // Singleton-fixer S6: replace `try?` with logged catch + 60s
+      // rate-limit. The previous swallowing made S1's silent 401 loop
+      // invisible; surface failures via ActivityReportLogger so the next
+      // breakage is observable in `/private/tmp/omi-dev.log`.
       Task {
-        try? await APIClient.shared.reportInFlight(
-          kind: work.kind.rawValue,
-          inFlight: inflightEntry
-        )
+        do {
+          try await APIClient.shared.reportInFlight(
+            kind: work.kind.rawValue,
+            inFlight: inflightEntry
+          )
+        } catch {
+          await ActivityReportLogger.shared.log(
+            error: error, context: "reportInFlight(start:\(work.kind.rawValue))")
+        }
       }
       // === /activity:G ===
 
@@ -325,10 +334,15 @@ public final class BatteryAwareScheduler: ObservableObject {
         // === activity:G ===
         self.inFlight[work.kind] = nil
         Task {
-          try? await APIClient.shared.reportInFlight(
-            kind: work.kind.rawValue,
-            inFlight: nil
-          )
+          do {
+            try await APIClient.shared.reportInFlight(
+              kind: work.kind.rawValue,
+              inFlight: nil
+            )
+          } catch {
+            await ActivityReportLogger.shared.log(
+              error: error, context: "reportInFlight(done:\(work.kind.rawValue))")
+          }
         }
         // === /activity:G ===
       } catch {
@@ -336,10 +350,15 @@ public final class BatteryAwareScheduler: ObservableObject {
         // === activity:G ===
         self.inFlight[work.kind] = nil
         Task {
-          try? await APIClient.shared.reportInFlight(
-            kind: work.kind.rawValue,
-            inFlight: nil
-          )
+          do {
+            try await APIClient.shared.reportInFlight(
+              kind: work.kind.rawValue,
+              inFlight: nil
+            )
+          } catch {
+            await ActivityReportLogger.shared.log(
+              error: error, context: "reportInFlight(fail:\(work.kind.rawValue))")
+          }
         }
         // === /activity:G ===
         // Stop draining; next state transition or explicit drain() can retry.

--- a/Desktop/Sources/ScreenCaptureService.swift
+++ b/Desktop/Sources/ScreenCaptureService.swift
@@ -901,18 +901,15 @@ final class ScreenCaptureService: Sendable {
 
   /// Capture the active window and return as JPEG data (synchronous - legacy)
   func captureActiveWindow() -> Data? {
-    // === activity:H ===
-    // Synchronous entry point: cannot await the MainActor-bound gate.
-    // Use a non-blocking best-effort read via DispatchQueue.main.sync,
-    // skipping the gate if we're already on the main thread (to avoid
-    // deadlock) — the async paths above provide the primary enforcement.
-    if !Thread.isMainThread {
-      let paused = DispatchQueue.main.sync { CapturePauseGate.shared.isPaused(target: "capture", id: "screen") }
-      if paused {
-        let until = DispatchQueue.main.sync { CapturePauseGate.shared.pausedUntil(target: "capture", id: "screen") }
-        log("ScreenCapture: paused until \(String(describing: until)) — skipping start")
-        return nil
-      }
+    // === activity:H === (consensus-fix C6)
+    // Use the nonisolated, lock-protected mirror so we can read the gate
+    // from any thread — including the main thread. The previous
+    // `!Thread.isMainThread` guard silently skipped the gate when called
+    // from MainActor, which let user-paused screen captures continue.
+    if CapturePauseGate.shared.isPausedSync(target: "capture", id: "screen") {
+      let until = CapturePauseGate.shared.pausedUntilSync(target: "capture", id: "screen")
+      log("ScreenCapture: paused until \(String(describing: until)) — skipping start")
+      return nil
     }
     // === /activity:H ===
     guard let windowID = Self.getActiveWindowID() else {


### PR DESCRIPTION
**Stacks on #36 — merge that first.** When #36 lands on `main`, this PR rebases automatically.

Addresses the 4 singleton review issues from umbrella #9 that all 3 independent reviewers (V1/V2/V3) confirmed unanimously, on top of the 6 consensus fixes already in #36.

## S1 — Auth token mismatch (CRIT, 3/3)

**Files:** `Desktop/Sources/APIClient.swift`, `Desktop/Sources/Activity/LocalDaemonToken.swift` (new)

`activityHeaders()` was calling `AuthService.shared.getAuthHeader()`, which throws `AuthError.notSignedIn` in this Firebase-stripped fork. The throw was swallowed by `try?` so every Activity tab call shipped without an `Authorization` header. The Rust daemon's `authed` middleware (`Backend-Rust/api/src/auth.rs:23-43`) returned 401 every snapshot. Tests use a hardcoded `TEST_TOKEN` so CI never noticed; the running app would 401-loop forever.

Fix: new `LocalDaemonToken.read()` helper that reads the same on-disk file the daemon writes — `~/Library/Application Support/InfiniteRecall/api-token.txt` (resolved via `Backend-Rust/api/src/token.rs::token_path()`, honours `INFINITE_RECALL_TOKEN_PATH` for tests). Cached in memory after first read since the daemon never rotates the token within a session. `activityHeaders()` now `try`s the helper and propagates a typed error; missing-token failures surface in `ActivityMonitorService.lastError` as "daemon token unavailable — is the backend running?" instead of looping silently on 401.

**Manual verification (curl):**
```
TOKEN=$(cat ~/Library/Application\ Support/InfiniteRecall/api-token.txt)
curl -H "Authorization: Bearer $TOKEN" http://127.0.0.1:7331/v1/activity/snapshot
# → HTTP 200, valid ActivitySnapshot JSON
curl http://127.0.0.1:7331/v1/activity/snapshot
# → HTTP 401
```
Token path used by the daemon: `/Users/<you>/Library/Application Support/InfiniteRecall/api-token.txt` (mode 0600).

## S4 — `spawn_blocking` for SystemResourceSampler (HIGH, 3/3)

**Files:** `Backend-Rust/api/src/routes/activity.rs`, `Backend-Rust/api/src/activity/resources.rs`

`SystemResourceSampler::sample()` does `thread::sleep(250ms)` plus 5–8 sync subprocess forks (`ioreg`, `sysctl`, `pmset` ×2, `launchctl` ×0–2) on the calling thread. Previously called inline in the `snapshot` handler, blocking a tokio worker for ~300ms per cache miss.

Fix: `tokio::task::spawn_blocking(move || sampler.sample())`. The `Arc<dyn ResourceSampler>` already had `Send + Sync` via supertrait so no trait change required. Snapshot handler now returns `Result<Json<…>, (StatusCode, String)>` to surface a join error if the blocking pool collapses.

Bonus: bumped `CACHE_TTL` 1s → 2s. With Swift polling at 1Hz, this halves the cache-miss rate (every other tick instead of every tick) without user-visible staleness — CPU/RSS/GPU rows are coarse readouts.

## S6 — Logged catch + rate-limit for in-flight reporting (MED, 3/3)

**Files:** `Desktop/Sources/Power/BatteryAwareScheduler.swift`, `Desktop/Sources/Activity/ActivityReportLogger.swift` (new)

Three `Task { try? await APIClient.shared.reportInFlight(...) }` sites swallowed every HTTP failure. Combined with S1, the user saw no in-flight rows AND no log breadcrumb. Even after S1 lands, future daemon failures would still be silent.

Fix: new `@MainActor` `ActivityReportLogger.shared` with 60s debounce per `(context, error.localizedDescription)` key. Logs the first failure, suppresses identical follow-ups, then emits "(N suppressed in last 60s)" on the next allowed log. All three sites use distinct contexts (`reportInFlight(start:…)`, `(done:…)`, `(fail:…)`) so a kind-specific issue doesn't get coalesced into a generic counter.

## S7 — Structured `discover_pids` warnings + newer launchctl format (LOW, 3/3)

**Files:** `Backend-Rust/api/src/activity/resources.rs`

`read_pidfile`, `pid_from_launchctl_any`, and `parse_launchctl_pid` collapsed every failure to `None`. Three failure modes (file missing / launchctl miss / parse fail) became indistinguishable — when someone renames a launchd label, the breadcrumb is invisible.

Fix:
1. `read_pidfile` now matches each failure mode explicitly with `tracing::debug!` and a `reason` field (`missing` / `unreadable` / `unparseable` / `stale`). `debug` not `warn` because pidfile-missing is normal at first launch.
2. `pid_from_launchctl_any` emits a single `tracing::warn!` listing the candidate labels when ALL of them miss — actionable for the next person who renames a launchd label.
3. `parse_launchctl_pid` now tolerates the newer macOS `pid = N` (lowercase) format in addition to the legacy `"PID" = N;`. Includes a guard so e.g. `pidsignal = 9` doesn't false-match. New `parses_launchctl_pid_new_format` unit test covers both shapes + the negative case (per Broad reviewer MED-14).
4. `discover_pids` emits a `tracing::debug!` per successful discovery showing which path won (`pidfile` vs `launchctl`).

## Build / test status

- `cargo build -p infinite-recall-api` — clean (only the pre-existing `unused import: Arc` warning in `health.rs`).
- `cargo test -p infinite-recall-api --features activity_test_wiring` — **31 unit + 9 integration tests pass** (added `parses_launchctl_pid_new_format`).
- `xcrun swift build -c debug --package-path Desktop` — clean (only pre-existing warnings in unrelated `RewindIndexer.swift` `MainActor.run` calls).
- Manual curl verification for S1: confirmed 200 with bearer / 401 without.

## Deviations

None of substance. The S1 recipe suggested optionally reusing `MCPAPIService.readTokenFromDisk()`, but that method is `private` and `MCPAPIService` is an `ObservableObject` with its own polling lifecycle — the standalone `LocalDaemonToken` helper is dependency-free and reuses the exact same path-resolution logic, including the `INFINITE_RECALL_TOKEN_PATH` env var override that mirrors the Rust side.

Refs: umbrella #9.