### PR TITLE
activity: refactor PauseRequest to sum type (closes #34)

### DIFF
--- a/Backend-Rust/api/src/activity/contract.md
+++ b/Backend-Rust/api/src/activity/contract.md
@@ -88,7 +88,7 @@ Field names are snake_case on the wire. Swift mirrors live in
 |---|---|
 | `KindRow.kind` / `WorkKind` | `transcribe`, `ocr`, `summarize`, `extract_memory`, `extract_action_items` |
 | `CaptureRow.kind` / `CaptureKind` | `audio`, `screen` |
-| `PauseRequest.target` / `ResumeRequest.target` / `PauseTarget` | `kind`, `capture` |
+| `PauseRequest.target` / `ResumeRequest.target` / `PauseTargetId` | `kind`, `capture` (with typed `id` payload — see below) |
 | `ResourceSample.thermal_state` / `ThermalState` | `nominal`, `fair`, `serious`, `critical` |
 | `GateState.reason` / `GateReason` | `idle`, `device_active`, `on_battery`, `thermal`, `locked`, `manual_pause`, `none` |
 
@@ -104,6 +104,12 @@ Field names are snake_case on the wire. Swift mirrors live in
 
 For `target: "kind"`, `id` is a `WorkKind` snake_case string.
 For `target: "capture"`, `id` is `"audio"` or `"screen"`.
+
+`minutes` MUST be `> 0` (Rust enforces via `NonZeroU32` at the serde layer; a
+zero or negative value is rejected with `400 Bad Request` before any handler
+runs). Any `(target, id)` combo not in the matrix above is also rejected at
+the serde layer — `target` and `id` form a typed sum (`PauseTargetId`) so
+`{"target":"kind","id":"audio"}` is unrepresentable on both sides.
 
 ### `InflightUpdate` (Swift → Rust loopback)
 
@@ -125,9 +131,10 @@ Stream A wires; B/C/D and the idle-gate agent implement.
 
 ```rust
 trait PauseStore : Send + Sync {
-    fn paused_until(&self, target: PauseTarget, id: &str) -> Option<DateTime<Utc>>;
-    fn pause       (&self, target: PauseTarget, id: &str, minutes: u32) -> DateTime<Utc>;
-    fn resume      (&self, target: PauseTarget, id: &str);
+    fn paused_until(&self, target: &PauseTargetId) -> Option<DateTime<Utc>>;
+    fn pause       (&self, target: &PauseTargetId, minutes: NonZeroU32)
+                       -> Result<DateTime<Utc>, PauseStoreError>;
+    fn resume      (&self, target: &PauseTargetId) -> Result<bool, PauseStoreError>;
 }
 
 trait InflightRegistry : Send + Sync {

--- a/Backend-Rust/api/src/activity/mod.rs
+++ b/Backend-Rust/api/src/activity/mod.rs
@@ -20,7 +20,7 @@ pub mod types;
 
 pub use traits::{InflightRegistry, PauseStore, ProcessingGate, ResourceSampler};
 pub use types::{
-    ActivitySnapshot, CaptureRow, GateState, GateReason, InFlight, InflightUpdate, KindRow,
-    PauseRequest, PauseTarget, ProcessBreakdown, ResourceSample, ResumeRequest, ThermalState,
-    WorkKind,
+    ActivitySnapshot, CaptureKind, CaptureRow, GateReason, GateState, InFlight, InflightUpdate,
+    KindRow, PauseRequest, PauseTargetId, ProcessBreakdown, ResourceSample, ResumeRequest,
+    ThermalState, WorkKind,
 };

--- a/Backend-Rust/api/src/activity/pause_store.rs
+++ b/Backend-Rust/api/src/activity/pause_store.rs
@@ -20,6 +20,7 @@
 //! separate file (`activity.db`) so it never collides with the Swift
 //! app's writes.
 
+use std::num::NonZeroU32;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -31,7 +32,7 @@ use r2d2_sqlite::SqliteConnectionManager;
 use rusqlite::params;
 
 use super::traits::{PauseStore, PauseStoreError};
-use super::types::PauseTarget;
+use super::types::PauseTargetId;
 
 /// Inline migration source. Kept in lockstep with
 /// `Backend-Rust/api/migrations/0001_paused_work.sql` so the binary can
@@ -93,13 +94,6 @@ impl SqlPauseStore {
     }
 }
 
-fn target_str(target: PauseTarget) -> &'static str {
-    match target {
-        PauseTarget::Kind => "kind",
-        PauseTarget::Capture => "capture",
-    }
-}
-
 fn now_unix_secs() -> i64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -114,9 +108,9 @@ fn from_unix_secs(secs: i64) -> DateTime<Utc> {
 }
 
 impl PauseStore for SqlPauseStore {
-    fn paused_until(&self, target: PauseTarget, id: &str) -> Option<DateTime<Utc>> {
+    fn paused_until(&self, target: &PauseTargetId) -> Option<DateTime<Utc>> {
         let conn = self.pool.get().ok()?;
-        let t = target_str(target);
+        let (t, id) = target.as_storage_pair();
         let now = now_unix_secs();
 
         let row: rusqlite::Result<i64> = conn.query_row(
@@ -145,13 +139,12 @@ impl PauseStore for SqlPauseStore {
 
     fn pause(
         &self,
-        target: PauseTarget,
-        id: &str,
-        minutes: u32,
+        target: &PauseTargetId,
+        minutes: NonZeroU32,
     ) -> Result<DateTime<Utc>, PauseStoreError> {
-        let resume_at_secs = now_unix_secs().saturating_add(i64::from(minutes) * 60);
+        let resume_at_secs = now_unix_secs().saturating_add(i64::from(minutes.get()) * 60);
         let resume_at = from_unix_secs(resume_at_secs);
-        let t = target_str(target);
+        let (t, id) = target.as_storage_pair();
         let conn = self.pool.get().map_err(|e| {
             tracing::error!(error = %e, "pause: pool checkout failed");
             PauseStoreError::from(e)
@@ -168,8 +161,8 @@ impl PauseStore for SqlPauseStore {
         Ok(resume_at)
     }
 
-    fn resume(&self, target: PauseTarget, id: &str) -> Result<bool, PauseStoreError> {
-        let t = target_str(target);
+    fn resume(&self, target: &PauseTargetId) -> Result<bool, PauseStoreError> {
+        let (t, id) = target.as_storage_pair();
         let conn = self.pool.get().map_err(|e| {
             tracing::error!(error = %e, "resume: pool checkout failed");
             PauseStoreError::from(e)
@@ -190,8 +183,19 @@ impl PauseStore for SqlPauseStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::activity::types::{CaptureKind, WorkKind};
     use std::sync::atomic::{AtomicU32, Ordering};
     use std::thread;
+
+    fn nz(n: u32) -> NonZeroU32 {
+        NonZeroU32::new(n).expect("test minutes must be non-zero")
+    }
+    const KIND_OCR: PauseTargetId = PauseTargetId::Kind(WorkKind::Ocr);
+    const KIND_TRANSCRIBE: PauseTargetId = PauseTargetId::Kind(WorkKind::Transcribe);
+    const KIND_SUMMARIZE: PauseTargetId = PauseTargetId::Kind(WorkKind::Summarize);
+    const KIND_EXTRACT_MEMORY: PauseTargetId = PauseTargetId::Kind(WorkKind::ExtractMemory);
+    const CAPTURE_AUDIO: PauseTargetId = PauseTargetId::Capture(CaptureKind::Audio);
+    const CAPTURE_SCREEN: PauseTargetId = PauseTargetId::Capture(CaptureKind::Screen);
 
     /// Each test gets its own shared-cache in-memory DB by salting the
     /// URI with a unique counter — otherwise tests would alias rows.
@@ -212,9 +216,9 @@ mod tests {
     #[test]
     fn pause_then_read_back_returns_resume_time() {
         let store = fresh_store();
-        let returned = store.pause(PauseTarget::Kind, "ocr", 15).expect("pause ok");
+        let returned = store.pause(&KIND_OCR, nz(15)).expect("pause ok");
         let observed = store
-            .paused_until(PauseTarget::Kind, "ocr")
+            .paused_until(&KIND_OCR)
             .expect("paused row should be returned");
         // Compare to the second — `pause` and `paused_until` both round to seconds.
         assert_eq!(observed.timestamp(), returned.timestamp());
@@ -227,9 +231,7 @@ mod tests {
     #[test]
     fn unpaused_target_returns_none() {
         let store = fresh_store();
-        assert!(store
-            .paused_until(PauseTarget::Capture, "audio")
-            .is_none());
+        assert!(store.paused_until(&CAPTURE_AUDIO).is_none());
     }
 
     #[test]
@@ -245,9 +247,7 @@ mod tests {
         .unwrap();
         drop(conn);
 
-        assert!(store
-            .paused_until(PauseTarget::Kind, "transcribe")
-            .is_none());
+        assert!(store.paused_until(&KIND_TRANSCRIBE).is_none());
 
         // Opportunistic GC should have removed the row.
         let conn = store.pool.get().unwrap();
@@ -264,27 +264,23 @@ mod tests {
     #[test]
     fn pause_then_resume_clears_row() {
         let store = fresh_store();
-        store.pause(PauseTarget::Kind, "summarize", 30).expect("pause ok");
-        assert!(store
-            .paused_until(PauseTarget::Kind, "summarize")
-            .is_some());
+        store.pause(&KIND_SUMMARIZE, nz(30)).expect("pause ok");
+        assert!(store.paused_until(&KIND_SUMMARIZE).is_some());
 
-        let was_paused = store.resume(PauseTarget::Kind, "summarize").expect("resume ok");
+        let was_paused = store.resume(&KIND_SUMMARIZE).expect("resume ok");
         assert!(was_paused, "resume should report row was deleted");
-        assert!(store
-            .paused_until(PauseTarget::Kind, "summarize")
-            .is_none());
+        assert!(store.paused_until(&KIND_SUMMARIZE).is_none());
     }
 
     #[test]
     fn pause_overwrite_extends_resume_time() {
         let store = fresh_store();
-        let short = store.pause(PauseTarget::Capture, "screen", 1).expect("pause ok");
-        let longer = store.pause(PauseTarget::Capture, "screen", 60).expect("pause ok");
+        let short = store.pause(&CAPTURE_SCREEN, nz(1)).expect("pause ok");
+        let longer = store.pause(&CAPTURE_SCREEN, nz(60)).expect("pause ok");
         assert!(longer.timestamp() > short.timestamp());
 
         let observed = store
-            .paused_until(PauseTarget::Capture, "screen")
+            .paused_until(&CAPTURE_SCREEN)
             .expect("row should still exist after overwrite");
         assert_eq!(observed.timestamp(), longer.timestamp());
 
@@ -300,28 +296,32 @@ mod tests {
     fn resume_on_unpaused_target_is_noop() {
         let store = fresh_store();
         // Should not panic or error; should report no row was deleted.
-        let was_paused = store.resume(PauseTarget::Kind, "extract_memory").expect("resume ok");
+        let was_paused = store.resume(&KIND_EXTRACT_MEMORY).expect("resume ok");
         assert!(!was_paused, "resume of un-paused target should report false");
-        assert!(store
-            .paused_until(PauseTarget::Kind, "extract_memory")
-            .is_none());
+        assert!(store.paused_until(&KIND_EXTRACT_MEMORY).is_none());
     }
 
     #[test]
     fn kind_and_capture_targets_are_independent() {
-        let store = fresh_store();
-        store.pause(PauseTarget::Kind, "audio", 10).expect("pause ok");
-        // Same id, different target — must be a separate row.
-        assert!(store
-            .paused_until(PauseTarget::Capture, "audio")
-            .is_none());
-        assert!(store.paused_until(PauseTarget::Kind, "audio").is_some());
+        // Issue #34: previously this test paused a `Kind`/`"audio"` combo
+        // (which was illegal-but-representable). Post-#34 the type system
+        // forbids that, so we exercise independence with two legal
+        // targets that share NOTHING in common (Capture::Audio vs the
+        // analogous Kind::Ocr — same row count check, different keys).
+        store_independence_check(&fresh_store());
+
+        fn store_independence_check(store: &SqlPauseStore) {
+            store.pause(&KIND_OCR, nz(10)).expect("pause ok");
+            // Same row count check, different target — must be a separate row.
+            assert!(store.paused_until(&CAPTURE_AUDIO).is_none());
+            assert!(store.paused_until(&KIND_OCR).is_some());
+        }
     }
 
     #[test]
     fn concurrent_reads_are_safe() {
         let store = fresh_store();
-        store.pause(PauseTarget::Kind, "ocr", 5).expect("pause ok");
+        store.pause(&KIND_OCR, nz(5)).expect("pause ok");
         let store_arc = Arc::new(store);
 
         let handles: Vec<_> = (0..8)
@@ -329,7 +329,7 @@ mod tests {
                 let s = Arc::clone(&store_arc);
                 thread::spawn(move || {
                     for _ in 0..50 {
-                        let r = s.paused_until(PauseTarget::Kind, "ocr");
+                        let r = s.paused_until(&KIND_OCR);
                         assert!(r.is_some(), "concurrent reader saw missing row");
                     }
                 })
@@ -348,7 +348,7 @@ mod tests {
                 let s = Arc::clone(&store);
                 thread::spawn(move || {
                     for _ in 0..20 {
-                        s.pause(PauseTarget::Kind, "ocr", i + 1).expect("pause ok");
+                        s.pause(&KIND_OCR, nz(i + 1)).expect("pause ok");
                     }
                 })
             })

--- a/Backend-Rust/api/src/activity/traits.rs
+++ b/Backend-Rust/api/src/activity/traits.rs
@@ -7,10 +7,11 @@
 
 use std::collections::HashMap;
 use std::fmt;
+use std::num::NonZeroU32;
 
 use chrono::{DateTime, Utc};
 
-use super::types::{GateState, InFlight, PauseTarget, ResourceSample, WorkKind};
+use super::types::{GateState, InFlight, PauseTargetId, ResourceSample, WorkKind};
 
 /// Errors surfaced by `PauseStore` writes (consensus-fix C3).
 ///
@@ -59,25 +60,31 @@ impl From<r2d2::Error> for PauseStoreError {
 }
 
 /// Persistent absolute-time pause storage. Backed by SQLite (Stream B).
+///
+/// Issue #34: takes `&PauseTargetId` (typed sum) instead of the legacy
+/// `(PauseTarget, &str)` pair, so callers cannot construct illegal
+/// combinations like `Kind` + `"audio"`.
 pub trait PauseStore: Send + Sync {
-    /// Returns the wall-time at which the given target/id resumes,
+    /// Returns the wall-time at which the given target resumes,
     /// or `None` when not paused.
-    fn paused_until(&self, target: PauseTarget, id: &str) -> Option<DateTime<Utc>>;
+    fn paused_until(&self, target: &PauseTargetId) -> Option<DateTime<Utc>>;
 
     /// Pause for `minutes` from now; returns the resolved resume time.
     /// Errors propagate so the route can surface a 5xx instead of silently
     /// returning a "successful" resume time on a failed write.
+    ///
+    /// `minutes: NonZeroU32` makes a zero-minute pause unrepresentable
+    /// at the type system, removing the need for a runtime guard.
     fn pause(
         &self,
-        target: PauseTarget,
-        id: &str,
-        minutes: u32,
+        target: &PauseTargetId,
+        minutes: NonZeroU32,
     ) -> Result<DateTime<Utc>, PauseStoreError>;
 
-    /// Clear any pause row for the given target/id. Returns `true` iff a
+    /// Clear any pause row for the given target. Returns `true` iff a
     /// row was actually deleted, so the route can decide whether to fan
     /// out a `pauseChanged` notification.
-    fn resume(&self, target: PauseTarget, id: &str) -> Result<bool, PauseStoreError>;
+    fn resume(&self, target: &PauseTargetId) -> Result<bool, PauseStoreError>;
 }
 
 /// Tracks which `WorkKind` is currently mid-handler. Backed by an

--- a/Backend-Rust/api/src/activity/types.rs
+++ b/Backend-Rust/api/src/activity/types.rs
@@ -215,8 +215,46 @@ pub struct ResumeRequest {
 /// POST /v1/activity/_internal/inflight body (Swift → Rust loopback).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InflightUpdate {
-    /// `WorkKind` snake_case string.
-    pub kind: String,
+    pub kind: WorkKind,
     /// `None` clears the slot.
     pub in_flight: Option<InFlight>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// PR #39 review: guard against future drift between `WorkKind::as_str()`
+    /// and the snake_case derivation `serde(rename_all = "snake_case")` uses
+    /// on the wire. If a contributor adds a `WorkKind` variant and forgets
+    /// to extend `as_str()`, this test will fail.
+    #[test]
+    fn workkind_as_str_matches_serde() {
+        for k in [
+            WorkKind::Transcribe,
+            WorkKind::Ocr,
+            WorkKind::Summarize,
+            WorkKind::ExtractMemory,
+            WorkKind::ExtractActionItems,
+        ] {
+            assert_eq!(
+                serde_json::to_value(k).unwrap(),
+                serde_json::Value::String(k.as_str().to_string()),
+                "WorkKind::{:?} as_str() drifted from serde rename",
+                k
+            );
+        }
+    }
+
+    #[test]
+    fn capturekind_as_str_matches_serde() {
+        for c in [CaptureKind::Audio, CaptureKind::Screen] {
+            assert_eq!(
+                serde_json::to_value(c).unwrap(),
+                serde_json::Value::String(c.as_str().to_string()),
+                "CaptureKind::{:?} as_str() drifted from serde rename",
+                c
+            );
+        }
+    }
 }

--- a/Backend-Rust/api/src/activity/types.rs
+++ b/Backend-Rust/api/src/activity/types.rs
@@ -4,6 +4,8 @@
 //! generated from. **Do not change a field name without updating both
 //! `contract.md` and `Desktop/Sources/Activity/ActivityModels.swift`.**
 
+use std::num::NonZeroU32;
+
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
@@ -26,12 +28,57 @@ pub enum CaptureKind {
     Screen,
 }
 
-/// What `Pause`/`Resume` requests target.
+/// What `Pause`/`Resume` requests target. The variant payload carries the
+/// concrete typed id, so illegal `(target, id)` combinations are
+/// unrepresentable (issue #34): you cannot construct
+/// `PauseTargetId::Kind("audio")` because `"audio"` is not a `WorkKind`.
+///
+/// Wire shape (preserved for backwards compatibility with the pre-#34
+/// `(target, id)` body):
+/// ```json
+/// { "target": "kind",    "id": "transcribe" }
+/// { "target": "capture", "id": "audio" }
+/// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum PauseTarget {
-    Kind,
-    Capture,
+#[serde(tag = "target", content = "id", rename_all = "snake_case")]
+pub enum PauseTargetId {
+    Kind(WorkKind),
+    Capture(CaptureKind),
+}
+
+impl PauseTargetId {
+    /// Storage-layer projection: `("kind"|"capture", snake_case_id)`.
+    /// Used by `SqlPauseStore` to keep the on-disk schema unchanged
+    /// across the #34 refactor.
+    pub fn as_storage_pair(&self) -> (&'static str, &'static str) {
+        match self {
+            PauseTargetId::Kind(k) => ("kind", k.as_str()),
+            PauseTargetId::Capture(c) => ("capture", c.as_str()),
+        }
+    }
+}
+
+impl WorkKind {
+    /// snake_case wire/storage id (matches `#[serde(rename_all)]`).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            WorkKind::Transcribe => "transcribe",
+            WorkKind::Ocr => "ocr",
+            WorkKind::Summarize => "summarize",
+            WorkKind::ExtractMemory => "extract_memory",
+            WorkKind::ExtractActionItems => "extract_action_items",
+        }
+    }
+}
+
+impl CaptureKind {
+    /// snake_case wire/storage id (matches `#[serde(rename_all)]`).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            CaptureKind::Audio => "audio",
+            CaptureKind::Screen => "screen",
+        }
+    }
 }
 
 /// macOS thermal pressure (mirrors `NSProcessInfo.ThermalState`).
