### PR TITLE
refactor: rename OMI_ env vars and constants to IR_

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,20 +15,20 @@
 # VPS dev:    http://<your-dev-ip>:<port>
 # Cloud Run:  https://desktop-backend-dt5lrfkkoa-uc.a.run.app
 # Production: https://api.omi.me
-OMI_API_URL=http://localhost:10201
+IR_API_URL=http://localhost:10201
 
 # Python backend API URL — the main Omi backend (api.omi.me)
 # Serves subscriptions, payments, transcription, and other core endpoints
 # that the Rust desktop-backend does not have.
 # Local dev:    http://localhost:8080  (if running Python backend locally)
 # Production:   https://api.omi.me
-# WARNING: Do NOT set this to OMI_API_URL — that points to the Rust desktop-backend.
-OMI_PYTHON_API_URL=https://api.omi.me
+# WARNING: Do NOT set this to IR_API_URL — that points to the Rust desktop-backend.
+IR_PYTHON_API_URL=https://api.omi.me
 
 # Auth backend URL — where OAuth sign-in requests go
 # Local dev: run.sh starts Auth-Python on port 10200 automatically
 # Production: https://omi-desktop-auth-208440318997.us-central1.run.app/
-OMI_AUTH_URL=http://localhost:10200/
+IR_AUTH_URL=http://localhost:10200/
 
 # Firebase Web API key — fetched from backend via /v1/config/api-keys
 # Only set this for local dev without a backend running

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,12 +22,12 @@ xcrun swift build -c debug --package-path Desktop
 For full app build + install + launch:
 
 ```bash
-OMI_APP_NAME="Infinite Recall" \
-OMI_SKIP_BACKEND=1 OMI_SKIP_AUTH=1 OMI_SKIP_TUNNEL=1 OMI_SKIP_PYTHON=1 \
+IR_APP_NAME="Infinite Recall" \
+IR_SKIP_BACKEND=1 IR_SKIP_AUTH=1 IR_SKIP_TUNNEL=1 IR_SKIP_PYTHON=1 \
 ./run.sh --yolo
 ```
 
-The `OMI_APP_NAME` puts the build in `/Applications/Infinite Recall.app` so it
+The `IR_APP_NAME` puts the build in `/Applications/Infinite Recall.app` so it
 won't collide with any "Omi Dev" install on the same machine. Skip-flags
 disable everything cloud — we don't need any of it.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,12 +33,12 @@ xcrun swift build -c debug --package-path Desktop
 **Full build + sign + launch:**
 
 ```bash
-OMI_APP_NAME="Infinite Recall" \
-OMI_SKIP_BACKEND=1 OMI_SKIP_AUTH=1 OMI_SKIP_TUNNEL=1 OMI_SKIP_PYTHON=1 \
+IR_APP_NAME="Infinite Recall" \
+IR_SKIP_BACKEND=1 IR_SKIP_AUTH=1 IR_SKIP_TUNNEL=1 IR_SKIP_PYTHON=1 \
 ./run.sh --yolo
 ```
 
-The `OMI_SKIP_*` flags disable all inherited Omi cloud services. They must always
+The `IR_SKIP_*` flags disable all inherited Omi cloud services. They must always
 be set when building locally.
 
 **Backend-Rust (Cargo workspace — daemon + CLI):**