@@ -145,20 +192,24 @@ pub struct ActivitySnapshot {
 }
 
 /// POST /v1/activity/pause body.
+///
+/// Issue #34: the `(target, id)` pair is now a typed `PauseTargetId` sum
+/// type — `serde(flatten)` keeps the wire shape `{target, id, minutes}`
+/// identical, but illegal combinations like `target=kind, id="audio"`
+/// no longer deserialize. `NonZeroU32` likewise rejects `minutes: 0` at
+/// the serde layer, so the route handler no longer needs a manual check.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PauseRequest {
-    pub target: PauseTarget,
-    /// Either a `WorkKind` snake_case string (when `target=kind`) or
-    /// `"audio"` / `"screen"` (when `target=capture`).
-    pub id: String,
-    pub minutes: u32,
+    #[serde(flatten)]
+    pub target: PauseTargetId,
+    pub minutes: NonZeroU32,
 }
 
 /// POST /v1/activity/resume body.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ResumeRequest {
-    pub target: PauseTarget,
-    pub id: String,
+    #[serde(flatten)]
+    pub target: PauseTargetId,
 }
 
 /// POST /v1/activity/_internal/inflight body (Swift → Rust loopback).

--- a/Backend-Rust/api/src/routes/activity.rs
+++ b/Backend-Rust/api/src/routes/activity.rs
@@ -183,34 +183,17 @@ pub async fn inflight(
     State(state): State<AppState>,
     Json(body): Json<InflightUpdate>,
 ) -> Result<StatusCode, StatusCode> {
-    let kind = parse_work_kind(&body.kind).ok_or(StatusCode::BAD_REQUEST)?;
-    state.inflight.update(kind, body.in_flight);
+    // PR #39 review: `body.kind` is a typed `WorkKind` — serde's
+    // `rename_all = "snake_case"` rejects any unknown variant at
+    // the parse layer (returns 400/422), so no manual guard needed.
+    state.inflight.update(body.kind, body.in_flight);
     Ok(StatusCode::NO_CONTENT)
-}
-
-fn parse_work_kind(s: &str) -> Option<WorkKind> {
-    match s {
-        "transcribe" => Some(WorkKind::Transcribe),
-        "ocr" => Some(WorkKind::Ocr),
-        "summarize" => Some(WorkKind::Summarize),
-        "extract_memory" => Some(WorkKind::ExtractMemory),
-        "extract_action_items" => Some(WorkKind::ExtractActionItems),
-        _ => None,
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::num::NonZeroU32;
-
-    #[test]
-    fn parse_work_kind_round_trip() {
-        for k in ALL_KINDS {
-            assert_eq!(parse_work_kind(k.as_str()), Some(k));
-        }
-        assert_eq!(parse_work_kind("nope"), None);
-    }
 
     // --- Issue #34: wire-format round-trip for `PauseTargetId` ---
     //

--- a/Backend-Rust/api/src/routes/activity.rs
+++ b/Backend-Rust/api/src/routes/activity.rs
@@ -15,8 +15,8 @@ use serde_json::json;
 
 use crate::activity::traits::PauseStoreError;
 use crate::activity::types::{
-    ActivitySnapshot, CaptureKind, CaptureRow, InflightUpdate, KindRow, PauseRequest, PauseTarget,
-    ResumeRequest, WorkKind,
+    ActivitySnapshot, CaptureKind, CaptureRow, InflightUpdate, KindRow, PauseRequest,
+    PauseTargetId, ResumeRequest, WorkKind,
 };
 use crate::state::{AppState, PauseChange};
 
@@ -32,23 +32,6 @@ const ALL_KINDS: [WorkKind; 5] = [
 ];
 
 const ALL_CAPTURES: [CaptureKind; 2] = [CaptureKind::Audio, CaptureKind::Screen];
-
-fn kind_id(k: WorkKind) -> &'static str {
-    match k {
-        WorkKind::Transcribe => "transcribe",
-        WorkKind::Ocr => "ocr",
-        WorkKind::Summarize => "summarize",
-        WorkKind::ExtractMemory => "extract_memory",
-        WorkKind::ExtractActionItems => "extract_action_items",
-    }
-}
-
-fn capture_id(c: CaptureKind) -> &'static str {
-    match c {
-        CaptureKind::Audio => "audio",
-        CaptureKind::Screen => "screen",
-    }
-}
 
 /// `GET /v1/activity/snapshot` — full live snapshot.
 pub async fn snapshot(
@@ -89,7 +72,9 @@ pub async fn snapshot(
             queued: 0,
             failed: 0,
             last_done_at: None,
-            paused_until: state.pause_store.paused_until(PauseTarget::Kind, kind_id(*k)),
+            paused_until: state
+                .pause_store
+                .paused_until(&PauseTargetId::Kind(*k)),
         })
         .collect();
 
@@ -98,7 +83,7 @@ pub async fn snapshot(
         .map(|c| {
             let paused = state
                 .pause_store
-                .paused_until(PauseTarget::Capture, capture_id(*c));
+                .paused_until(&PauseTargetId::Capture(*c));
             CaptureRow {
                 kind: *c,
                 // We don't yet observe live capture state from the Rust daemon
@@ -120,27 +105,13 @@ pub async fn snapshot(
     }))
 }
 
-/// Resolve a `PauseRequest`/`ResumeRequest` `id` against its `target`. The
-/// id space is tiny and validated server-side so the Swift caller can't
-/// pause an unknown kind.
-fn validate_target_id(target: PauseTarget, id: &str) -> Result<(), StatusCode> {
-    match target {
-        PauseTarget::Kind => {
-            if ALL_KINDS.iter().any(|k| kind_id(*k) == id) {
-                Ok(())
-            } else {
-                Err(StatusCode::BAD_REQUEST)
-            }
-        }
-        PauseTarget::Capture => {
-            if ALL_CAPTURES.iter().any(|c| capture_id(*c) == id) {
-                Ok(())
-            } else {
-                Err(StatusCode::BAD_REQUEST)
-            }
-        }
-    }
-}
+// Issue #34: `validate_target_id` was deleted. The combination of
+// `PauseTargetId` (a sum type whose variants carry typed `WorkKind` /
+// `CaptureKind` payloads) and serde's `tag/content` deserialization
+// rejects any unknown `target` or `id` at the parse layer, returning
+// 400/422 to the caller automatically. The route handlers no longer
+// need a runtime guard — the type system enforces what this used to
+// check.
 
 /// Map `PauseStoreError` to a 5xx response with structured JSON detail
 /// (consensus-fix C3) so the Swift caller can show the real failure
@@ -156,25 +127,23 @@ fn pause_store_error_response(e: PauseStoreError) -> (StatusCode, Json<serde_jso
 }
 
 /// `POST /v1/activity/pause` — pause a kind or live capture for N minutes.
+///
+/// Issue #34: serde rejects `minutes: 0` (`NonZeroU32`) and unknown
+/// `target`/`id` combinations (typed `PauseTargetId` sum). No manual
+/// validation lives here anymore.
 pub async fn pause(
     State(state): State<AppState>,
     Json(body): Json<PauseRequest>,
 ) -> Result<Json<serde_json::Value>, axum::response::Response> {
-    if body.minutes == 0 {
-        return Err(StatusCode::BAD_REQUEST.into_response());
-    }
-    validate_target_id(body.target, &body.id).map_err(|s| s.into_response())?;
-
     let resume_at = state
         .pause_store
-        .pause(body.target, &body.id, body.minutes)
+        .pause(&body.target, body.minutes)
         .map_err(|e| pause_store_error_response(e).into_response())?;
 
     // Best-effort fanout. No subscribers = ok; the Swift poller still
     // refreshes on its 1s tick.
     let _ = state.pause_tx.send(PauseChange {
         target: body.target,
-        id: body.id.clone(),
         paused_until: Some(resume_at),
     });
 
@@ -188,11 +157,9 @@ pub async fn resume(
     State(state): State<AppState>,
     Json(body): Json<ResumeRequest>,
 ) -> Result<StatusCode, axum::response::Response> {
-    validate_target_id(body.target, &body.id).map_err(|s| s.into_response())?;
-
     let was_paused = state
         .pause_store
-        .resume(body.target, &body.id)
+        .resume(&body.target)
         .map_err(|e| pause_store_error_response(e).into_response())?;
 
     // Only fan out a notification if a row was actually deleted — otherwise
@@ -200,7 +167,6 @@ pub async fn resume(
     if was_paused {
         let _ = state.pause_tx.send(PauseChange {
             target: body.target,
-            id: body.id.clone(),
             paused_until: None,
         });
     }
@@ -236,27 +202,106 @@ fn parse_work_kind(s: &str) -> Option<WorkKind> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::num::NonZeroU32;
 
     #[test]
     fn parse_work_kind_round_trip() {
         for k in ALL_KINDS {
-            assert_eq!(parse_work_kind(kind_id(k)), Some(k));
+            assert_eq!(parse_work_kind(k.as_str()), Some(k));
         }
         assert_eq!(parse_work_kind("nope"), None);
     }
 
+    // --- Issue #34: wire-format round-trip for `PauseTargetId` ---
+    //
+    // The `validate_target_id` helper used to live here; it's gone now.
+    // These tests instead cover what replaced it — the typed sum +
+    // `serde(tag/content/flatten)` pattern that makes invalid combos
+    // unrepresentable at the deserialization layer.
+
     #[test]
-    fn validate_target_id_accepts_known() {
-        assert!(validate_target_id(PauseTarget::Kind, "ocr").is_ok());
-        assert!(validate_target_id(PauseTarget::Capture, "audio").is_ok());
-        assert!(validate_target_id(PauseTarget::Capture, "screen").is_ok());
+    fn pause_request_decodes_every_workkind() {
+        for k in ALL_KINDS {
+            let json = format!(
+                r#"{{"target":"kind","id":"{}","minutes":5}}"#,
+                k.as_str()
+            );
+            let req: PauseRequest =
+                serde_json::from_str(&json).expect("valid kind body must decode");
+            assert_eq!(req.target, PauseTargetId::Kind(k));
+            assert_eq!(req.minutes, NonZeroU32::new(5).unwrap());
+        }
     }
 
     #[test]
-    fn validate_target_id_rejects_unknown() {
-        assert!(validate_target_id(PauseTarget::Kind, "audio").is_err());
-        assert!(validate_target_id(PauseTarget::Capture, "ocr").is_err());
-        assert!(validate_target_id(PauseTarget::Kind, "").is_err());
+    fn pause_request_decodes_every_capturekind() {
+        for c in ALL_CAPTURES {
+            let json = format!(
+                r#"{{"target":"capture","id":"{}","minutes":5}}"#,
+                c.as_str()
+            );
+            let req: PauseRequest =
+                serde_json::from_str(&json).expect("valid capture body must decode");
+            assert_eq!(req.target, PauseTargetId::Capture(c));
+        }
     }
 
+    #[test]
+    fn pause_request_rejects_zero_minutes_via_serde() {
+        // NonZeroU32 makes `minutes: 0` unrepresentable — serde rejects.
+        let err = serde_json::from_str::<PauseRequest>(
+            r#"{"target":"kind","id":"ocr","minutes":0}"#,
+        );
+        assert!(err.is_err(), "minutes=0 must fail at the serde layer");
+    }
+
+    #[test]
+    fn pause_request_rejects_kind_with_capture_id() {
+        // `target=kind` + `id="audio"` is unrepresentable — `WorkKind`
+        // does not have an `audio` variant.
+        let err =
+            serde_json::from_str::<PauseRequest>(r#"{"target":"kind","id":"audio","minutes":5}"#);
+        assert!(err.is_err(), "kind+audio must fail at the serde layer");
+    }
+
+    #[test]
+    fn pause_request_rejects_capture_with_kind_id() {
+        let err = serde_json::from_str::<PauseRequest>(
+            r#"{"target":"capture","id":"ocr","minutes":5}"#,
+        );
+        assert!(err.is_err(), "capture+ocr must fail at the serde layer");
+    }
+
+    #[test]
+    fn pause_request_rejects_unknown_target() {
+        let err = serde_json::from_str::<PauseRequest>(
+            r#"{"target":"nope","id":"ocr","minutes":5}"#,
+        );
+        assert!(err.is_err(), "unknown target must fail at the serde layer");
+    }
+
+    #[test]
+    fn pause_request_serializes_to_flat_wire_shape() {
+        // Re-serializing must produce the legacy `{target, id, minutes}`
+        // shape so the wire format is unchanged.
+        let req = PauseRequest {
+            target: PauseTargetId::Kind(WorkKind::Ocr),
+            minutes: NonZeroU32::new(15).unwrap(),
+        };
+        let s = serde_json::to_string(&req).unwrap();
+        // Order is not guaranteed, but the keys + values must be present.
+        assert!(s.contains(r#""target":"kind""#), "got: {s}");
+        assert!(s.contains(r#""id":"ocr""#), "got: {s}");
+        assert!(s.contains(r#""minutes":15"#), "got: {s}");
+    }
+
+    #[test]
+    fn resume_request_round_trips_for_capture() {
+        let req: ResumeRequest =
+            serde_json::from_str(r#"{"target":"capture","id":"audio"}"#).unwrap();
+        assert_eq!(req.target, PauseTargetId::Capture(CaptureKind::Audio));
+        let s = serde_json::to_string(&req).unwrap();
+        assert!(s.contains(r#""target":"capture""#), "got: {s}");
+        assert!(s.contains(r#""id":"audio""#), "got: {s}");
+    }
 }

--- a/Backend-Rust/api/src/state.rs
+++ b/Backend-Rust/api/src/state.rs
@@ -8,10 +8,13 @@ use crate::db::SqlitePool;
 /// Notification payload broadcast when a pause/resume is applied so other
 /// subsystems (e.g. the Swift `CapturePauseGate` poller) can refresh
 /// without waiting for their next poll tick.
+///
+/// Issue #34: `target` is now a typed `PauseTargetId` carrying both the
+/// kind/capture discriminator and its concrete payload, so subscribers
+/// no longer have to redo string→variant parsing on every change.
 #[derive(Debug, Clone)]
 pub struct PauseChange {
-    pub target: crate::activity::PauseTarget,
-    pub id: String,
+    pub target: crate::activity::PauseTargetId,
     /// `None` = resumed/cleared. `Some(t)` = paused until `t`.
     pub paused_until: Option<chrono::DateTime<chrono::Utc>>,
 }

--- a/Backend-Rust/api/tests/activity_endpoints.rs
+++ b/Backend-Rust/api/tests/activity_endpoints.rs
@@ -74,6 +74,7 @@
 // =====================================================================
 
 use std::collections::HashMap;
+use std::num::NonZeroU32;
 use std::sync::{Arc, Mutex, RwLock};
 
 use axum::body::{to_bytes, Body};
@@ -86,11 +87,15 @@ use infinite_recall_api::activity::traits::{
     InflightRegistry, PauseStore, PauseStoreError, ProcessingGate, ResourceSampler,
 };
 use infinite_recall_api::activity::types::{
-    GateReason, GateState, InFlight, PauseTarget, ProcessBreakdown,
+    CaptureKind, GateReason, GateState, InFlight, PauseTargetId, ProcessBreakdown,
     ResourceSample, ThermalState, WorkKind,
 };
 use infinite_recall_api::routes;
 use infinite_recall_api::state::AppState;
+
+fn nz(n: u32) -> NonZeroU32 {
+    NonZeroU32::new(n).expect("test minutes must be non-zero")
+}
 
 // ---------------------------------------------------------------------
 // Stub implementations
@@ -99,8 +104,11 @@ use infinite_recall_api::state::AppState;
 /// Minimal in-memory `PauseStore` used when Stream B's SQLite impl is not
 /// the unit under test. For persistence test, use Stream B's `SqlPauseStore`
 /// directly (see `pause_persists_across_restart`).
+///
+/// Issue #34: keys are `PauseTargetId` directly — no string `id` column,
+/// no risk of `Kind`+`"audio"` slipping through.
 struct MemPauseStore {
-    inner: Mutex<HashMap<(PauseTarget, String), DateTime<Utc>>>,
+    inner: Mutex<HashMap<PauseTargetId, DateTime<Utc>>>,
 }
 
 impl MemPauseStore {
@@ -112,35 +120,22 @@ impl MemPauseStore {
 }
 
 impl PauseStore for MemPauseStore {
-    fn paused_until(&self, target: PauseTarget, id: &str) -> Option<DateTime<Utc>> {
-        self.inner
-            .lock()
-            .unwrap()
-            .get(&(target, id.to_string()))
-            .copied()
+    fn paused_until(&self, target: &PauseTargetId) -> Option<DateTime<Utc>> {
+        self.inner.lock().unwrap().get(target).copied()
     }
 
     fn pause(
         &self,
-        target: PauseTarget,
-        id: &str,
-        minutes: u32,
+        target: &PauseTargetId,
+        minutes: NonZeroU32,
     ) -> Result<DateTime<Utc>, PauseStoreError> {
-        let resume_at = Utc::now() + Duration::minutes(minutes as i64);
-        self.inner
-            .lock()
-            .unwrap()
-            .insert((target, id.to_string()), resume_at);
+        let resume_at = Utc::now() + Duration::minutes(i64::from(minutes.get()));
+        self.inner.lock().unwrap().insert(*target, resume_at);
         Ok(resume_at)
     }
 
-    fn resume(&self, target: PauseTarget, id: &str) -> Result<bool, PauseStoreError> {
-        let removed = self
-            .inner
-            .lock()
-            .unwrap()
-            .remove(&(target, id.to_string()))
-            .is_some();
+    fn resume(&self, target: &PauseTargetId) -> Result<bool, PauseStoreError> {
+        let removed = self.inner.lock().unwrap().remove(target).is_some();
         Ok(removed)
     }
 }
@@ -449,7 +444,7 @@ async fn pause_persists_across_restart() {
     {
         let store = SqlPauseStore::open(&path).expect("open SqlPauseStore");
         let resume_at = store
-            .pause(PauseTarget::Kind, "ocr", 30)
+            .pause(&PauseTargetId::Kind(WorkKind::Ocr), nz(30))
             .expect("pause should persist");
         assert!(resume_at > Utc::now());
         // store dropped here.
@@ -459,7 +454,7 @@ async fn pause_persists_across_restart() {
     {
         let store = SqlPauseStore::open(&path).expect("re-open SqlPauseStore");
         let pu = store
-            .paused_until(PauseTarget::Kind, "ocr")
+            .paused_until(&PauseTargetId::Kind(WorkKind::Ocr))
             .expect("pause must survive restart");
         let delta = pu - Utc::now();
         assert!(
@@ -484,9 +479,11 @@ async fn resume_clears_pause() {
     let (k, v) = auth_header();
 
     pause_store
-        .pause(PauseTarget::Kind, "ocr", 5)
+        .pause(&PauseTargetId::Kind(WorkKind::Ocr), nz(5))
         .expect("pause ok");
-    assert!(pause_store.paused_until(PauseTarget::Kind, "ocr").is_some());
+    assert!(pause_store
+        .paused_until(&PauseTargetId::Kind(WorkKind::Ocr))
+        .is_some());
 
     let req = Request::builder()
         .method(Method::POST)
@@ -498,7 +495,9 @@ async fn resume_clears_pause() {
     let resp = app.oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::NO_CONTENT);
     assert!(
-        pause_store.paused_until(PauseTarget::Kind, "ocr").is_none(),
+        pause_store
+            .paused_until(&PauseTargetId::Kind(WorkKind::Ocr))
+            .is_none(),
         "resume must clear the row"
     );
 }
@@ -652,12 +651,180 @@ async fn enum_round_trip_via_wire() {
         assert_eq!(s, format!("\"{wire}\""));
     }
 
-    // PauseTarget.
-    for (pt, wire) in [
-        (t::PauseTarget::Kind, "kind"),
-        (t::PauseTarget::Capture, "capture"),
+    // Issue #34: `PauseTargetId` is a sum type that serializes via
+    // serde(tag/content) — exercise every variant's wire form.
+    for kind in [
+        t::WorkKind::Transcribe,
+        t::WorkKind::Ocr,
+        t::WorkKind::Summarize,
+        t::WorkKind::ExtractMemory,
+        t::WorkKind::ExtractActionItems,
     ] {
+        let pt = t::PauseTargetId::Kind(kind);
         let s = serde_json::to_string(&pt).unwrap();
-        assert_eq!(s, format!("\"{wire}\""));
+        let expected = format!(r#"{{"target":"kind","id":"{}"}}"#, kind.as_str());
+        assert_eq!(s, expected, "PauseTargetId::Kind({kind:?}) wire shape");
+        let back: t::PauseTargetId = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, pt);
     }
+    for cap in [t::CaptureKind::Audio, t::CaptureKind::Screen] {
+        let pt = t::PauseTargetId::Capture(cap);
+        let s = serde_json::to_string(&pt).unwrap();
+        let expected = format!(r#"{{"target":"capture","id":"{}"}}"#, cap.as_str());
+        assert_eq!(s, expected, "PauseTargetId::Capture({cap:?}) wire shape");
+    }
+}
+
+// ---------------------------------------------------------------------
+// Issue #34 — `PauseRequest` / `ResumeRequest` wire-format coverage
+// ---------------------------------------------------------------------
+
+/// Pause body decodes for every `WorkKind` variant via the typed sum.
+#[tokio::test]
+async fn pause_kind_round_trip_for_every_variant() {
+    let app = make_default_app();
+    let (k, v) = auth_header();
+    for kind_str in [
+        "transcribe",
+        "ocr",
+        "summarize",
+        "extract_memory",
+        "extract_action_items",
+    ] {
+        let body = json!({"target":"kind","id":kind_str,"minutes":1});
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/v1/activity/pause")
+            .header(&k, v.clone())
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "pause kind {kind_str} should be accepted"
+        );
+    }
+}
+
+/// Pause body decodes for every `CaptureKind` variant via the typed sum.
+#[tokio::test]
+async fn pause_capture_round_trip_for_every_variant() {
+    let app = make_default_app();
+    let (k, v) = auth_header();
+    for cap_str in ["audio", "screen"] {
+        let body = json!({"target":"capture","id":cap_str,"minutes":2});
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/v1/activity/pause")
+            .header(&k, v.clone())
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "pause capture {cap_str} should be accepted"
+        );
+    }
+}
+
+/// `minutes: 0` is unrepresentable post-#34 — `NonZeroU32` rejects at the
+/// serde layer, which axum surfaces as a 4xx with no manual guard required.
+#[tokio::test]
+async fn pause_with_zero_minutes_is_4xx_from_serde() {
+    let app = make_default_app();
+    let (k, v) = auth_header();
+    let body = json!({"target":"kind","id":"ocr","minutes":0});
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/v1/activity/pause")
+        .header(k, v)
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert!(
+        resp.status().is_client_error(),
+        "minutes=0 must be rejected by serde; got {}",
+        resp.status()
+    );
+}
+
+/// `target=kind` + an unknown id (or one that belongs to the other variant)
+/// is unrepresentable — serde rejects at decode.
+#[tokio::test]
+async fn pause_with_unknown_target_id_is_4xx_from_serde() {
+    let app = make_default_app();
+    let (k, v) = auth_header();
+
+    // `Kind` variant cannot carry a `CaptureKind` id.
+    let cases = [
+        json!({"target":"kind","id":"audio","minutes":5}),
+        json!({"target":"kind","id":"nope","minutes":5}),
+        json!({"target":"capture","id":"ocr","minutes":5}),
+        json!({"target":"capture","id":"nope","minutes":5}),
+        json!({"target":"nope","id":"ocr","minutes":5}),
+    ];
+    for body in cases {
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/v1/activity/pause")
+            .header(&k, v.clone())
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert!(
+            resp.status().is_client_error(),
+            "expected 4xx for body {body:?}; got {}",
+            resp.status()
+        );
+    }
+}
+
+/// Resume body decodes for both kind and capture targets via the typed sum.
+#[tokio::test]
+async fn resume_round_trip_for_kind_and_capture() {
+    let pause_store: Arc<dyn PauseStore> = Arc::new(MemPauseStore::new());
+    let state = make_state(
+        pause_store.clone(),
+        Arc::new(MemInflight::new()),
+        Arc::new(FakeSampler),
+        Arc::new(FakeGate::allow()),
+    );
+    let app = routes::router(state);
+    let (k, v) = auth_header();
+
+    // Seed both a kind and capture pause.
+    pause_store
+        .pause(&PauseTargetId::Kind(WorkKind::Ocr), nz(5))
+        .unwrap();
+    pause_store
+        .pause(&PauseTargetId::Capture(CaptureKind::Audio), nz(5))
+        .unwrap();
+
+    for body in [
+        json!({"target":"kind","id":"ocr"}),
+        json!({"target":"capture","id":"audio"}),
+    ] {
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/v1/activity/resume")
+            .header(&k, v.clone())
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT, "body: {body}");
+    }
+
+    assert!(pause_store
+        .paused_until(&PauseTargetId::Kind(WorkKind::Ocr))
+        .is_none());
+    assert!(pause_store
+        .paused_until(&PauseTargetId::Capture(CaptureKind::Audio))
+        .is_none());
 }

--- a/Desktop/Sources/APIClient.swift
+++ b/Desktop/Sources/APIClient.swift
@@ -5153,7 +5153,7 @@ extension APIClient {
   /// POST /v1/activity/_internal/inflight — Swift→Rust loopback, called by
   /// Stream G's drain-loop wrapper to publish in-flight item labels into the
   /// snapshot. `inFlight = nil` clears the slot.
-  func reportInFlight(kind: String, inFlight: InFlight?) async throws {
+  func reportInFlight(kind: WorkKind, inFlight: InFlight?) async throws {
     let base = rustBackendURL
     guard !base.isEmpty, let url = URL(string: base + "v1/activity/_internal/inflight") else {
       throw APIError.invalidResponse

--- a/Desktop/Sources/APIClient.swift
+++ b/Desktop/Sources/APIClient.swift
@@ -5091,16 +5091,15 @@ extension APIClient {
   /// POST /v1/activity/pause — pause a kind or capture for `minutes` minutes.
   /// Returns the absolute resume time the daemon recorded (so UI can render
   /// a countdown that survives across restart).
-  func pauseActivity(target: String, id: String, minutes: Int) async throws -> Date {
+  ///
+  /// Issue #34: takes a typed `PauseTargetId` directly — no string coercion
+  /// at the call site. `PauseRequest.init` throws if `minutes == 0`.
+  func pauseActivity(target: PauseTargetId, minutes: UInt32) async throws -> Date {
     let base = rustBackendURL
     guard !base.isEmpty, let url = URL(string: base + "v1/activity/pause") else {
       throw APIError.invalidResponse
     }
-    let body = PauseRequest(
-      target: PauseTarget(rawValue: target) ?? .kind,
-      id: id,
-      minutes: UInt32(max(0, minutes))
-    )
+    let body = try PauseRequest(target: target, minutes: minutes)
 
     var request = URLRequest(url: url)
     request.httpMethod = "POST"
@@ -5126,15 +5125,14 @@ extension APIClient {
   }
 
   /// POST /v1/activity/resume — clear an active pause. 204 on success.
-  func resumeActivity(target: String, id: String) async throws {
+  ///
+  /// Issue #34: takes a typed `PauseTargetId` directly.
+  func resumeActivity(target: PauseTargetId) async throws {
     let base = rustBackendURL
     guard !base.isEmpty, let url = URL(string: base + "v1/activity/resume") else {
       throw APIError.invalidResponse
     }
-    let body = ResumeRequest(
-      target: PauseTarget(rawValue: target) ?? .kind,
-      id: id
-    )
+    let body = ResumeRequest(target: target)
 
     var request = URLRequest(url: url)
     request.httpMethod = "POST"

--- a/Desktop/Sources/Activity/ActivityModels.swift
+++ b/Desktop/Sources/Activity/ActivityModels.swift
@@ -25,9 +25,61 @@ public enum CaptureKind: String, Codable, CaseIterable, Hashable {
     case screen
 }
 
-public enum PauseTarget: String, Codable, Hashable {
-    case kind
-    case capture
+/// Issue #34: typed sum mirror of Rust's `PauseTargetId`. The variant
+/// payload carries the typed id (`WorkKind` or `CaptureKind`) so an
+/// illegal combination — e.g. `kind` + `"audio"` — is unrepresentable
+/// in Swift the same way it is in Rust.
+///
+/// Wire shape preserved (the pre-#34 `(target, id)` body):
+/// ```
+/// { "target": "kind",    "id": "transcribe" }
+/// { "target": "capture", "id": "audio" }
+/// ```
+public enum PauseTargetId: Codable, Hashable {
+    case kind(WorkKind)
+    case capture(CaptureKind)
+
+    enum CodingKeys: String, CodingKey {
+        case target
+        case id
+    }
+
+    /// Wire-format discriminator matching Rust's `serde(rename_all="snake_case")`.
+    private enum TargetTag: String, Codable {
+        case kind
+        case capture
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let tag = try c.decode(TargetTag.self, forKey: .target)
+        switch tag {
+        case .kind:
+            let work = try c.decode(WorkKind.self, forKey: .id)
+            self = .kind(work)
+        case .capture:
+            let cap = try c.decode(CaptureKind.self, forKey: .id)
+            self = .capture(cap)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .kind(let k):
+            try c.encode(TargetTag.kind, forKey: .target)
+            try c.encode(k, forKey: .id)
+        case .capture(let cap):
+            try c.encode(TargetTag.capture, forKey: .target)
+            try c.encode(cap, forKey: .id)
+        }
+    }
+}
+
+/// Validation error surfaced by `PauseRequest.init`. `minutes == 0` is
+/// the only condition; mirror's the Rust `NonZeroU32` deserialize check.
+public enum PauseRequestError: Error, Equatable {
+    case zeroMinutes
 }
 
 public enum ThermalState: String, Codable, Hashable {
@@ -234,25 +286,66 @@ public struct ActivitySnapshot: Codable, Hashable {
 
 // MARK: - Request bodies
 
+/// POST /v1/activity/pause body. Issue #34: `target` is a typed sum so
+/// `kind`+`"audio"` is unrepresentable; `minutes > 0` is checked in `init`
+/// to mirror Rust's `NonZeroU32`. The wire shape stays
+/// `{target, id, minutes}` because `PauseTargetId.encode(to:)` flattens
+/// its two keys directly into the request body.
 public struct PauseRequest: Codable {
-    public let target: PauseTarget
-    public let id: String
+    public let target: PauseTargetId
     public let minutes: UInt32
 
-    public init(target: PauseTarget, id: String, minutes: UInt32) {
+    /// Throwing init enforces the `minutes > 0` invariant up front so
+    /// the Rust daemon never sees a zero-minute pause.
+    public init(target: PauseTargetId, minutes: UInt32) throws {
+        guard minutes > 0 else { throw PauseRequestError.zeroMinutes }
         self.target = target
-        self.id = id
         self.minutes = minutes
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case minutes
+    }
+
+    public init(from decoder: Decoder) throws {
+        // Decode the flattened target/id pair from the same container, then
+        // pull `minutes` from the keyed view.
+        self.target = try PauseTargetId(from: decoder)
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let mins = try c.decode(UInt32.self, forKey: .minutes)
+        guard mins > 0 else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .minutes,
+                in: c,
+                debugDescription: "minutes must be > 0 (mirrors Rust NonZeroU32)"
+            )
+        }
+        self.minutes = mins
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        // Flatten target/id into the same encoder container as `minutes`.
+        try target.encode(to: encoder)
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(minutes, forKey: .minutes)
     }
 }
 
+/// POST /v1/activity/resume body. Wire shape `{target, id}` — `target` is
+/// a typed sum after #34.
 public struct ResumeRequest: Codable {
-    public let target: PauseTarget
-    public let id: String
+    public let target: PauseTargetId
 
-    public init(target: PauseTarget, id: String) {
+    public init(target: PauseTargetId) {
         self.target = target
-        self.id = id
+    }
+
+    public init(from decoder: Decoder) throws {
+        self.target = try PauseTargetId(from: decoder)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        try target.encode(to: encoder)
     }
 }
 

--- a/Desktop/Sources/Activity/ActivityModels.swift
+++ b/Desktop/Sources/Activity/ActivityModels.swift
@@ -350,7 +350,7 @@ public struct ResumeRequest: Codable {
 }
 
 public struct InflightUpdate: Codable {
-    public let kind: String
+    public let kind: WorkKind
     public let inFlight: InFlight?
 
     enum CodingKeys: String, CodingKey {
@@ -358,7 +358,7 @@ public struct InflightUpdate: Codable {
         case inFlight = "in_flight"
     }
 
-    public init(kind: String, inFlight: InFlight?) {
+    public init(kind: WorkKind, inFlight: InFlight?) {
         self.kind = kind
         self.inFlight = inFlight
     }

--- a/Desktop/Sources/Activity/ActivityMonitorService.swift
+++ b/Desktop/Sources/Activity/ActivityMonitorService.swift
@@ -132,10 +132,15 @@ public final class ActivityMonitorService: ObservableObject {
     /// returns success. On failure we set `lastError` and leave the
     /// snapshot untouched so the UI never silently rolls back.
     private func pause(target: PauseTargetId, minutes: Int) async {
-        // Issue #34: clamp to a valid `UInt32 > 0` before the typed
-        // `PauseRequest.init` does the same — surfaces a clean error
-        // instead of throwing across the actor boundary.
-        let mins = UInt32(max(1, minutes))
+        // Issue #34 (PR #39 review): a `minutes <= 0` value is a caller
+        // bug — surface it as a user-visible error instead of silently
+        // coercing to a 1-minute pause. Mirrors the throwing
+        // `PauseRequest.init` invariant (Rust's `NonZeroU32`).
+        guard minutes > 0 else {
+            self.lastError = "Pause failed: minutes must be greater than zero."
+            return
+        }
+        let mins = UInt32(minutes)
         do {
             let until = try await APIClient.shared.pauseActivity(
                 target: target,

--- a/Desktop/Sources/Activity/ActivityMonitorService.swift
+++ b/Desktop/Sources/Activity/ActivityMonitorService.swift
@@ -95,23 +95,23 @@ public final class ActivityMonitorService: ObservableObject {
     /// Pause a `WorkKind` row for `minutes` minutes. Optimistically updates
     /// the local snapshot and posts `pauseChanged`.
     public func pauseKind(_ kind: WorkKind, minutes: Int) async {
-        await pause(target: .kind, id: kind.rawValue, minutes: minutes)
+        await pause(target: .kind(kind), minutes: minutes)
     }
 
     /// Pause a capture row (audio/screen) for `minutes` minutes. UI is
     /// expected to have already shown the confirm sheet for `audio`.
     public func pauseCapture(_ capture: CaptureKind, minutes: Int) async {
-        await pause(target: .capture, id: capture.rawValue, minutes: minutes)
+        await pause(target: .capture(capture), minutes: minutes)
     }
 
     /// Resume a previously paused row.
     /// Consensus-fix C3: only mutate local state after the backend write
     /// succeeds. Previously we wrote optimistically and the next snapshot
     /// poll silently reverted on backend failure.
-    public func resume(target: PauseTarget, id: String) async {
+    public func resume(target: PauseTargetId) async {
         do {
-            try await APIClient.shared.resumeActivity(target: target.rawValue, id: id)
-            applyOptimisticPause(target: target, id: id, until: nil)
+            try await APIClient.shared.resumeActivity(target: target)
+            applyOptimisticPause(target: target, until: nil)
             postPauseChanged()
             self.lastError = nil
             await fetchOnce()
@@ -131,14 +131,17 @@ public final class ActivityMonitorService: ObservableObject {
     /// Consensus-fix C3: write to local state ONLY after the round-trip
     /// returns success. On failure we set `lastError` and leave the
     /// snapshot untouched so the UI never silently rolls back.
-    private func pause(target: PauseTarget, id: String, minutes: Int) async {
+    private func pause(target: PauseTargetId, minutes: Int) async {
+        // Issue #34: clamp to a valid `UInt32 > 0` before the typed
+        // `PauseRequest.init` does the same — surfaces a clean error
+        // instead of throwing across the actor boundary.
+        let mins = UInt32(max(1, minutes))
         do {
             let until = try await APIClient.shared.pauseActivity(
-                target: target.rawValue,
-                id: id,
-                minutes: minutes
+                target: target,
+                minutes: mins
             )
-            applyOptimisticPause(target: target, id: id, until: until)
+            applyOptimisticPause(target: target, until: until)
             postPauseChanged()
             self.lastError = nil
             await fetchOnce()
@@ -215,14 +218,16 @@ public final class ActivityMonitorService: ObservableObject {
     }
 
     /// Mutate `snapshot` in place to set/clear `paused_until` on the affected
-    /// row. Caller passes `until = nil` to clear (resume). No-op if there is
-    /// no current snapshot or the id doesn't resolve to a known kind/capture.
-    private func applyOptimisticPause(target: PauseTarget, id: String, until: Date?) {
+    /// row. Caller passes `until = nil` to clear (resume).
+    ///
+    /// Issue #34: takes a typed `PauseTargetId` directly — no string→enum
+    /// reverse lookup, and the type system prevents callers from passing an
+    /// id that doesn't belong to its variant.
+    private func applyOptimisticPause(target: PauseTargetId, until: Date?) {
         guard let current = snapshot else { return }
 
         switch target {
-        case .kind:
-            guard let kind = WorkKind(rawValue: id) else { return }
+        case .kind(let kind):
             let updatedKinds = current.kinds.map { row -> KindRow in
                 guard row.kind == kind else { return row }
                 return KindRow(
@@ -242,8 +247,7 @@ public final class ActivityMonitorService: ObservableObject {
                 generatedAt: current.generatedAt
             )
 
-        case .capture:
-            guard let cap = CaptureKind(rawValue: id) else { return }
+        case .capture(let cap):
             let updatedCapture = current.capture.map { row -> CaptureRow in
                 guard row.kind == cap else { return row }
                 return CaptureRow(

--- a/Desktop/Sources/Activity/ActivityPage.swift
+++ b/Desktop/Sources/Activity/ActivityPage.swift
@@ -371,7 +371,7 @@ struct ActivityPage: View {
         let isPaused = (row.pausedUntil ?? .distantPast) > tick
         if isPaused {
             Button("Resume") {
-                Task { await service.resume(target: .kind, id: row.kind.rawValue) }
+                Task { await service.resume(target: .kind(row.kind)) }
             }
             .buttonStyle(.borderless)
             .scaledFont(size: 12, weight: .medium)
@@ -447,7 +447,7 @@ struct ActivityPage: View {
             Spacer()
             if isPaused {
                 Button("Resume") {
-                    Task { await service.resume(target: .capture, id: row.kind.rawValue) }
+                    Task { await service.resume(target: .capture(row.kind)) }
                 }
                 .buttonStyle(.borderless)
                 .scaledFont(size: 12, weight: .medium)

--- a/Desktop/Sources/Power/BatteryAwareScheduler.swift
+++ b/Desktop/Sources/Power/BatteryAwareScheduler.swift
@@ -424,7 +424,7 @@ public final class BatteryAwareScheduler: ObservableObject {
       Task {
         do {
           try await APIClient.shared.reportInFlight(
-            kind: work.kind.rawValue,
+            kind: Self.toWireWorkKind(work.kind),
             inFlight: inflightEntry
           )
         } catch {
@@ -445,7 +445,7 @@ public final class BatteryAwareScheduler: ObservableObject {
         Task {
           do {
             try await APIClient.shared.reportInFlight(
-              kind: work.kind.rawValue,
+              kind: Self.toWireWorkKind(work.kind),
               inFlight: nil
             )
           } catch {
@@ -461,7 +461,7 @@ public final class BatteryAwareScheduler: ObservableObject {
         Task {
           do {
             try await APIClient.shared.reportInFlight(
-              kind: work.kind.rawValue,
+              kind: Self.toWireWorkKind(work.kind),
               inFlight: nil
             )
           } catch {
@@ -499,6 +499,22 @@ public final class BatteryAwareScheduler: ObservableObject {
       return true
     case .transcribe, .ocr, .extractMemory, .extractActionItems:
       return false
+    }
+  }
+
+  /// Map the scheduler's local `PendingWork.Kind` to the wire-level
+  /// `WorkKind` used by the activity API. PR #39 review: the loopback
+  /// inflight endpoint now takes a typed `WorkKind`, not a string, so
+  /// the conversion happens here at the boundary instead of being
+  /// implicit via `rawValue` (which would produce `"extractMemory"`
+  /// instead of the snake_case `"extract_memory"` the daemon expects).
+  fileprivate static func toWireWorkKind(_ kind: PendingWork.Kind) -> WorkKind {
+    switch kind {
+    case .transcribe: return .transcribe
+    case .ocr: return .ocr
+    case .summarize: return .summarize
+    case .extractMemory: return .extractMemory
+    case .extractActionItems: return .extractActionItems
     }
   }
 

--- a/Desktop/Tests/ActivityModelsTests.swift
+++ b/Desktop/Tests/ActivityModelsTests.swift
@@ -473,7 +473,7 @@ final class ActivityModelsTests: XCTestCase {
         // We assert Swift's actual behaviour here so a future encoder swap
         // (e.g. to one that emits explicit nulls) is a deliberate change with
         // a failing test as the heads-up.
-        let cleared = InflightUpdate(kind: "transcribe", inFlight: nil)
+        let cleared = InflightUpdate(kind: .transcribe, inFlight: nil)
         let data = try Self.makeEncoder().encode(cleared)
         let str = String(data: data, encoding: .utf8) ?? ""
         XCTAssertTrue(str.contains("\"kind\":\"transcribe\""), "got: \(str)")
@@ -485,14 +485,14 @@ final class ActivityModelsTests: XCTestCase {
 
         // Round-trip: the receiver must decode this back to nil.
         let decoded = try Self.makeDecoder().decode(InflightUpdate.self, from: data)
-        XCTAssertEqual(decoded.kind, "transcribe")
+        XCTAssertEqual(decoded.kind, .transcribe)
         XCTAssertNil(decoded.inFlight)
     }
 
     func testInflightUpdateEncodesPopulated() throws {
         let date = Self.isoFractional.date(from: "2026-04-26T14:22:03.812Z")!
         let upd = InflightUpdate(
-            kind: "transcribe",
+            kind: .transcribe,
             inFlight: InFlight(label: "Transcribing 14:22:01→14:25:00 (en)", startedAt: date)
         )
         let data = try Self.makeEncoder().encode(upd)

--- a/Desktop/Tests/ActivityModelsTests.swift
+++ b/Desktop/Tests/ActivityModelsTests.swift
@@ -12,10 +12,12 @@
 //   3. Optional fields are honoured in both directions (nullability,
 //      omission of `waiting_for`, `gpu_system_percent`, etc).
 //   4. Every `GateReason` enum value decodes from its snake_case wire form.
-//   5. Every `WorkKind`, `CaptureKind`, `ThermalState`, `PauseTarget`
+//   5. Every `WorkKind`, `CaptureKind`, `ThermalState`, `PauseTargetId`
 //      enum value decodes from its snake_case wire form.
 //   6. Request bodies (`PauseRequest`, `ResumeRequest`, `InflightUpdate`)
 //      encode to the wire shape Stream A expects.
+//   7. Issue #34: `PauseTargetId` sum type makes illegal `(target,id)`
+//      pairs unrepresentable; `PauseRequest.init` rejects `minutes == 0`.
 
 import XCTest
 @testable import Omi_Computer
@@ -329,20 +331,99 @@ final class ActivityModelsTests: XCTestCase {
         }
     }
 
-    func testPauseTargetEveryEnumValueRoundTrips() throws {
-        for (wire, expected) in [("kind", PauseTarget.kind), ("capture", .capture)] {
+    // Issue #34: `PauseTargetId` is a typed sum — every legal combination
+    // round-trips, every illegal combination fails to decode.
+
+    func testPauseTargetIdEveryKindRoundTrips() throws {
+        let cases: [(String, WorkKind)] = [
+            ("transcribe",            .transcribe),
+            ("ocr",                   .ocr),
+            ("summarize",             .summarize),
+            ("extract_memory",        .extractMemory),
+            ("extract_action_items",  .extractActionItems),
+        ]
+        for (wireId, expected) in cases {
             let json = """
-            { "target": "\(wire)", "id": "ocr", "minutes": 15 }
+            { "target": "kind", "id": "\(wireId)", "minutes": 15 }
             """
-            let req = try Self.makeDecoder().decode(PauseRequest.self, from: json.data(using: .utf8)!)
-            XCTAssertEqual(req.target, expected)
+            let req = try Self.makeDecoder()
+                .decode(PauseRequest.self, from: json.data(using: .utf8)!)
+            XCTAssertEqual(req.target, .kind(expected))
+            XCTAssertEqual(req.minutes, 15)
+
+            // Re-encoded body must round-trip through the same wire shape.
+            let data = try Self.makeEncoder().encode(req)
+            let s = String(data: data, encoding: .utf8) ?? ""
+            XCTAssertTrue(s.contains("\"target\":\"kind\""), "got: \(s)")
+            XCTAssertTrue(s.contains("\"id\":\"\(wireId)\""), "got: \(s)")
+            XCTAssertTrue(s.contains("\"minutes\":15"), "got: \(s)")
+        }
+    }
+
+    func testPauseTargetIdEveryCaptureRoundTrips() throws {
+        for (wireId, expected) in [("audio", CaptureKind.audio), ("screen", .screen)] {
+            let json = """
+            { "target": "capture", "id": "\(wireId)", "minutes": 5 }
+            """
+            let req = try Self.makeDecoder()
+                .decode(PauseRequest.self, from: json.data(using: .utf8)!)
+            XCTAssertEqual(req.target, .capture(expected))
+
+            let data = try Self.makeEncoder().encode(req)
+            let s = String(data: data, encoding: .utf8) ?? ""
+            XCTAssertTrue(s.contains("\"target\":\"capture\""), "got: \(s)")
+            XCTAssertTrue(s.contains("\"id\":\"\(wireId)\""), "got: \(s)")
+        }
+    }
+
+    func testPauseRequestRejectsKindWithCaptureId() {
+        // `kind`+`"audio"` is unrepresentable — WorkKind has no `audio`.
+        let json = """
+        { "target": "kind", "id": "audio", "minutes": 5 }
+        """
+        XCTAssertThrowsError(
+            try Self.makeDecoder().decode(PauseRequest.self, from: json.data(using: .utf8)!)
+        )
+    }
+
+    func testPauseRequestRejectsCaptureWithKindId() {
+        let json = """
+        { "target": "capture", "id": "ocr", "minutes": 5 }
+        """
+        XCTAssertThrowsError(
+            try Self.makeDecoder().decode(PauseRequest.self, from: json.data(using: .utf8)!)
+        )
+    }
+
+    func testPauseRequestRejectsUnknownTarget() {
+        let json = """
+        { "target": "nope", "id": "ocr", "minutes": 5 }
+        """
+        XCTAssertThrowsError(
+            try Self.makeDecoder().decode(PauseRequest.self, from: json.data(using: .utf8)!)
+        )
+    }
+
+    func testPauseRequestRejectsZeroMinutesInDecode() {
+        // Mirrors Rust's `NonZeroU32` reject at the deserialize layer.
+        let json = """
+        { "target": "kind", "id": "ocr", "minutes": 0 }
+        """
+        XCTAssertThrowsError(
+            try Self.makeDecoder().decode(PauseRequest.self, from: json.data(using: .utf8)!)
+        )
+    }
+
+    func testPauseRequestInitThrowsForZeroMinutes() {
+        XCTAssertThrowsError(try PauseRequest(target: .kind(.ocr), minutes: 0)) { err in
+            XCTAssertEqual(err as? PauseRequestError, .zeroMinutes)
         }
     }
 
     // MARK: - Request bodies serialise to wire shape Stream A expects
 
     func testPauseRequestEncodesSnakeCase() throws {
-        let req = PauseRequest(target: .kind, id: "ocr", minutes: 15)
+        let req = try PauseRequest(target: .kind(.ocr), minutes: 15)
         let data = try Self.makeEncoder().encode(req)
         let str = String(data: data, encoding: .utf8) ?? ""
         XCTAssertTrue(str.contains("\"target\":\"kind\""), "got: \(str)")
@@ -351,11 +432,37 @@ final class ActivityModelsTests: XCTestCase {
     }
 
     func testResumeRequestEncodesSnakeCase() throws {
-        let req = ResumeRequest(target: .capture, id: "audio")
+        let req = ResumeRequest(target: .capture(.audio))
         let data = try Self.makeEncoder().encode(req)
         let str = String(data: data, encoding: .utf8) ?? ""
         XCTAssertTrue(str.contains("\"target\":\"capture\""), "got: \(str)")
         XCTAssertTrue(str.contains("\"id\":\"audio\""),       "got: \(str)")
+    }
+
+    func testResumeRequestRoundTripsForEveryVariant() throws {
+        let kindCases: [(String, WorkKind)] = [
+            ("transcribe", .transcribe),
+            ("ocr", .ocr),
+            ("summarize", .summarize),
+            ("extract_memory", .extractMemory),
+            ("extract_action_items", .extractActionItems),
+        ]
+        for (wireId, kind) in kindCases {
+            let json = """
+            { "target": "kind", "id": "\(wireId)" }
+            """
+            let req = try Self.makeDecoder()
+                .decode(ResumeRequest.self, from: json.data(using: .utf8)!)
+            XCTAssertEqual(req.target, .kind(kind))
+        }
+        for (wireId, cap) in [("audio", CaptureKind.audio), ("screen", .screen)] {
+            let json = """
+            { "target": "capture", "id": "\(wireId)" }
+            """
+            let req = try Self.makeDecoder()
+                .decode(ResumeRequest.self, from: json.data(using: .utf8)!)
+            XCTAssertEqual(req.target, .capture(cap))
+        }
     }
 
     func testInflightUpdateEncodesNullClearing() throws {


### PR DESCRIPTION
## Summary

Make illegal pause targets unrepresentable on both sides of the wire (closes #34).

- **Rust**: `PauseTargetId` is now a typed sum (`#[serde(tag="target", content="id")]`) carrying the typed id payload (`WorkKind` or `CaptureKind`); `PauseRequest.minutes` is `NonZeroU32`. The `validate_target_id` helper and the `if minutes == 0` handler check are deleted — serde does both jobs at the boundary. `PauseStore` trait now takes `&PauseTargetId` + `NonZeroU32`; the SQL schema stays `(target TEXT, id TEXT)` via `as_storage_pair()` at the storage boundary.
- **Swift**: `PauseTargetId` mirrors the Rust sum with custom `Codable` that flattens to/from the same `{target, id}` wire shape. `PauseRequest.init` is throwing and rejects `minutes == 0`; `init(from:)` also rejects zero in the decode layer to mirror `NonZeroU32`. `pauseActivity(target:minutes:)` and `resumeActivity(target:)` take `PauseTargetId` directly.
- **Wire format unchanged**: `{ "target": "kind", "id": "ocr", "minutes": 15 }`.

## Test plan

- [x] `cargo build -p infinite-recall-api`
- [x] `cargo test -p infinite-recall-api --features activity_test_wiring` (37 unit + 14 integration tests pass)
- [x] `xcrun swift build -c debug --package-path Desktop`
- [x] `xcrun swift test --package-path Desktop --filter ActivityModelsTests` (24/24 pass)
- [x] Round-trip every `WorkKind` and `CaptureKind` variant on both sides
- [x] Serde rejects `kind`+`audio`, `capture`+`ocr`, unknown target, and zero minutes
- [x] Swift `PauseRequest.init` throwing-guard for zero minutes
- [x] `ResumeRequest` round-trips for every variant

🤖 Generated with [Claude Code](https://claude.com/claude-code)