--- a/Desktop/Sources/APIClient.swift
+++ b/Desktop/Sources/APIClient.swift
@@ -3,9 +3,9 @@ import Foundation
 actor APIClient {
   static let shared = APIClient()
   // Primary data backend URL — Python backend (api.omi.me) is the single source of truth for all data CRUD.
-  // Override via OMI_PYTHON_API_URL for local dev.
+  // Override via IR_PYTHON_API_URL for local dev.
   var baseURL: String {
-    if let cString = getenv("OMI_PYTHON_API_URL"), let url = String(validatingUTF8: cString),
+    if let cString = getenv("IR_PYTHON_API_URL"), let url = String(validatingUTF8: cString),
       !url.isEmpty
     {
       return url.hasSuffix("/") ? url : url + "/"
@@ -16,20 +16,20 @@ actor APIClient {
   // Rust desktop backend URL — used only for: agent VM provisioning/status,
   // config/api-keys, Crisp, and local test subscription. All data CRUD,
   // chat AI, and title generation are on Python.
-  // Set via OMI_API_URL env var (in .env).
+  // Set via IR_API_URL env var (in .env).
   var rustBackendURL: String {
     // First check getenv() for values set by setenv() in loadEnvironment()
-    if let cString = getenv("OMI_API_URL"), let url = String(validatingUTF8: cString), !url.isEmpty
+    if let cString = getenv("IR_API_URL"), let url = String(validatingUTF8: cString), !url.isEmpty
     {
       let normalized = url.hasSuffix("/") ? url : url + "/"
       return normalized
     }
     // Fallback to ProcessInfo (launch-time snapshot)
-    if let envURL = ProcessInfo.processInfo.environment["OMI_API_URL"], !envURL.isEmpty {
+    if let envURL = ProcessInfo.processInfo.environment["IR_API_URL"], !envURL.isEmpty {
       let normalized = envURL.hasSuffix("/") ? envURL : envURL + "/"
       return normalized
     }
-    NSLog("OMI API: OMI_API_URL not set — Rust backend calls will fail")
+    NSLog("OMI API: IR_API_URL not set — Rust backend calls will fail")
     return ""
   }
 

--- a/Desktop/Sources/APIKeyService.swift
+++ b/Desktop/Sources/APIKeyService.swift
@@ -167,9 +167,9 @@ final class APIKeyService: ObservableObject {
     }
 
     /// True when the app has enough configuration to start transcription and screen analysis.
-    /// In proxy mode (OMI_API_URL set), no client-side Deepgram/Gemini keys are needed.
+    /// In proxy mode (IR_API_URL set), no client-side Deepgram/Gemini keys are needed.
     nonisolated static var keysAvailable: Bool {
-        getenv("GEMINI_API_KEY") != nil || getenv("OMI_API_URL") != nil
+        getenv("GEMINI_API_KEY") != nil || getenv("IR_API_URL") != nil
     }
 
     private nonisolated static func nonEmptyStatic(_ s: String?) -> String? {

--- a/Desktop/Sources/AuthService.swift
+++ b/Desktop/Sources/AuthService.swift
@@ -45,13 +45,13 @@ class AuthService {
     private var appleSignInDelegate: AppleSignInDelegate?
 
     // API Configuration
-    // Auth backend URL — must be set via OMI_AUTH_URL env var (in .env)
+    // Auth backend URL — must be set via IR_AUTH_URL env var (in .env)
     private let apiBaseURL: String = {
-        if let envURL = getenv("OMI_AUTH_URL") {
+        if let envURL = getenv("IR_AUTH_URL") {
             let url = String(cString: envURL)
             if !url.isEmpty { return url.hasSuffix("/") ? url : url + "/" }
         }
-        NSLog("OMI AUTH: OMI_AUTH_URL not set — OAuth sign-in will fail")
+        NSLog("OMI AUTH: IR_AUTH_URL not set — OAuth sign-in will fail")
         return ""
     }()
     private var redirectURI: String {

--- a/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/Desktop/Sources/DesktopAutomationBridge.swift
@@ -9,7 +9,7 @@ enum DesktopAutomationLaunchOptions {
 
   static var isEnabled: Bool {
     CommandLine.arguments.contains(enableFlag)
-      || ProcessInfo.processInfo.environment["OMI_ENABLE_LOCAL_AUTOMATION"] == "1"
+      || ProcessInfo.processInfo.environment["IR_ENABLE_LOCAL_AUTOMATION"] == "1"
   }
 
   static var port: UInt16 {
@@ -21,7 +21,7 @@ enum DesktopAutomationLaunchOptions {
       }
     }
 
-    if let rawValue = ProcessInfo.processInfo.environment["OMI_AUTOMATION_PORT"],
+    if let rawValue = ProcessInfo.processInfo.environment["IR_AUTOMATION_PORT"],
       let parsed = UInt16(rawValue)
     {
       return parsed

--- a/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
+++ b/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
@@ -147,7 +147,7 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
   private func resolvePlaybackMode() -> PlaybackMode {
     // TTS is now proxied through the backend — no client-side API key needed.
     // Fall back to system voice only if the backend URL is not configured.
-    guard getenv("OMI_API_URL") != nil else {
+    guard getenv("IR_API_URL") != nil else {
       return .systemFallback
     }
     let voiceID = ShortcutSettings.shared.selectedVoiceID
@@ -247,7 +247,7 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
 
     // Without the backend URL the service falls back to the system voice, which
     // wouldn't demo the ElevenLabs voice anyway.
-    guard getenv("OMI_API_URL") != nil else {
+    guard getenv("IR_API_URL") != nil else {
       enqueueSystemSpeech(phrase)
       return
     }

--- a/Desktop/Sources/ProactiveAssistants/Core/GeminiClient.swift
+++ b/Desktop/Sources/ProactiveAssistants/Core/GeminiClient.swift
@@ -162,9 +162,9 @@ struct GeminiResponse: Decodable {
 actor GeminiClient {
   private let model: String
 
-  /// Backend proxy base URL (from OMI_API_URL env var)
+  /// Backend proxy base URL (from IR_API_URL env var)
   private static var proxyBaseURL: String {
-    if let cString = getenv("OMI_API_URL"), let url = String(validatingUTF8: cString), !url.isEmpty {
+    if let cString = getenv("IR_API_URL"), let url = String(validatingUTF8: cString), !url.isEmpty {
       return url.hasSuffix("/") ? url : url + "/"
     }
     return ""
@@ -228,7 +228,7 @@ actor GeminiClient {
 
   init(apiKey: String? = nil, model: String = ModelQoS.Gemini.proactive) throws {
     // Infinite Recall fork: local-only mode — Gemini proxy disabled.
-    // All Gemini requests previously routed through the backend proxy at OMI_API_URL.
+    // All Gemini requests previously routed through the backend proxy at IR_API_URL.
     // Refuse to construct a client so no caller can issue a remote request.
     log("[backend-stripped] GeminiClient.init: no-op (refusing to build client)")
     throw GeminiClientError.missingAPIKey

--- a/Desktop/Sources/TranscriptionService.swift
+++ b/Desktop/Sources/TranscriptionService.swift
@@ -522,7 +522,7 @@ extension TranscriptionService {
 //    private var urlSession: URLSession?
 //    private let apiKey: String = ""
 //    private static let pythonBackendBaseURL: String = {
-//        if let cString = getenv("OMI_PYTHON_API_URL"),
+//        if let cString = getenv("IR_PYTHON_API_URL"),
 //           let url = String(validatingUTF8: cString), !url.isEmpty {
 //            return url.hasSuffix("/") ? url : url + "/"
 //        }

--- a/Desktop/Tests/APIClientRoutingTests.swift
+++ b/Desktop/Tests/APIClientRoutingTests.swift
@@ -83,55 +83,55 @@ final class APIClientRoutingTests: XCTestCase {
     // MARK: - URL property tests
 
     func testBaseURLDefaultsToPythonBackend() async {
-        unsetenv("OMI_PYTHON_API_URL")
+        unsetenv("IR_PYTHON_API_URL")
         let client = APIClient()
         let url = await client.baseURL
         XCTAssertEqual(url, "https://api.omi.me/")
     }
 
     func testBaseURLReadsFromPythonEnvVar() async {
-        setenv("OMI_PYTHON_API_URL", "http://localhost:8080", 1)
-        defer { unsetenv("OMI_PYTHON_API_URL") }
+        setenv("IR_PYTHON_API_URL", "http://localhost:8080", 1)
+        defer { unsetenv("IR_PYTHON_API_URL") }
         let client = APIClient()
         let url = await client.baseURL
         XCTAssertEqual(url, "http://localhost:8080/")
     }
 
     func testBaseURLAddsTrailingSlash() async {
-        setenv("OMI_PYTHON_API_URL", "http://localhost:8080", 1)
-        defer { unsetenv("OMI_PYTHON_API_URL") }
+        setenv("IR_PYTHON_API_URL", "http://localhost:8080", 1)
+        defer { unsetenv("IR_PYTHON_API_URL") }
         let client = APIClient()
         let url = await client.baseURL
         XCTAssertTrue(url.hasSuffix("/"))
     }
 
     func testBaseURLPreservesExistingTrailingSlash() async {
-        setenv("OMI_PYTHON_API_URL", "http://localhost:8080/", 1)
-        defer { unsetenv("OMI_PYTHON_API_URL") }
+        setenv("IR_PYTHON_API_URL", "http://localhost:8080/", 1)
+        defer { unsetenv("IR_PYTHON_API_URL") }
         let client = APIClient()
         let url = await client.baseURL
         XCTAssertEqual(url, "http://localhost:8080/")
     }
 
     func testRustBackendURLReadsFromApiUrlEnvVar() async {
-        setenv("OMI_API_URL", "http://localhost:8787", 1)
-        defer { unsetenv("OMI_API_URL") }
+        setenv("IR_API_URL", "http://localhost:8787", 1)
+        defer { unsetenv("IR_API_URL") }
         let client = APIClient()
         let url = await client.rustBackendURL
         XCTAssertEqual(url, "http://localhost:8787/")
     }
 
     func testRustBackendURLReturnsEmptyWhenNotSet() async {
-        unsetenv("OMI_API_URL")
+        unsetenv("IR_API_URL")
         let client = APIClient()
         let url = await client.rustBackendURL
         XCTAssertEqual(url, "")
     }
 
     func testBaseURLAndRustBackendURLAreIndependent() async {
-        setenv("OMI_PYTHON_API_URL", "http://python:8080", 1)
-        setenv("OMI_API_URL", "http://rust:8787", 1)
-        defer { unsetenv("OMI_PYTHON_API_URL"); unsetenv("OMI_API_URL") }
+        setenv("IR_PYTHON_API_URL", "http://python:8080", 1)
+        setenv("IR_API_URL", "http://rust:8787", 1)
+        defer { unsetenv("IR_PYTHON_API_URL"); unsetenv("IR_API_URL") }
 
         let client = APIClient()
         let base = await client.baseURL
@@ -155,13 +155,13 @@ final class APIClientRoutingTests: XCTestCase {
     override func setUp() {
         super.setUp()
         URLCapture.reset()
-        setenv("OMI_PYTHON_API_URL", "http://python-test:9001", 1)
-        setenv("OMI_API_URL", "http://rust-test:9002", 1)
+        setenv("IR_PYTHON_API_URL", "http://python-test:9001", 1)
+        setenv("IR_API_URL", "http://rust-test:9002", 1)
     }
 
     override func tearDown() {
-        unsetenv("OMI_PYTHON_API_URL")
-        unsetenv("OMI_API_URL")
+        unsetenv("IR_PYTHON_API_URL")
+        unsetenv("IR_API_URL")
         URLCapture.reset()
         super.tearDown()
     }

--- a/README.md
+++ b/README.md
@@ -65,13 +65,13 @@ are pending merge.
 ### Build and launch
 
 ```bash
-OMI_APP_NAME="Infinite Recall" \
-OMI_SKIP_BACKEND=1 OMI_SKIP_AUTH=1 OMI_SKIP_TUNNEL=1 OMI_SKIP_PYTHON=1 \
+IR_APP_NAME="Infinite Recall" \
+IR_SKIP_BACKEND=1 IR_SKIP_AUTH=1 IR_SKIP_TUNNEL=1 IR_SKIP_PYTHON=1 \
 ./run.sh --yolo
 ```
 
-`OMI_APP_NAME` controls the `.app` bundle name so it does not collide with any
-existing Omi install. The `OMI_SKIP_*` flags disable every inherited Omi cloud
+`IR_APP_NAME` controls the `.app` bundle name so it does not collide with any
+existing Omi install. The `IR_SKIP_*` flags disable every inherited Omi cloud
 service — none of them are used.
 
 > **Note on `--yolo`:** The `--yolo` shortcut was inherited from Omi and its

--- a/e2e/activity-tab.md
+++ b/e2e/activity-tab.md
@@ -29,8 +29,8 @@ TOKEN="$(cat "$HOME/Library/Application Support/InfiniteRecall/api-token.txt")"
 PORT=7331   # default; check INFINITE_RECALL_BIND if overridden
 
 # 4. Build + launch the Swift app
-OMI_APP_NAME="Infinite Recall" \
-  OMI_SKIP_BACKEND=1 OMI_SKIP_AUTH=1 OMI_SKIP_TUNNEL=1 OMI_SKIP_PYTHON=1 \
+IR_APP_NAME="Infinite Recall" \
+  IR_SKIP_BACKEND=1 IR_SKIP_AUTH=1 IR_SKIP_TUNNEL=1 IR_SKIP_PYTHON=1 \
   ./run.sh --yolo
 ```
 

--- a/pi-mono-extension/index.test.ts
+++ b/pi-mono-extension/index.test.ts
@@ -22,8 +22,8 @@ import {
   summarizeInput,
   appendAudit,
   __resetAuditWarnedForTest,
-  OMI_TOOLS,
-  OMI_TOOL_TIMEOUT_MS,
+  IR_TOOLS,
+  IR_TOOL_TIMEOUT_MS,
   __connectOmiPipeForTest,
   __callSwiftToolForTest,
   __omiPendingCallsForTest,
@@ -684,7 +684,7 @@ test("classifyBash: blocks repeated backslash-newline line continuations", () =>
 //
 // The PR body and the code at index.ts promise the audit appender "never
 // throws" and emits exactly one stderr warning per process on disk-full /
-// ENOTDIR / EACCES. Unit-pin that guarantee by pointing OMI_PI_AUDIT_LOG at
+// ENOTDIR / EACCES. Unit-pin that guarantee by pointing IR_PI_AUDIT_LOG at
 // a path whose parent is a file (mkdir recursive fails with ENOTDIR) and
 // asserting no throw + one-shot stderr warning.
 // ---------------------------------------------------------------------------
@@ -696,9 +696,9 @@ test("appendAudit: fail-safe when audit path is unwritable", async () => {
   const blockerFile = `/tmp/omi-audit-blocker-${process.pid}-${Date.now()}`;
   await writeFile(blockerFile, "x", "utf-8");
 
-  const originalPath = process.env.OMI_PI_AUDIT_LOG;
+  const originalPath = process.env.IR_PI_AUDIT_LOG;
   const originalWrite = process.stderr.write.bind(process.stderr);
-  process.env.OMI_PI_AUDIT_LOG = `${blockerFile}/audit.log`;
+  process.env.IR_PI_AUDIT_LOG = `${blockerFile}/audit.log`;
   __resetAuditWarnedForTest();
 
   const stderrCalls: string[] = [];
@@ -744,9 +744,9 @@ test("appendAudit: fail-safe when audit path is unwritable", async () => {
     (process.stderr as unknown as { write: typeof originalWrite }).write =
       originalWrite;
     if (originalPath === undefined) {
-      delete process.env.OMI_PI_AUDIT_LOG;
+      delete process.env.IR_PI_AUDIT_LOG;
     } else {
-      process.env.OMI_PI_AUDIT_LOG = originalPath;
+      process.env.IR_PI_AUDIT_LOG = originalPath;
     }
     __resetAuditWarnedForTest();
     try {
@@ -927,12 +927,12 @@ function createMockBridge(): { server: Server; sockPath: string } {
   return { server, sockPath };
 }
 
-test("OMI_TOOLS: exactly 14 tools defined via defineTool()", () => {
-  assert.equal(OMI_TOOLS.length, 14);
+test("IR_TOOLS: exactly 14 tools defined via defineTool()", () => {
+  assert.equal(IR_TOOLS.length, 14);
 });
 
-test("OMI_TOOLS: all tools have name, label, description, parameters, execute", () => {
-  for (const tool of OMI_TOOLS) {
+test("IR_TOOLS: all tools have name, label, description, parameters, execute", () => {
+  for (const tool of IR_TOOLS) {
     assert.ok(tool.name, `tool missing name`);
     assert.ok(tool.label, `${tool.name} missing label`);
     assert.ok(tool.description, `${tool.name} missing description`);
@@ -942,13 +942,13 @@ test("OMI_TOOLS: all tools have name, label, description, parameters, execute", 
   }
 });
 
-test("OMI_TOOLS: unique tool names", () => {
-  const names = OMI_TOOLS.map(t => t.name);
+test("IR_TOOLS: unique tool names", () => {
+  const names = IR_TOOLS.map(t => t.name);
   assert.equal(new Set(names).size, names.length, "duplicate tool names");
 });
 
-test("OMI_TOOLS: all have promptSnippet for system prompt injection", () => {
-  for (const tool of OMI_TOOLS) {
+test("IR_TOOLS: all have promptSnippet for system prompt injection", () => {
+  for (const tool of IR_TOOLS) {
     assert.ok(tool.promptSnippet, `${tool.name} missing promptSnippet`);
   }
 });
@@ -957,8 +957,8 @@ test("OMI_TOOLS: all have promptSnippet for system prompt injection", () => {
 // TypeBox schema shape validation per tool
 // ---------------------------------------------------------------------------
 
-test("OMI_TOOLS: TypeBox schemas have additionalProperties=false", () => {
-  for (const tool of OMI_TOOLS) {
+test("IR_TOOLS: TypeBox schemas have additionalProperties=false", () => {
+  for (const tool of IR_TOOLS) {
     assert.equal(
       (tool.parameters as any).additionalProperties,
       false,
@@ -967,7 +967,7 @@ test("OMI_TOOLS: TypeBox schemas have additionalProperties=false", () => {
   }
 });
 
-test("OMI_TOOLS: required fields match expected per tool", () => {
+test("IR_TOOLS: required fields match expected per tool", () => {
   const expected: Record<string, string[]> = {
     execute_sql: ["query"],
     semantic_search: ["query"],
@@ -984,7 +984,7 @@ test("OMI_TOOLS: required fields match expected per tool", () => {
     update_action_item: ["action_item_id"],
     capture_screen: [],
   };
-  for (const tool of OMI_TOOLS) {
+  for (const tool of IR_TOOLS) {
     const req = (tool.parameters as any).required ?? [];
     assert.deepEqual(
       req.sort(),
@@ -994,8 +994,8 @@ test("OMI_TOOLS: required fields match expected per tool", () => {
   }
 });
 
-test("OMI_TOOLS: all declared properties have TypeBox type metadata", () => {
-  for (const tool of OMI_TOOLS) {
+test("IR_TOOLS: all declared properties have TypeBox type metadata", () => {
+  for (const tool of IR_TOOLS) {
     const props = (tool.parameters as any).properties;
     assert.ok(props, `${tool.name} missing properties`);
     for (const [key, schema] of Object.entries(props)) {
@@ -1008,15 +1008,15 @@ test("OMI_TOOLS: all declared properties have TypeBox type metadata", () => {
   }
 });
 
-test("OMI_TOOLS: execute_sql has 'query' as Type.String", () => {
-  const tool = OMI_TOOLS.find(t => t.name === "execute_sql")!;
+test("IR_TOOLS: execute_sql has 'query' as Type.String", () => {
+  const tool = IR_TOOLS.find(t => t.name === "execute_sql")!;
   const queryProp = (tool.parameters as any).properties.query;
   assert.equal(queryProp.type, "string");
   assert.ok(queryProp.description);
 });
 
-test("OMI_TOOLS: semantic_search optional fields exist and are not required", () => {
-  const tool = OMI_TOOLS.find(t => t.name === "semantic_search")!;
+test("IR_TOOLS: semantic_search optional fields exist and are not required", () => {
+  const tool = IR_TOOLS.find(t => t.name === "semantic_search")!;
   const props = (tool.parameters as any).properties;
   const required = (tool.parameters as any).required ?? [];
   // Verify optional properties exist in the schema
@@ -1034,8 +1034,8 @@ test("OMI_TOOLS: semantic_search optional fields exist and are not required", ()
 // promptGuidelines tests
 // ---------------------------------------------------------------------------
 
-test("OMI_TOOLS: execute_sql has promptGuidelines", () => {
-  const tool = OMI_TOOLS.find(t => t.name === "execute_sql")!;
+test("IR_TOOLS: execute_sql has promptGuidelines", () => {
+  const tool = IR_TOOLS.find(t => t.name === "execute_sql")!;
   assert.ok(tool.promptGuidelines, "execute_sql missing promptGuidelines");
   assert.ok(tool.promptGuidelines!.length >= 1, "execute_sql should have at least 1 guideline");
   assert.ok(
@@ -1044,14 +1044,14 @@ test("OMI_TOOLS: execute_sql has promptGuidelines", () => {
   );
 });
 
-test("OMI_TOOLS: semantic_search has promptGuidelines", () => {
-  const tool = OMI_TOOLS.find(t => t.name === "semantic_search")!;
+test("IR_TOOLS: semantic_search has promptGuidelines", () => {
+  const tool = IR_TOOLS.find(t => t.name === "semantic_search")!;
   assert.ok(tool.promptGuidelines, "semantic_search missing promptGuidelines");
   assert.ok(tool.promptGuidelines!.length >= 1);
 });
 
-test("OMI_TOOL_TIMEOUT_MS: is 30 seconds", () => {
-  assert.equal(OMI_TOOL_TIMEOUT_MS, 30_000);
+test("IR_TOOL_TIMEOUT_MS: is 30 seconds", () => {
+  assert.equal(IR_TOOL_TIMEOUT_MS, 30_000);
 });
 
 test("callSwiftTool: returns error when not connected", async () => {

--- a/pi-mono-extension/index.ts
+++ b/pi-mono-extension/index.ts
@@ -296,10 +296,10 @@ export function classifyFileWrite(filePath: string): DenyDecision | null {
 }
 
 /** Classify a whole tool_call event by dispatching on toolName.
- *  When OMI_YOLO_MODE=1, all tool calls are allowed (no denylist).
+ *  When IR_YOLO_MODE=1, all tool calls are allowed (no denylist).
  *  Yolo mode is gated by the adapter — only forwarded from dev builds. */
 export function inspectToolCall(event: ToolCallEvent): DenyDecision | null {
-  if (process.env.OMI_YOLO_MODE === "1") {
+  if (process.env.IR_YOLO_MODE === "1") {
     process.stderr.write(`[omi-provider] YOLO bypass: ${event.toolName}\n`);
     return null;
   }
@@ -377,10 +377,10 @@ function truncate(s: string, max: number): string {
   return s.slice(0, max - 1) + "…";
 }
 
-/** Resolve the audit log path. Overridable via OMI_PI_AUDIT_LOG for tests. */
+/** Resolve the audit log path. Overridable via IR_PI_AUDIT_LOG for tests. */
 function auditLogPath(): string {
   return (
-    process.env.OMI_PI_AUDIT_LOG ||
+    process.env.IR_PI_AUDIT_LOG ||
     join(process.env.HOME || homedir(), ".omi", "pi-mono-audit.log")
   );
 }
@@ -415,7 +415,7 @@ export async function appendAudit(entry: AuditEntry): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
-// Omi tools — forwarded to Swift via Unix socket (OMI_BRIDGE_PIPE)
+// Omi tools — forwarded to Swift via Unix socket (IR_BRIDGE_PIPE)
 // ---------------------------------------------------------------------------
 
 let omiPipeConnection: Socket | null = null;
@@ -473,8 +473,8 @@ function callSwiftTool(name: string, input: Record<string, unknown>, signal?: Ab
   return new Promise<string>((resolve) => {
     const timer = setTimeout(() => {
       omiPendingCalls.delete(callId);
-      resolve(`Error: tool '${name}' timed out after ${OMI_TOOL_TIMEOUT_MS / 1000}s`);
-    }, OMI_TOOL_TIMEOUT_MS);
+      resolve(`Error: tool '${name}' timed out after ${IR_TOOL_TIMEOUT_MS / 1000}s`);
+    }, IR_TOOL_TIMEOUT_MS);
     const cleanup = () => {
       clearTimeout(timer);
       omiPendingCalls.delete(callId);
@@ -492,7 +492,7 @@ function callSwiftTool(name: string, input: Record<string, unknown>, signal?: Ab
   });
 }
 
-export const OMI_TOOL_TIMEOUT_MS = 30_000;
+export const IR_TOOL_TIMEOUT_MS = 30_000;
 
 // ---------------------------------------------------------------------------
 // Omi tool definitions — pi-mono defineTool() with TypeBox schemas
@@ -525,7 +525,7 @@ function omiTool<T extends Parameters<typeof Type.Object>[0]>(spec: {
   });
 }
 
-export const OMI_TOOLS = [
+export const IR_TOOLS = [
   omiTool({
     name: "execute_sql",
     label: "Execute SQL",
@@ -705,9 +705,9 @@ export const OMI_TOOLS = [
 ];
 
 async function registerOmiTools(pi: ExtensionAPI): Promise<void> {
-  const pipePath = process.env.OMI_BRIDGE_PIPE;
+  const pipePath = process.env.IR_BRIDGE_PIPE;
   if (!pipePath) {
-    process.stderr.write("[omi-tools] OMI_BRIDGE_PIPE not set — Omi tools unavailable\n");
+    process.stderr.write("[omi-tools] IR_BRIDGE_PIPE not set — Omi tools unavailable\n");
     return;
   }
   try {
@@ -716,10 +716,10 @@ async function registerOmiTools(pi: ExtensionAPI): Promise<void> {
     process.stderr.write(`[omi-tools] Failed to connect: ${err instanceof Error ? err.message : err}\n`);
     return;
   }
-  for (const tool of OMI_TOOLS) {
+  for (const tool of IR_TOOLS) {
     pi.registerTool(tool);
   }
-  process.stderr.write(`[omi-tools] Registered ${OMI_TOOLS.length} Omi tools\n`);
+  process.stderr.write(`[omi-tools] Registered ${IR_TOOLS.length} Omi tools\n`);
 }
 
 // ---------------------------------------------------------------------------
@@ -727,8 +727,8 @@ async function registerOmiTools(pi: ExtensionAPI): Promise<void> {
 // ---------------------------------------------------------------------------
 
 export default function omiProvider(pi: ExtensionAPI): void {
-  const baseUrl = process.env.OMI_API_BASE_URL || "https://api.omi.me/v2";
-  const apiKey = process.env.OMI_API_KEY || "";
+  const baseUrl = process.env.IR_API_BASE_URL || "https://api.omi.me/v2";
+  const apiKey = process.env.IR_API_KEY || "";
 
   pi.registerProvider("omi", {
     api: "openai-completions",
@@ -807,7 +807,7 @@ export default function omiProvider(pi: ExtensionAPI): void {
   });
 
   // Register Omi-specific tools (execute_sql, semantic_search, etc.)
-  // These forward to Swift via the OMI_BRIDGE_PIPE Unix socket.
+  // These forward to Swift via the IR_BRIDGE_PIPE Unix socket.
   void registerOmiTools(pi);
 }
 

--- a/run.sh
+++ b/run.sh
@@ -283,6 +283,18 @@ elif [ ! -f "google-credentials.json" ] && [ -f "../Backend/google-credentials.j
     ln -sf "../Backend/google-credentials.json" "google-credentials.json"
 fi
 
+# Guard: reject stale OMI_* keys that would silently miss the IR_ bootstrap.
+# Without this, a leftover OMI_PYTHON_API_URL=http://localhost:8080 silently falls
+# through to the production default https://api.omi.me — wrong behavior, no diagnostic.
+if [ -f "$BACKEND_DIR/.env" ] && grep -qE "^OMI_[A-Z]" "$BACKEND_DIR/.env"; then
+    echo "ERROR: $BACKEND_DIR/.env contains legacy OMI_* keys:" >&2
+    grep -E "^OMI_[A-Z][A-Z0-9_]*=" "$BACKEND_DIR/.env" | sed 's/=.*//; s/^/  /' >&2
+    echo "" >&2
+    echo "  These were renamed to IR_*. Update them and re-run:" >&2
+    echo "    sed -i '' -E 's/^OMI_([A-Z])/IR_\\1/' $BACKEND_DIR/.env" >&2
+    exit 1
+fi
+
 # Read environment from .env (skip if missing — yolo mode doesn't need it)
 if [ -f "$BACKEND_DIR/.env" ]; then
     set -a; source "$BACKEND_DIR/.env"; set +a

--- a/run.sh
+++ b/run.sh
@@ -13,15 +13,15 @@ Usage: ./run.sh [options]
 Build and run the Omi Desktop dev app with local backend services.
 
 Options (via environment variables):
-  OMI_SKIP_BACKEND=1      Skip starting Rust backend (use remote backend via OMI_API_URL)
-  OMI_SKIP_AUTH=1          Skip starting Python auth service (use remote auth via OMI_AUTH_URL)
-  OMI_SKIP_TUNNEL=1        Skip Cloudflare tunnel (use OMI_API_URL from .env directly)
+  IR_SKIP_BACKEND=1      Skip starting Rust backend (use remote backend via IR_API_URL)
+  IR_SKIP_AUTH=1          Skip starting Python auth service (use remote auth via IR_AUTH_URL)
+  IR_SKIP_TUNNEL=1        Skip Cloudflare tunnel (use IR_API_URL from .env directly)
   AUTH_PORT=10200           Auth service port (default: 10200)
   PORT=10201                Rust backend port (default: 10201, never use 8080)
-  OMI_APP_NAME="Infinite Recall Dev"   Optional app name override (default: "Infinite Recall")
-  OMI_PYTHON_API_URL="..."  Python backend URL (subscriptions, payments, etc; default: https://api.omi.me)
-  OMI_SIGN_IDENTITY="..."  Code signing identity (auto-detected if not set)
-  OMI_ENABLE_LOCAL_AUTOMATION=1  Enable agent-swift automation bridge
+  IR_APP_NAME="Infinite Recall Dev"   Optional app name override (default: "Infinite Recall")
+  IR_PYTHON_API_URL="..."  Python backend URL (subscriptions, payments, etc; default: https://api.omi.me)
+  IR_SIGN_IDENTITY="..."  Code signing identity (auto-detected if not set)
+  IR_ENABLE_LOCAL_AUTOMATION=1  Enable agent-swift automation bridge
 
 Required files:
   Backend-Rust/.env         Environment variables (copy from ../.env.example)
@@ -35,8 +35,8 @@ Port allocation (avoid 8080 to prevent port conflicts):
 
 Examples:
   ./run.sh                                  # Full local dev (backend + auth + tunnel + app)
-  OMI_SKIP_BACKEND=1 OMI_SKIP_AUTH=1 ./run.sh  # App only (backend running elsewhere)
-  OMI_SKIP_TUNNEL=1 ./run.sh                # No Cloudflare tunnel (use direct URL)
+  IR_SKIP_BACKEND=1 IR_SKIP_AUTH=1 ./run.sh  # App only (backend running elsewhere)
+  IR_SKIP_TUNNEL=1 ./run.sh                # No Cloudflare tunnel (use direct URL)
   ./run.sh --yolo                            # Quick start: use prod backend, no local services
 USAGE
     exit 0
@@ -58,12 +58,12 @@ if [ "$1" = "--yolo" ]; then
     echo "=========================================="
     echo ""
 
-    export OMI_SKIP_BACKEND=1
-    export OMI_SKIP_AUTH=1
-    export OMI_SKIP_TUNNEL=1
-    export OMI_API_URL="http://127.0.0.1:7331"          # local Backend-Rust default
-    export OMI_PYTHON_API_URL=""
-    export OMI_AUTH_URL=""                               # auth is stubbed in this fork
+    export IR_SKIP_BACKEND=1
+    export IR_SKIP_AUTH=1
+    export IR_SKIP_TUNNEL=1
+    export IR_API_URL="http://127.0.0.1:7331"          # local Backend-Rust default
+    export IR_PYTHON_API_URL=""
+    export IR_AUTH_URL=""                               # auth is stubbed in this fork
     export FIREBASE_API_KEY=""                           # Firebase is dormant (not initialized)
 fi
 
@@ -96,9 +96,9 @@ substep() {
 
 # App configuration
 BINARY_NAME="Omi Computer"  # Package.swift target — binary paths, pkill, CFBundleExecutable
-APP_NAME="${OMI_APP_NAME:-Infinite Recall}"
+APP_NAME="${IR_APP_NAME:-Infinite Recall}"
 IS_NAMED_BUNDLE=false
-[ -n "${OMI_APP_NAME:-}" ] && IS_NAMED_BUNDLE=true
+[ -n "${IR_APP_NAME:-}" ] && IS_NAMED_BUNDLE=true
 
 slugify_identifier() {
     printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-+/-/g'
@@ -110,21 +110,21 @@ if [ "$IS_NAMED_BUNDLE" = false ]; then
 else
     APP_SLUG="$(slugify_identifier "$APP_NAME")"
     if [ -z "$APP_SLUG" ]; then
-        echo "ERROR: OMI_APP_NAME must contain at least one letter or number"
+        echo "ERROR: IR_APP_NAME must contain at least one letter or number"
         exit 1
     fi
     EXPECTED_BUNDLE_ID="com.omi.$APP_SLUG"
     EXPECTED_URL_SCHEME="omi-$APP_SLUG"
 fi
 
-BUNDLE_ID="${OMI_BUNDLE_ID:-$EXPECTED_BUNDLE_ID}"
+BUNDLE_ID="${IR_BUNDLE_ID:-$EXPECTED_BUNDLE_ID}"
 BUILD_DIR="build"
 APP_BUNDLE="$BUILD_DIR/$APP_NAME.app"
 APP_PATH="/Applications/$APP_NAME.app"
 APP_DESKTOP_PATH="$HOME/Desktop/$APP_NAME.app"
 APP_DOWNLOADS_PATH="$HOME/Downloads/$APP_NAME.app"
-SIGN_IDENTITY="${OMI_SIGN_IDENTITY:-}"
-URL_SCHEME="${OMI_URL_SCHEME:-$EXPECTED_URL_SCHEME}"
+SIGN_IDENTITY="${IR_SIGN_IDENTITY:-}"
+URL_SCHEME="${IR_URL_SCHEME:-$EXPECTED_URL_SCHEME}"
 
 if [ "$BUNDLE_ID" != "$EXPECTED_BUNDLE_ID" ]; then
     echo "ERROR: APP_NAME '$APP_NAME' must use bundle ID '$EXPECTED_BUNDLE_ID' (got '$BUNDLE_ID')"
@@ -136,8 +136,8 @@ if [ "$URL_SCHEME" != "$EXPECTED_URL_SCHEME" ]; then
     exit 1
 fi
 AUTOMATION_ARGS=()
-if [ "${OMI_ENABLE_LOCAL_AUTOMATION:-0}" = "1" ]; then
-    AUTOMATION_PORT="${OMI_AUTOMATION_PORT:-47777}"
+if [ "${IR_ENABLE_LOCAL_AUTOMATION:-0}" = "1" ]; then
+    AUTOMATION_PORT="${IR_AUTOMATION_PORT:-47777}"
     AUTOMATION_ARGS+=(--automation-bridge "--automation-port=$AUTOMATION_PORT")
 fi
 
@@ -216,7 +216,7 @@ find "$HOME" -maxdepth 4 -name "$APP_NAME.app" -type d -not -path "$APP_BUNDLE" 
     rm -rf "$stale"
 done
 
-if [ "${OMI_SKIP_TUNNEL:-0}" != "1" ]; then
+if [ "${IR_SKIP_TUNNEL:-0}" != "1" ]; then
     step "Starting Cloudflare quick tunnel..."
     if command -v cloudflared >/dev/null 2>&1; then
         TUNNEL_LOG=$(mktemp /tmp/cloudflared-XXXXXX.log)
@@ -234,10 +234,10 @@ if [ "${OMI_SKIP_TUNNEL:-0}" != "1" ]; then
             substep "Warning: Could not capture tunnel URL (see $TUNNEL_LOG for details)"
         fi
     else
-        substep "cloudflared not found — skipping tunnel (set OMI_API_URL in .env instead)"
+        substep "cloudflared not found — skipping tunnel (set IR_API_URL in .env instead)"
     fi
 else
-    substep "Skipping tunnel (OMI_SKIP_TUNNEL=1)"
+    substep "Skipping tunnel (IR_SKIP_TUNNEL=1)"
 fi
 
 # ─── Load .env and credentials ─────────────────────────────────────────
@@ -267,8 +267,8 @@ if [ ! -f ".env" ] && [ "$1" != "--yolo" ]; then
     echo "  GOOGLE_APPLICATION_CREDENTIALS=./google-credentials.json"
     echo ""
     echo "Or skip the backend entirely:"
-    echo "  OMI_SKIP_BACKEND=1 OMI_SKIP_AUTH=1 ./run.sh"
-    echo "  (set OMI_API_URL and OMI_AUTH_URL in .env.app to point to a remote backend)"
+    echo "  IR_SKIP_BACKEND=1 IR_SKIP_AUTH=1 ./run.sh"
+    echo "  (set IR_API_URL and IR_AUTH_URL in .env.app to point to a remote backend)"
     echo ""
     echo "Or just use the production backend (no setup needed):"
     echo "  ./run.sh --yolo"
@@ -294,14 +294,14 @@ export PORT="$BACKEND_PORT"
 
 # Validate credentials (needed for both backend and auth)
 CREDS_PATH="$BACKEND_DIR/google-credentials.json"
-if [ "${OMI_SKIP_BACKEND:-0}" != "1" ] && [ ! -f "$CREDS_PATH" ]; then
+if [ "${IR_SKIP_BACKEND:-0}" != "1" ] && [ ! -f "$CREDS_PATH" ]; then
     echo "ERROR: Missing credentials file: $CREDS_PATH"
     echo ""
     echo "  Option A: Place your GCP service account key here:"
     echo "    cp /path/to/google-credentials.json $CREDS_PATH"
     echo ""
     echo "  Option B: Skip the local backend and use a remote one:"
-    echo "    OMI_SKIP_BACKEND=1 ./run.sh"
+    echo "    IR_SKIP_BACKEND=1 ./run.sh"
     exit 1
 fi
 if [ -f "$CREDS_PATH" ]; then
@@ -309,7 +309,7 @@ if [ -f "$CREDS_PATH" ]; then
 fi
 
 # Validate FIREBASE_PROJECT_ID (required unless yolo mode — no local backend)
-if [ -z "$FIREBASE_PROJECT_ID" ] && [ "${OMI_SKIP_BACKEND:-0}" != "1" ]; then
+if [ -z "$FIREBASE_PROJECT_ID" ] && [ "${IR_SKIP_BACKEND:-0}" != "1" ]; then
     echo "ERROR: FIREBASE_PROJECT_ID is not set."
     echo ""
     echo "  Add to $BACKEND_DIR/.env:"
@@ -324,7 +324,7 @@ substep "Firebase project: $FIREBASE_PROJECT_ID | Backend port: $BACKEND_PORT | 
 cd - > /dev/null
 
 # ─── Start Rust backend ───────────────────────────────────────────────
-if [ "${OMI_SKIP_BACKEND:-0}" != "1" ]; then
+if [ "${IR_SKIP_BACKEND:-0}" != "1" ]; then
     step "Starting Rust backend..."
     cd "$BACKEND_DIR"
 
@@ -351,11 +351,11 @@ if [ "${OMI_SKIP_BACKEND:-0}" != "1" ]; then
         sleep 0.5
     done
 else
-    substep "Skipping backend (OMI_SKIP_BACKEND=1) — using OMI_API_URL from .env"
+    substep "Skipping backend (IR_SKIP_BACKEND=1) — using IR_API_URL from .env"
 fi
 
 # ─── Start Python auth service ────────────────────────────────────────
-if [ "${OMI_SKIP_AUTH:-0}" != "1" ]; then
+if [ "${IR_SKIP_AUTH:-0}" != "1" ]; then
     step "Starting Python auth service (port $AUTH_PORT)..."
     if [ -d "$AUTH_DIR" ]; then
         # Set up venv if needed
@@ -383,10 +383,10 @@ if [ "${OMI_SKIP_AUTH:-0}" != "1" ]; then
             substep "Auth service starting (PID: $AUTH_PID)..."
         fi
     else
-        substep "Auth-Python/ not found — skipping (auth will use OMI_AUTH_URL from .env)"
+        substep "Auth-Python/ not found — skipping (auth will use IR_AUTH_URL from .env)"
     fi
 else
-    substep "Skipping auth service (OMI_SKIP_AUTH=1) — using OMI_AUTH_URL from .env"
+    substep "Skipping auth service (IR_SKIP_AUTH=1) — using IR_AUTH_URL from .env"
 fi
 
 # Check if another SwiftPM instance is running (will block our build)
@@ -497,20 +497,20 @@ elif [ -f ".env.app" ]; then
 else
     touch "$APP_BUNDLE/Contents/Resources/.env"
 fi
-# Set OMI_API_URL: tunnel URL if available, otherwise from .env or local backend
+# Set IR_API_URL: tunnel URL if available, otherwise from .env or local backend
 if [ -n "$TUNNEL_URL" ]; then
     EFFECTIVE_API_URL="$TUNNEL_URL"
-elif [ -n "$OMI_API_URL" ]; then
-    EFFECTIVE_API_URL="$OMI_API_URL"
+elif [ -n "$IR_API_URL" ]; then
+    EFFECTIVE_API_URL="$IR_API_URL"
 else
     EFFECTIVE_API_URL="http://localhost:$BACKEND_PORT"
 fi
-if grep -q "^OMI_API_URL=" "$APP_BUNDLE/Contents/Resources/.env"; then
-    sed -i '' "s|^OMI_API_URL=.*|OMI_API_URL=$EFFECTIVE_API_URL|" "$APP_BUNDLE/Contents/Resources/.env"
+if grep -q "^IR_API_URL=" "$APP_BUNDLE/Contents/Resources/.env"; then
+    sed -i '' "s|^IR_API_URL=.*|IR_API_URL=$EFFECTIVE_API_URL|" "$APP_BUNDLE/Contents/Resources/.env"
 else
-    echo "OMI_API_URL=$EFFECTIVE_API_URL" >> "$APP_BUNDLE/Contents/Resources/.env"
+    echo "IR_API_URL=$EFFECTIVE_API_URL" >> "$APP_BUNDLE/Contents/Resources/.env"
 fi
-substep "OMI_API_URL=$EFFECTIVE_API_URL"
+substep "IR_API_URL=$EFFECTIVE_API_URL"
 # Bootstrap FIREBASE_API_KEY — check env var first (yolo mode), then backend .env
 if ! grep -q "^FIREBASE_API_KEY=" "$APP_BUNDLE/Contents/Resources/.env"; then
     FIREBASE_KEY="${FIREBASE_API_KEY:-}"
@@ -522,32 +522,32 @@ if ! grep -q "^FIREBASE_API_KEY=" "$APP_BUNDLE/Contents/Resources/.env"; then
         substep "Bootstrapped FIREBASE_API_KEY"
     fi
 fi
-# Bootstrap OMI_AUTH_URL — check env var first (yolo mode), then backend .env, then local auth
-if ! grep -q "^OMI_AUTH_URL=" "$APP_BUNDLE/Contents/Resources/.env"; then
-    AUTH_URL="${OMI_AUTH_URL:-}"
+# Bootstrap IR_AUTH_URL — check env var first (yolo mode), then backend .env, then local auth
+if ! grep -q "^IR_AUTH_URL=" "$APP_BUNDLE/Contents/Resources/.env"; then
+    AUTH_URL="${IR_AUTH_URL:-}"
     if [ -z "$AUTH_URL" ] && [ -f "$BACKEND_DIR/.env" ]; then
-        AUTH_URL=$(grep "^OMI_AUTH_URL=" "$BACKEND_DIR/.env" | head -1 | cut -d= -f2-)
+        AUTH_URL=$(grep "^IR_AUTH_URL=" "$BACKEND_DIR/.env" | head -1 | cut -d= -f2-)
     fi
     if [ -z "$AUTH_URL" ]; then
         AUTH_URL="http://localhost:${AUTH_PORT}/"
-        substep "OMI_AUTH_URL not set — defaulting to local auth service: $AUTH_URL"
+        substep "IR_AUTH_URL not set — defaulting to local auth service: $AUTH_URL"
     fi
-    echo "OMI_AUTH_URL=$AUTH_URL" >> "$APP_BUNDLE/Contents/Resources/.env"
-    substep "Set OMI_AUTH_URL=$AUTH_URL"
+    echo "IR_AUTH_URL=$AUTH_URL" >> "$APP_BUNDLE/Contents/Resources/.env"
+    substep "Set IR_AUTH_URL=$AUTH_URL"
 fi
-# Bootstrap OMI_PYTHON_API_URL — main Omi Python backend (subscriptions, payments, transcription)
-# Do NOT fall back to OMI_API_URL — that's the Rust desktop-backend which doesn't serve these routes
-if ! grep -q "^OMI_PYTHON_API_URL=" "$APP_BUNDLE/Contents/Resources/.env"; then
-    PYTHON_API_URL="${OMI_PYTHON_API_URL:-}"
+# Bootstrap IR_PYTHON_API_URL — main Omi Python backend (subscriptions, payments, transcription)
+# Do NOT fall back to IR_API_URL — that's the Rust desktop-backend which doesn't serve these routes
+if ! grep -q "^IR_PYTHON_API_URL=" "$APP_BUNDLE/Contents/Resources/.env"; then
+    PYTHON_API_URL="${IR_PYTHON_API_URL:-}"
     if [ -z "$PYTHON_API_URL" ] && [ -f "$BACKEND_DIR/.env" ]; then
-        PYTHON_API_URL=$(grep "^OMI_PYTHON_API_URL=" "$BACKEND_DIR/.env" | head -1 | cut -d= -f2-)
+        PYTHON_API_URL=$(grep "^IR_PYTHON_API_URL=" "$BACKEND_DIR/.env" | head -1 | cut -d= -f2-)
     fi
     if [ -z "$PYTHON_API_URL" ]; then
         PYTHON_API_URL="https://api.omi.me"
-        substep "OMI_PYTHON_API_URL not set — defaulting to production: $PYTHON_API_URL"
+        substep "IR_PYTHON_API_URL not set — defaulting to production: $PYTHON_API_URL"
     fi
-    echo "OMI_PYTHON_API_URL=$PYTHON_API_URL" >> "$APP_BUNDLE/Contents/Resources/.env"
-    substep "Set OMI_PYTHON_API_URL=$PYTHON_API_URL"
+    echo "IR_PYTHON_API_URL=$PYTHON_API_URL" >> "$APP_BUNDLE/Contents/Resources/.env"
+    substep "Set IR_PYTHON_API_URL=$PYTHON_API_URL"
 fi
 
 substep "Copying app icon"
@@ -653,8 +653,8 @@ else
     echo "       Screen Recording permissions for ALL Omi apps (including prod/beta)."
     echo ""
     echo "  Fix: Install an Apple Development certificate in Keychain Access,"
-    echo "       or set OMI_SIGN_IDENTITY to a valid identity:"
-    echo "       OMI_SIGN_IDENTITY=\"Apple Development: you@example.com\" ./run.sh"
+    echo "       or set IR_SIGN_IDENTITY to a valid identity:"
+    echo "       IR_SIGN_IDENTITY=\"Apple Development: you@example.com\" ./run.sh"
     echo ""
     exit 1
 fi
@@ -697,7 +697,7 @@ echo "=== Services Running (total: ${TOTAL_TIME%.*}s) ==="
 if [ -n "$BACKEND_PID" ]; then
     echo "Backend:  http://localhost:$BACKEND_PORT (PID: $BACKEND_PID)"
 else
-    echo "Backend:  skipped (OMI_SKIP_BACKEND=1)"
+    echo "Backend:  skipped (IR_SKIP_BACKEND=1)"
 fi
 if [ -n "$AUTH_PID" ]; then
     echo "Auth:     http://localhost:$AUTH_PORT (PID: $AUTH_PID)"

--- a/scripts/build-dmg.sh
+++ b/scripts/build-dmg.sh
@@ -12,10 +12,10 @@
 #   TEAM_ID                  Apple Developer Team ID (10-char alphanumeric).
 #
 # Optional env vars:
-#   OMI_SIGN_IDENTITY        Code-signing identity. Defaults to first
+#   IR_SIGN_IDENTITY        Code-signing identity. Defaults to first
 #                            "Developer ID Application" cert in the keychain.
-#   OMI_APP_NAME             Display + bundle name. Default: "Infinite Recall".
-#   OMI_VERSION              Override version string (otherwise read from
+#   IR_APP_NAME             Display + bundle name. Default: "Infinite Recall".
+#   IR_VERSION              Override version string (otherwise read from
 #                            Desktop/Info.plist:CFBundleShortVersionString,
 #                            falling back to `git describe --tags`).
 #
@@ -92,7 +92,7 @@ for tool in xcrun codesign hdiutil spctl /usr/libexec/PlistBuddy; do
 done
 
 # ─── Configuration ─────────────────────────────────────────────────────
-APP_NAME="${OMI_APP_NAME:-Infinite Recall}"
+APP_NAME="${IR_APP_NAME:-Infinite Recall}"
 BINARY_NAME="Omi Computer"   # Package.swift target name (matches run.sh)
 BUNDLE_ID="com.omi.infinite-recall"
 
@@ -100,8 +100,8 @@ INFO_PLIST="Desktop/Info.plist"
 [ -f "$INFO_PLIST" ] || die "Desktop/Info.plist not found at $REPO_ROOT/$INFO_PLIST"
 
 # Version: prefer explicit override → Info.plist → git tag → "0.0.0".
-if [ -n "${OMI_VERSION:-}" ]; then
-    VERSION="$OMI_VERSION"
+if [ -n "${IR_VERSION:-}" ]; then
+    VERSION="$IR_VERSION"
 else
     VERSION=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$INFO_PLIST" 2>/dev/null || true)
     if [ -z "$VERSION" ] || [ "$VERSION" = "0" ]; then
@@ -122,11 +122,11 @@ ENTITLEMENTS="Desktop/Omi-Release.entitlements"
 [ -f "$ENTITLEMENTS" ] || die "No entitlements file found (Desktop/Omi-Release.entitlements or Desktop/Omi.entitlements)."
 
 # ─── Resolve signing identity ──────────────────────────────────────────
-SIGN_IDENTITY="${OMI_SIGN_IDENTITY:-}"
+SIGN_IDENTITY="${IR_SIGN_IDENTITY:-}"
 if [ -z "$SIGN_IDENTITY" ]; then
     SIGN_IDENTITY=$(security find-identity -v -p codesigning | grep "Developer ID Application" | head -1 | sed 's/.*"\(.*\)"/\1/')
 fi
-[ -n "$SIGN_IDENTITY" ] || die "No 'Developer ID Application' identity found in keychain. Install one or set OMI_SIGN_IDENTITY."
+[ -n "$SIGN_IDENTITY" ] || die "No 'Developer ID Application' identity found in keychain. Install one or set IR_SIGN_IDENTITY."
 substep "Signing identity: $SIGN_IDENTITY"
 
 # ─── Idempotent cleanup ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Mechanical rename of every `OMI_<UPPERCASE>` identifier to `IR_` across shell, Swift, and TypeScript (17 files)
- Covers env vars (`IR_API_URL`, `IR_AUTH_URL`, `IR_PYTHON_API_URL`, `IR_APP_NAME`, `IR_BUNDLE_ID`, `IR_SIGN_IDENTITY`, `IR_VERSION`, `IR_SKIP_*`, `IR_ENABLE_LOCAL_AUTOMATION`, `IR_AUTOMATION_PORT`, `IR_BRIDGE_PIPE`, `IR_API_KEY`, `IR_API_BASE_URL`, `IR_YOLO_MODE`, `IR_PI_AUDIT_LOG`) and TS exports (`IR_TOOLS`, `IR_TOOL_TIMEOUT_MS`)

## Breaking change
Existing `Backend-Rust/.env`, `.env.app`, and shell exports using `OMI_*` keys must be renamed. No fallback shim — hard cutover.

## Out of scope
- Upstream URL `https://api.omi.me` (real Omi service)
- Prose describing the upstream Omi project
- Filenames (`omi_icon.icns`, `OmiApp.swift`) and the `~/.omi.env` load path
- `"OMI API:"` / `"OMI AUTH:"` `NSLog` tag prefixes in `APIClient.swift` and `AuthService.swift` (not `OMI_` identifiers)

## Test plan
- [ ] `xcrun swift build -c debug --package-path Desktop` compiles
- [ ] `IR_APP_NAME="Infinite Recall" IR_SKIP_BACKEND=1 IR_SKIP_AUTH=1 IR_SKIP_TUNNEL=1 IR_SKIP_PYTHON=1 ./run.sh --yolo` builds + launches
- [ ] `pi-mono-extension/index.test.ts` passes (`IR_TOOLS` / `IR_TOOL_TIMEOUT_MS` exports + `IR_PI_AUDIT_LOG`)
- [ ] `Desktop/Tests/APIClientRoutingTests.swift` passes (`IR_API_URL`, `IR_PYTHON_API_URL` setenv/unsetenv)
- [ ] Repo-wide `grep "OMI_[A-Z]"` returns no matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)