### PR TITLE
activity: bridge Swift pending_work depths into Rust snapshot (closes #41)

### DIFF
--- a/Backend-Rust/api/src/routes/activity.rs
+++ b/Backend-Rust/api/src/routes/activity.rs
@@ -9,8 +9,12 @@
 //! impls are owned by Streams B/C/D and the idle-gate agent — the Phase 0
 //! contract (`activity/contract.md`) is the source of truth.
 
+use std::collections::HashMap;
+use std::sync::{Arc, OnceLock, RwLock};
+
 use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
 use chrono::Utc;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use crate::activity::traits::PauseStoreError;
@@ -32,6 +36,86 @@ const ALL_KINDS: [WorkKind; 5] = [
 ];
 
 const ALL_CAPTURES: [CaptureKind; 2] = [CaptureKind::Audio, CaptureKind::Screen];
+
+// ---------------------------------------------------------------------
+// Per-kind queue-depth state (Issue #41 — Lane 2)
+// ---------------------------------------------------------------------
+//
+// The Swift app owns the `pending_work` table; only it knows how many rows
+// are queued / failed for each `PendingWork.Kind`. Lane 4 pushes a frozen
+// snapshot of those counts via `POST /v1/activity/_internal/queue-depth`
+// (loopback-only, mirrors `_internal/inflight`). The snapshot handler reads
+// from this map when assembling each `KindRow`, defaulting to 0/0 so the
+// `/v1/activity/snapshot` shape stays valid before the first push.
+//
+// Frozen interface I1 (do NOT renegotiate):
+//
+//   { "depths": {
+//       "transcribe":         { "queued": 47, "failed": 0 },
+//       "ocr":                { "queued": 2,  "failed": 1 },
+//       "summarize":          { "queued": 0,  "failed": 0 },
+//       "extractMemory":      { "queued": 0,  "failed": 0 },
+//       "extractActionItems": { "queued": 0,  "failed": 0 }
+//   } }
+//
+// Keys are `PendingWork.Kind.rawValue` (camelCase, Swift-side), NOT the
+// snake_case wire form of `WorkKind`. We map between them in
+// `workkind_swift_raw_value` below.
+//
+// State is process-global rather than another `Arc<dyn …>` field on
+// `AppState` because (a) lane 2 is forbidden from editing `state.rs` and
+// (b) the data is purely a passive cache pushed in by Swift. Replace is
+// atomic: each POST swaps the entire map under a single write lock.
+
+/// One row of the queue-depth payload — `queued` and `failed` counts for a
+/// single `PendingWork.Kind`. Defaults to all-zeros for kinds Swift hasn't
+/// pushed yet.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct QueueDepth {
+    pub queued: u32,
+    pub failed: u32,
+}
+
+/// Body for `POST /v1/activity/_internal/queue-depth`. Matches frozen
+/// interface I1; the entire `depths` map replaces the previous state.
+#[derive(Debug, Clone, Deserialize)]
+pub struct QueueDepthUpdate {
+    pub depths: HashMap<String, QueueDepth>,
+}
+
+/// Process-global queue-depth state. `OnceLock` so the first reader/writer
+/// initializes the empty map; `RwLock` so the snapshot read path doesn't
+/// serialize against itself under load.
+fn queue_depths_state() -> &'static Arc<RwLock<HashMap<String, QueueDepth>>> {
+    static STATE: OnceLock<Arc<RwLock<HashMap<String, QueueDepth>>>> = OnceLock::new();
+    STATE.get_or_init(|| Arc::new(RwLock::new(HashMap::new())))
+}
+
+/// Snapshot of the current queue-depth map. Cloned under a read lock so
+/// callers never see a torn write. Falls back to an empty map on lock
+/// poisoning (a poisoned write means an earlier writer panicked; the data
+/// itself is still readable, but defaulting to empty here is the safer
+/// path — the snapshot just degrades to 0/0).
+fn queue_depths_snapshot() -> HashMap<String, QueueDepth> {
+    match queue_depths_state().read() {
+        Ok(g) => g.clone(),
+        Err(poisoned) => poisoned.into_inner().clone(),
+    }
+}
+
+/// Map a Rust `WorkKind` to the Swift `PendingWork.Kind.rawValue` string
+/// used as a key in the queue-depth payload. Frozen interface I1 — these
+/// strings are camelCase (Swift's default `RawRepresentable` derivation),
+/// NOT the snake_case `WorkKind::as_str()` wire form.
+fn workkind_swift_raw_value(k: WorkKind) -> &'static str {
+    match k {
+        WorkKind::Transcribe => "transcribe",
+        WorkKind::Ocr => "ocr",
+        WorkKind::Summarize => "summarize",
+        WorkKind::ExtractMemory => "extractMemory",
+        WorkKind::ExtractActionItems => "extractActionItems",
+    }
+}
 
 /// `GET /v1/activity/snapshot` — full live snapshot.
 pub async fn snapshot(
@@ -61,20 +145,29 @@ pub async fn snapshot(
         })?;
     let processing_gate = state.processing_gate.current();
 
+    // Per-kind queue depth + failure counters live in the Swift app's domain
+    // (PendingWork rows). Lane 4 pushes them via `_internal/queue-depth`; we
+    // read the latest atomic snapshot here and default to 0/0 for any kind
+    // Swift hasn't reported yet so the snapshot still works pre-first-push.
+    let depths_snap = queue_depths_snapshot();
+
     let kinds: Vec<KindRow> = ALL_KINDS
         .iter()
-        .map(|k| KindRow {
-            kind: *k,
-            in_flight: inflight_map.get(k).cloned(),
-            // Queue depth + failure counters live in the Swift app's domain
-            // (PendingWork rows). Until Stream G/F surface those into the
-            // Rust daemon, report 0/0 — the UI degrades gracefully.
-            queued: 0,
-            failed: 0,
-            last_done_at: None,
-            paused_until: state
-                .pause_store
-                .paused_until(&PauseTargetId::Kind(*k)),
+        .map(|k| {
+            let qd = depths_snap
+                .get(workkind_swift_raw_value(*k))
+                .copied()
+                .unwrap_or_default();
+            KindRow {
+                kind: *k,
+                in_flight: inflight_map.get(k).cloned(),
+                queued: qd.queued,
+                failed: qd.failed,
+                last_done_at: None,
+                paused_until: state
+                    .pause_store
+                    .paused_until(&PauseTargetId::Kind(*k)),
+            }
         })
         .collect();
 
@@ -188,6 +281,26 @@ pub async fn inflight(
     // the parse layer (returns 400/422), so no manual guard needed.
     state.inflight.update(body.kind, body.in_flight);
     Ok(StatusCode::NO_CONTENT)
+}
+
+/// `POST /v1/activity/_internal/queue-depth` — Swift → Rust loopback for
+/// per-`PendingWork.Kind` queue / failure counts (Issue #41 — frozen
+/// interface I1).
+///
+/// Same loopback enforcement as `_internal/inflight`: the daemon binds to
+/// 127.0.0.1 only (see `lib.rs::run`), and the route still passes through
+/// the bearer-auth middleware. Replaces the entire depths map atomically;
+/// no deltas, no per-key partial updates.
+pub async fn internal_queue_depth(
+    State(_state): State<AppState>,
+    Json(body): Json<QueueDepthUpdate>,
+) -> StatusCode {
+    let mut g = match queue_depths_state().write() {
+        Ok(g) => g,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    *g = body.depths;
+    StatusCode::NO_CONTENT
 }
 
 #[cfg(test)]

--- a/Backend-Rust/api/src/routes/mod.rs
+++ b/Backend-Rust/api/src/routes/mod.rs
@@ -51,6 +51,10 @@ pub fn router(state: AppState) -> Router {
         .route("/v1/activity/pause", post(activity::pause))
         .route("/v1/activity/resume", post(activity::resume))
         .route("/v1/activity/_internal/inflight", post(activity::inflight))
+        .route(
+            "/v1/activity/_internal/queue-depth",
+            post(activity::internal_queue_depth),
+        )
         // === /activity:A ===
         .route_layer(middleware::from_fn_with_state(
             state.clone(),

--- a/Backend-Rust/api/tests/activity_endpoints.rs
+++ b/Backend-Rust/api/tests/activity_endpoints.rs
@@ -612,6 +612,80 @@ async fn inflight_loopback_round_trip() {
     assert!(inflight.snapshot().get(&WorkKind::Transcribe).is_none());
 }
 
+/// Issue #41 — `_internal/queue-depth` updates the per-kind queue / failure
+/// counters; the next snapshot reflects them on the matching `KindRow`.
+///
+/// Validates the frozen interface I1 wire shape (camelCase keys mapped to
+/// `PendingWork.Kind.rawValue` on the Swift side) and confirms the
+/// snapshot route degrades to 0/0 for any kind Swift hasn't reported yet
+/// (here: `summarize`, which is omitted from the payload).
+#[tokio::test]
+async fn queue_depth_loopback_round_trip() {
+    let app = make_default_app();
+    let (k, v) = auth_header();
+
+    // Push the frozen-interface payload — note `summarize` is intentionally
+    // omitted so we can also assert the missing-key default.
+    let body = json!({
+        "depths": {
+            "transcribe":         { "queued": 47, "failed": 0 },
+            "ocr":                { "queued": 2,  "failed": 1 },
+            "extractMemory":      { "queued": 5,  "failed": 0 },
+            "extractActionItems": { "queued": 0,  "failed": 3 },
+        }
+    });
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/v1/activity/_internal/queue-depth")
+        .header(&k, v.clone())
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+    // Snapshot must surface the depths on each KindRow.
+    let snap_req = Request::builder()
+        .method(Method::GET)
+        .uri("/v1/activity/snapshot")
+        .header(k, v)
+        .body(Body::empty())
+        .unwrap();
+    let snap = json_body(app.oneshot(snap_req).await.unwrap()).await;
+    let kinds = snap["kinds"].as_array().expect("kinds is an array");
+
+    let row_for = |wire: &str| -> &Value {
+        kinds
+            .iter()
+            .find(|r| r["kind"] == wire)
+            .unwrap_or_else(|| panic!("snapshot missing row for `{wire}`"))
+    };
+
+    let transcribe = row_for("transcribe");
+    assert_eq!(transcribe["queued"], json!(47));
+    assert_eq!(transcribe["failed"], json!(0));
+
+    let ocr = row_for("ocr");
+    assert_eq!(ocr["queued"], json!(2));
+    assert_eq!(ocr["failed"], json!(1));
+
+    // `extract_memory` is the snake_case wire form for the WorkKind whose
+    // Swift rawValue is `extractMemory`.
+    let extract_memory = row_for("extract_memory");
+    assert_eq!(extract_memory["queued"], json!(5));
+    assert_eq!(extract_memory["failed"], json!(0));
+
+    let extract_action_items = row_for("extract_action_items");
+    assert_eq!(extract_action_items["queued"], json!(0));
+    assert_eq!(extract_action_items["failed"], json!(3));
+
+    // `summarize` was omitted from the payload — must default to 0/0
+    // rather than disappearing or crashing the snapshot.
+    let summarize = row_for("summarize");
+    assert_eq!(summarize["queued"], json!(0));
+    assert_eq!(summarize["failed"], json!(0));
+}
+
 /// Auth: missing bearer → 401.
 #[tokio::test]
 async fn missing_bearer_returns_401() {

--- a/Desktop/Sources/APIClient.swift
+++ b/Desktop/Sources/APIClient.swift
@@ -5204,7 +5204,7 @@ extension APIClient {
   /// Body shape (frozen interface I1):
   ///     { "depths": { "<kind.rawValue>": { "queued": N, "failed": M }, … } }
   ///
-  /// Returns when the daemon answers 204. Throws `APIError.invalidResponse`
+  /// Returns when the daemon answers 204. Throws `APIError.daemonNotConfigured`
   /// when `IR_API_URL` is unset (caller should treat that as "daemon not up").
   func reportQueueDepth(_ depths: [PendingWork.Kind: (queued: Int, failed: Int)]) async throws {
     let base = try rustBackendURL

--- a/Desktop/Sources/APIClient.swift
+++ b/Desktop/Sources/APIClient.swift
@@ -17,20 +17,29 @@ actor APIClient {
   // config/api-keys, Crisp, and local test subscription. All data CRUD,
   // chat AI, and title generation are on Python.
   // Set via IR_API_URL env var (in .env).
+  //
+  // Throws `APIError.daemonNotConfigured` when `IR_API_URL` is unset so a
+  // missing daemon configuration surfaces as a clear UI banner (via
+  // `ActivityMonitorService.lastError`) instead of cascading into a
+  // misleading HTTP 404 / "Invalid response from server". Display-only
+  // call sites (e.g. `SettingsPage`) that don't actually issue HTTP can
+  // use `try?` and fall back to "" — they just won't render a Rust URL.
   var rustBackendURL: String {
-    // First check getenv() for values set by setenv() in loadEnvironment()
-    if let cString = getenv("IR_API_URL"), let url = String(validatingUTF8: cString), !url.isEmpty
-    {
-      let normalized = url.hasSuffix("/") ? url : url + "/"
-      return normalized
+    get throws {
+      // First check getenv() for values set by setenv() in loadEnvironment()
+      if let cString = getenv("IR_API_URL"), let url = String(validatingUTF8: cString), !url.isEmpty
+      {
+        let normalized = url.hasSuffix("/") ? url : url + "/"
+        return normalized
+      }
+      // Fallback to ProcessInfo (launch-time snapshot)
+      if let envURL = ProcessInfo.processInfo.environment["IR_API_URL"], !envURL.isEmpty {
+        let normalized = envURL.hasSuffix("/") ? envURL : envURL + "/"
+        return normalized
+      }
+      NSLog("OMI API: IR_API_URL not set — Rust backend calls will fail")
+      throw APIError.daemonNotConfigured
     }
-    // Fallback to ProcessInfo (launch-time snapshot)
-    if let envURL = ProcessInfo.processInfo.environment["IR_API_URL"], !envURL.isEmpty {
-      let normalized = envURL.hasSuffix("/") ? envURL : envURL + "/"
-      return normalized
-    }
-    NSLog("OMI API: IR_API_URL not set — Rust backend calls will fail")
-    return ""
   }
 
   let session: URLSession
@@ -336,6 +345,10 @@ enum APIError: LocalizedError {
   // (e.g. wrapper structs with required fields). Stores should treat this as a
   // silent no-op, not an error to surface.
   case localOnlyMode
+  // Thrown by `APIClient.rustBackendURL` when `IR_API_URL` is unset. The
+  // Activity panel surfaces the localizedDescription so the user knows to
+  // re-run `scripts/run.sh` instead of seeing a misleading HTTP 404.
+  case daemonNotConfigured
 
   var errorDescription: String? {
     switch self {
@@ -349,6 +362,9 @@ enum APIError: LocalizedError {
       return "Failed to decode response: \(error.localizedDescription)"
     case .localOnlyMode:
       return "Local-only mode"
+    case .daemonNotConfigured:
+      return
+        "Infinite Recall daemon URL not configured (IR_API_URL is unset). Run scripts/run.sh to regenerate .env.app."
     }
   }
 }
@@ -4516,7 +4532,7 @@ extension APIClient {
 
   /// Provision a cloud agent VM for the current user (fire-and-forget)
   func provisionAgentVM() async throws -> AgentProvisionResponse {
-    return try await post("v2/agent/provision", customBaseURL: rustBackendURL)
+    return try await post("v2/agent/provision", customBaseURL: try rustBackendURL)
   }
 
   struct AgentStatusResponse: Decodable {
@@ -4531,7 +4547,7 @@ extension APIClient {
 
   /// Get current agent VM status
   func getAgentStatus() async throws -> AgentStatusResponse? {
-    return try await get("v2/agent/status", customBaseURL: rustBackendURL)
+    return try await get("v2/agent/status", customBaseURL: try rustBackendURL)
   }
 }
 
@@ -4772,7 +4788,7 @@ extension APIClient {
   }
 
   func fetchApiKeys() async throws -> ApiKeysResponse {
-    return try await get("v1/config/api-keys", customBaseURL: rustBackendURL)
+    return try await get("v1/config/api-keys", customBaseURL: try rustBackendURL)
   }
 
   // MARK: - TTS Proxy (issue #6622)
@@ -4810,7 +4826,7 @@ extension APIClient {
   /// Synthesize speech via the backend TTS proxy (ElevenLabs key stays server-side).
   /// Returns raw audio data (audio/mpeg).
   func synthesizeSpeech(request: TtsSynthesizeRequest) async throws -> Data {
-    let base = rustBackendURL
+    let base = try rustBackendURL
     let url = URL(string: base + "v1/tts/synthesize")!
     var urlRequest = URLRequest(url: url)
     urlRequest.httpMethod = "POST"
@@ -5068,8 +5084,11 @@ extension APIClient {
 
   /// GET /v1/activity/snapshot — full live activity snapshot for the UI.
   func getActivitySnapshot() async throws -> ActivitySnapshot {
-    let base = rustBackendURL
-    guard !base.isEmpty, let url = URL(string: base + "v1/activity/snapshot") else {
+    // `try rustBackendURL` throws `APIError.daemonNotConfigured` when
+    // `IR_API_URL` is unset so the UI can surface a clear configuration
+    // message instead of falling through to a generic HTTP 404.
+    let base = try rustBackendURL
+    guard let url = URL(string: base + "v1/activity/snapshot") else {
       throw APIError.invalidResponse
     }
     var request = URLRequest(url: url)
@@ -5095,8 +5114,8 @@ extension APIClient {
   /// Issue #34: takes a typed `PauseTargetId` directly — no string coercion
   /// at the call site. `PauseRequest.init` throws if `minutes == 0`.
   func pauseActivity(target: PauseTargetId, minutes: UInt32) async throws -> Date {
-    let base = rustBackendURL
-    guard !base.isEmpty, let url = URL(string: base + "v1/activity/pause") else {
+    let base = try rustBackendURL
+    guard let url = URL(string: base + "v1/activity/pause") else {
       throw APIError.invalidResponse
     }
     let body = try PauseRequest(target: target, minutes: minutes)
@@ -5128,8 +5147,8 @@ extension APIClient {
   ///
   /// Issue #34: takes a typed `PauseTargetId` directly.
   func resumeActivity(target: PauseTargetId) async throws {
-    let base = rustBackendURL
-    guard !base.isEmpty, let url = URL(string: base + "v1/activity/resume") else {
+    let base = try rustBackendURL
+    guard let url = URL(string: base + "v1/activity/resume") else {
       throw APIError.invalidResponse
     }
     let body = ResumeRequest(target: target)
@@ -5154,8 +5173,8 @@ extension APIClient {
   /// Stream G's drain-loop wrapper to publish in-flight item labels into the
   /// snapshot. `inFlight = nil` clears the slot.
   func reportInFlight(kind: WorkKind, inFlight: InFlight?) async throws {
-    let base = rustBackendURL
-    guard !base.isEmpty, let url = URL(string: base + "v1/activity/_internal/inflight") else {
+    let base = try rustBackendURL
+    guard let url = URL(string: base + "v1/activity/_internal/inflight") else {
       throw APIError.invalidResponse
     }
     let body = InflightUpdate(kind: kind, inFlight: inFlight)
@@ -5175,5 +5194,54 @@ extension APIClient {
       throw APIError.httpError(statusCode: http.statusCode)
     }
   }
+
+  /// POST /v1/activity/_internal/queue-depth — Swift→Rust loopback, called by
+  /// `BatteryAwareScheduler`'s debounced delegate listener whenever
+  /// `PendingWorkStorage` mutates. Pushes per-kind `(queued, failed)` counts
+  /// into the daemon's snapshot so the Activity panel reflects depth without
+  /// polling SQLite from Rust. Mirrors `reportInFlight` byte-for-byte.
+  ///
+  /// Body shape (frozen interface I1):
+  ///     { "depths": { "<kind.rawValue>": { "queued": N, "failed": M }, … } }
+  ///
+  /// Returns when the daemon answers 204. Throws `APIError.invalidResponse`
+  /// when `IR_API_URL` is unset (caller should treat that as "daemon not up").
+  func reportQueueDepth(_ depths: [PendingWork.Kind: (queued: Int, failed: Int)]) async throws {
+    let base = try rustBackendURL
+    guard let url = URL(string: base + "v1/activity/_internal/queue-depth") else {
+      throw APIError.invalidResponse
+    }
+
+    var encoded: [String: QueueDepthEntry] = [:]
+    for (kind, counts) in depths {
+      encoded[kind.rawValue] = QueueDepthEntry(queued: counts.queued, failed: counts.failed)
+    }
+    let body = QueueDepthUpdate(depths: encoded)
+
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.allHTTPHeaderFields = try activityHeaders()
+    request.httpBody = try Self.makeActivityEncoder().encode(body)
+    request.timeoutInterval = 5
+
+    let (_, response) = try await session.data(for: request)
+    guard let http = response as? HTTPURLResponse else {
+      throw APIError.invalidResponse
+    }
+    if http.statusCode == 401 { throw APIError.unauthorized }
+    guard (200...299).contains(http.statusCode) else {
+      throw APIError.httpError(statusCode: http.statusCode)
+    }
+  }
+}
+
+/// Wire shape for `POST /v1/activity/_internal/queue-depth` (interface I1).
+private struct QueueDepthEntry: Codable {
+  let queued: Int
+  let failed: Int
+}
+
+private struct QueueDepthUpdate: Codable {
+  let depths: [String: QueueDepthEntry]
 }
 // === /activity:F ===

--- a/Desktop/Sources/Activity/ActivityMonitorService.swift
+++ b/Desktop/Sources/Activity/ActivityMonitorService.swift
@@ -217,6 +217,12 @@ public final class ActivityMonitorService: ObservableObject {
             let snap = try await APIClient.shared.getActivitySnapshot()
             self.snapshot = snap
             self.lastError = nil
+        } catch APIError.daemonNotConfigured {
+            // Distinct UI message: tells the user the daemon URL is unset
+            // (almost always means `scripts/run.sh` wasn't re-run after a
+            // checkout), instead of letting it fall through to a misleading
+            // generic "HTTP error: 404" string.
+            self.lastError = APIError.daemonNotConfigured.localizedDescription
         } catch {
             self.lastError = "snapshot failed: \(error.localizedDescription)"
         }

--- a/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -8105,7 +8105,11 @@ struct SettingsContentView: View {
     guard let expectedPriceId = pendingSubscriptionPriceId else { return }
     let checkoutSessionId = pendingCheckoutSessionId
     let pythonBaseURL = await APIClient.shared.baseURL
-    let rustBaseURL = await APIClient.shared.rustBackendURL
+    // `rustBackendURL` throws `APIError.daemonNotConfigured` when `IR_API_URL`
+    // is unset; this code path only feeds `isLocalURL(...)` (a display-time
+    // check), so falling back to "" is safe — `isLocalURL("")` returns false
+    // and the caller no-ops the local-test-subscription path.
+    let rustBaseURL = (try? await APIClient.shared.rustBackendURL) ?? ""
 
     if let checkoutSessionId, isLocalURL(pythonBaseURL) {
       guard

--- a/Desktop/Sources/Power/BatteryAwareScheduler.swift
+++ b/Desktop/Sources/Power/BatteryAwareScheduler.swift
@@ -191,7 +191,43 @@ public final class BatteryAwareScheduler: ObservableObject {
   /// Worker tag embedded in `claimedBy` column so sweeper can identify orphans.
   private var workerTag: String { "PowerWorkBridge#\(ProcessInfo.processInfo.processIdentifier)" }
 
-  private init() {}
+  // MARK: - Queue-depth debouncer (Lane 4)
+
+  /// Coalesces a burst of `pendingWorkStorageDidMutate` callbacks into a
+  /// single Rust push. We pick 250 ms so a typical drain (ack → enqueue →
+  /// ack within tens of ms) emits exactly one POST while still feeling
+  /// instant in the Activity panel.
+  nonisolated fileprivate static let queueDepthDebounceMs: Int = 250
+
+  /// Nonisolated so the storage actor's executor (which calls
+  /// `pendingWorkStorageDidMutate`) can call `schedule()` without hopping
+  /// to the main actor first. Fire block is installed in `init()` so unit
+  /// tests that exercise the delegate without `start()` still get the
+  /// debounce path.
+  nonisolated private let queueDepthDebouncer = QueueDepthDebouncer(
+    debounceMs: BatteryAwareScheduler.queueDepthDebounceMs
+  )
+
+  private var didWireQueueDepthDelegate = false
+
+  #if DEBUG
+  /// Test hook: when set, `pushQueueDepthNow()` invokes this and returns
+  /// before touching `PendingWorkStorage` or `APIClient`. The debounce-test
+  /// uses it to count fires under rapid mutation without a live daemon.
+  internal var _testQueueDepthHook: (@Sendable () -> Void)?
+  #endif
+
+  private init() {
+    // Install the queue-depth debouncer's fire block now so a unit-test
+    // harness that exercises `pendingWorkStorageDidMutate` directly (without
+    // calling `start()`) still gets the debounce path. Production calls
+    // `start()`, which additionally registers us as the storage delegate.
+    queueDepthDebouncer.install { [weak self] in
+      Task { @MainActor in
+        await self?.pushQueueDepthNow()
+      }
+    }
+  }
 
   /// Wire up to the shared `PowerStateMonitor` and start watching for
   /// transitions. Idempotent.
@@ -277,6 +313,19 @@ public final class BatteryAwareScheduler: ObservableObject {
     // Seed lastAutonomousAllow from current state so the first tick doesn't
     // mistake "still false" for "just transitioned to false".
     self.lastAutonomousAllow = self.allowAutonomousAIWork
+
+    // Register with the storage actor so mutations push depth to the Rust
+    // daemon (debounced). Idempotent across repeated start() calls. Also
+    // emit one immediate hydration push so the Activity panel doesn't sit
+    // at "—" until the first mutation arrives.
+    if !didWireQueueDepthDelegate {
+      didWireQueueDepthDelegate = true
+      Task { [weak self] in
+        guard let self else { return }
+        await PendingWorkStorage.shared.setDelegate(self)
+        await self.pushQueueDepthNow()
+      }
+    }
   }
 
   /// Stop watching for transitions. Mainly for tests.
@@ -643,4 +692,101 @@ public final class BatteryAwareScheduler: ObservableObject {
     self.reevaluateAutonomousReadiness()
   }
   #endif
+
+  // MARK: - Queue-depth push (Lane 4)
+
+  /// Pull the latest depth summary from `PendingWorkStorage` and POST it to
+  /// the Rust daemon. Called from the debouncer's fire block and once at
+  /// `start()` for hydration. Errors are caught — `daemonNotConfigured`
+  /// (interface I2 from Lane 1) is logged at one line; everything else
+  /// flows through `ActivityReportLogger` like the inflight reporter.
+  fileprivate func pushQueueDepthNow() async {
+    #if DEBUG
+    if let hook = _testQueueDepthHook {
+      hook()
+      return
+    }
+    #endif
+
+    let summary: PendingWorkDepth
+    do {
+      summary = try await PendingWorkStorage.shared.depthSummary()
+    } catch {
+      log("BatteryAwareScheduler: depthSummary failed: \(error.localizedDescription)")
+      return
+    }
+
+    var depths: [PendingWork.Kind: (queued: Int, failed: Int)] = [:]
+    for kind in PendingWork.Kind.allCases {
+      depths[kind] = (
+        queued: summary.queued[kind.rawValue] ?? 0,
+        failed: summary.failed[kind.rawValue] ?? 0
+      )
+    }
+
+    do {
+      try await APIClient.shared.reportQueueDepth(depths)
+    } catch APIError.daemonNotConfigured {
+      log("BatteryAwareScheduler: daemon not configured; queue-depth push skipped")
+    } catch {
+      await ActivityReportLogger.shared.log(
+        error: error, context: "reportQueueDepth")
+    }
+  }
+}
+
+// MARK: - PendingWorkStorageDelegate (Lane 4)
+
+extension BatteryAwareScheduler: PendingWorkStorageDelegate {
+  /// Called from the `PendingWorkStorage` actor's executor after each
+  /// committed mutation. We bounce off the actor immediately and let the
+  /// debouncer coalesce bursts into one Rust push.
+  nonisolated func pendingWorkStorageDidMutate(_ storage: PendingWorkStorage) {
+    queueDepthDebouncer.schedule()
+  }
+}
+
+// MARK: - Queue-depth debouncer
+
+/// Cancel-and-reschedule debouncer dedicated to the queue-depth push. Owns
+/// a private serial `DispatchQueue` so mutator callbacks (which arrive on
+/// the storage actor's executor) don't contend with the main actor.
+///
+/// `@unchecked Sendable` is sound here because every read/write of `item`
+/// and `fireBlock` happens on `queue` (the same serial executor).
+fileprivate final class QueueDepthDebouncer: @unchecked Sendable {
+  private let queue = DispatchQueue(label: "BatteryAwareScheduler.queueDepth")
+  private var item: DispatchWorkItem?
+  private var fireBlock: (@Sendable () -> Void)?
+  private let debounceMs: Int
+
+  init(debounceMs: Int) {
+    self.debounceMs = debounceMs
+  }
+
+  /// Install (or replace) the closure invoked when the debounce window
+  /// closes. Must be called before `schedule()` produces an effect.
+  func install(fireBlock: @escaping @Sendable () -> Void) {
+    queue.async { [self] in
+      self.fireBlock = fireBlock
+    }
+  }
+
+  /// Cancel any pending work item and schedule a fresh one `debounceMs`
+  /// from now. Safe to call from any thread/actor.
+  func schedule() {
+    queue.async { [self] in
+      item?.cancel()
+      guard let fireBlock = fireBlock else {
+        // No fire block installed yet (scheduler hasn't called start()).
+        // Drop silently — the next mutation after start() will schedule.
+        return
+      }
+      let work = DispatchWorkItem {
+        fireBlock()
+      }
+      item = work
+      queue.asyncAfter(deadline: .now() + .milliseconds(debounceMs), execute: work)
+    }
+  }
 }

--- a/Desktop/Sources/Rewind/Core/PendingWorkStorage.swift
+++ b/Desktop/Sources/Rewind/Core/PendingWorkStorage.swift
@@ -17,6 +17,22 @@ enum PendingWorkStorageError: LocalizedError {
     }
 }
 
+// MARK: - Mutation delegate (frozen interface I3)
+
+/// Observes mutations to the `pending_work` table so listeners (e.g.
+/// `BatteryAwareScheduler`) can push fresh depth snapshots to the Rust
+/// daemon without polling.
+///
+/// Frozen contract:
+/// - Single method, no payload — listener calls `storage.depthSummary()` itself.
+/// - Fired AFTER each mutator's transaction commits, on the storage actor's
+///   own serial executor (no thread-hop).
+/// - NOT fired from read-only methods (`depthSummary`, `pendingCount`,
+///   `healthCounts`).
+protocol PendingWorkStorageDelegate: AnyObject {
+    func pendingWorkStorageDidMutate(_ storage: PendingWorkStorage)
+}
+
 // MARK: - Depth summary
 
 struct PendingWorkDepth {
@@ -58,7 +74,23 @@ actor PendingWorkStorage {
     // In-memory drop counter exposed via depthSummary (last-hour precision not required).
     private(set) var recentDrops: Int = 0
 
+    // Mutation observer (interface I3). Weak so listeners don't extend storage's lifetime.
+    weak var delegate: PendingWorkStorageDelegate?
+
     private init() {}
+
+    // MARK: - Delegate wiring
+
+    /// Set or clear the mutation delegate. Async because the actor owns the slot.
+    func setDelegate(_ delegate: PendingWorkStorageDelegate?) {
+        self.delegate = delegate
+    }
+
+    /// Fire the post-commit notification. Called from every mutator AFTER
+    /// `db.write { … }` returns, while still on the actor's serial executor.
+    private func notifyDidMutate() {
+        delegate?.pendingWorkStorageDidMutate(self)
+    }
 
     // MARK: - Cache management
 
@@ -142,6 +174,7 @@ actor PendingWorkStorage {
 
         // Update drop counter on actor-isolated side (after write closure returns).
         if wasCapped { recentDrops += 1 }
+        notifyDidMutate()
         return rowId
     }
 
@@ -158,7 +191,7 @@ actor PendingWorkStorage {
         let db = try await ensureInitialized()
         let now = Date()
 
-        return try await db.write { database -> PendingWork? in
+        let result: PendingWork? = try await db.write { database -> PendingWork? in
             let rows = try Row.fetchAll(database, sql: """
                 UPDATE pending_work
                 SET status = 'claimed',
@@ -195,6 +228,8 @@ actor PendingWorkStorage {
                 storageId: rowId
             )
         }
+        notifyDidMutate()
+        return result
     }
 
     // MARK: - Ack
@@ -210,6 +245,7 @@ actor PendingWorkStorage {
             """, arguments: [Date(), storageId])
         }
         log("PendingWorkStorage: ack id=\(storageId)")
+        notifyDidMutate()
     }
 
     // MARK: - Release claim (readiness loss)
@@ -239,6 +275,7 @@ actor PendingWorkStorage {
             """, arguments: [later, now, storageId])
         }
         log("PendingWorkStorage: released claim id=\(storageId) (no attempt counted)")
+        notifyDidMutate()
     }
 
     // MARK: - Dead-letter callback
@@ -315,6 +352,10 @@ actor PendingWorkStorage {
                 WHERE id = ?
             """, arguments: [newStatus, newAttempts, errorMsg, scheduledFor, now, storageId])
         }
+
+        // Fire delegate exactly once per fail() call, regardless of whether
+        // this transition lands in `failed` or `dead`.
+        notifyDidMutate()
 
         if newStatus == PendingWorkStatus.dead.rawValue {
             log("PendingWorkStorage: dead-lettered id=\(storageId) after \(newAttempts) attempts")

--- a/Desktop/Tests/APIClientRoutingTests.swift
+++ b/Desktop/Tests/APIClientRoutingTests.swift
@@ -113,29 +113,37 @@ final class APIClientRoutingTests: XCTestCase {
         XCTAssertEqual(url, "http://localhost:8080/")
     }
 
-    func testRustBackendURLReadsFromApiUrlEnvVar() async {
+    func testRustBackendURLReadsFromApiUrlEnvVar() async throws {
         setenv("IR_API_URL", "http://localhost:8787", 1)
         defer { unsetenv("IR_API_URL") }
         let client = APIClient()
-        let url = await client.rustBackendURL
+        let url = try await client.rustBackendURL
         XCTAssertEqual(url, "http://localhost:8787/")
     }
 
-    func testRustBackendURLReturnsEmptyWhenNotSet() async {
+    /// Was `testRustBackendURLReturnsEmptyWhenNotSet` — flipped to assert the
+    /// new throwing contract (see `APIError.daemonNotConfigured`).
+    func testRustBackendURLThrowsDaemonNotConfiguredWhenNotSet() async {
         unsetenv("IR_API_URL")
         let client = APIClient()
-        let url = await client.rustBackendURL
-        XCTAssertEqual(url, "")
+        do {
+            _ = try await client.rustBackendURL
+            XCTFail("Expected APIError.daemonNotConfigured to be thrown")
+        } catch APIError.daemonNotConfigured {
+            // Expected.
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
     }
 
-    func testBaseURLAndRustBackendURLAreIndependent() async {
+    func testBaseURLAndRustBackendURLAreIndependent() async throws {
         setenv("IR_PYTHON_API_URL", "http://python:8080", 1)
         setenv("IR_API_URL", "http://rust:8787", 1)
         defer { unsetenv("IR_PYTHON_API_URL"); unsetenv("IR_API_URL") }
 
         let client = APIClient()
         let base = await client.baseURL
-        let rust = await client.rustBackendURL
+        let rust = try await client.rustBackendURL
         XCTAssertEqual(base, "http://python:8080/")
         XCTAssertEqual(rust, "http://rust:8787/")
         XCTAssertNotEqual(base, rust)
@@ -501,6 +509,39 @@ final class APIClientRoutingTests: XCTestCase {
         assertRoutes(URLCapture.capturedRequests, host: "python-test", port: 9001,
                      pathContains: "v1/users/stats/chat-messages", method: "GET",
                      label: "getChatMessageCount")
+    }
+
+    // MARK: - APIError.daemonNotConfigured
+
+    /// Regression: when `IR_API_URL` is unset, `getActivitySnapshot` should
+    /// fail with the typed `APIError.daemonNotConfigured` instead of cascading
+    /// into `APIError.invalidResponse` (which renders to the user as a generic
+    /// "Invalid response from server" — or worse, an HTTP 404 once a
+    /// malformed URL escapes to the network layer).
+    func testGetActivitySnapshotThrowsDaemonNotConfiguredWhenIRApiUrlUnset() async {
+        // Override the setUp() seed: this single test needs the env var
+        // truly unset so the throwing-helper path is exercised.
+        unsetenv("IR_API_URL")
+        defer {
+            // Restore the routing-tests baseline so following tests still
+            // see the seeded value.
+            setenv("IR_API_URL", "http://rust-test:9002", 1)
+        }
+
+        let client = APIClient()
+        do {
+            _ = try await client.getActivitySnapshot()
+            XCTFail("Expected APIError.daemonNotConfigured to be thrown")
+        } catch APIError.daemonNotConfigured {
+            // Expected — also confirm the user-facing message is the one
+            // Lane 4 / the Activity panel will rely on.
+            XCTAssertEqual(
+                APIError.daemonNotConfigured.localizedDescription,
+                "Infinite Recall daemon URL not configured (IR_API_URL is unset). Run scripts/run.sh to regenerate .env.app."
+            )
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
     }
 }
 

--- a/Desktop/Tests/BatteryAwareSchedulerQueueDepthDebounceTests.swift
+++ b/Desktop/Tests/BatteryAwareSchedulerQueueDepthDebounceTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+@testable import Omi_Computer
+
+/// Verifies that `BatteryAwareScheduler`'s `PendingWorkStorageDelegate`
+/// conformance coalesces a burst of mutations into exactly one
+/// queue-depth push. We don't talk to the daemon — the scheduler exposes
+/// `_testQueueDepthHook` so the debounce-fire path runs without hitting
+/// `PendingWorkStorage.depthSummary()` or `APIClient.reportQueueDepth(_:)`.
+@MainActor
+final class BatteryAwareSchedulerQueueDepthDebounceTests: XCTestCase {
+
+    override func tearDown() {
+        BatteryAwareScheduler.shared._testQueueDepthHook = nil
+        super.tearDown()
+    }
+
+    /// Fire the delegate method N times rapidly within the 250 ms window
+    /// and assert the debounced fire block runs exactly once. The
+    /// scheduler's `pendingWorkStorageDidMutate` is `nonisolated` so
+    /// production callers (the storage actor) and this test path use the
+    /// identical entry.
+    func test_rapidMutationsCoalesceToSingleFire() async throws {
+        let scheduler = BatteryAwareScheduler.shared
+        let fireCount = FireCounter()
+        scheduler._testQueueDepthHook = { fireCount.increment() }
+
+        // Burst 10 mutations well under the 250 ms debounce window.
+        for _ in 0..<10 {
+            scheduler.pendingWorkStorageDidMutate(PendingWorkStorage.shared)
+        }
+
+        // Wait long enough for the debounce to elapse and the fire block
+        // to run on the main actor (debounce + scheduling slack).
+        try await Task.sleep(nanoseconds: 600_000_000)
+
+        XCTAssertEqual(fireCount.value, 1,
+                       "10 rapid mutations within the debounce window must produce exactly one push")
+    }
+
+    /// A second burst after the first has fired should produce a second
+    /// push — the debouncer is rearmable, not one-shot.
+    func test_secondBurstFiresAgain() async throws {
+        let scheduler = BatteryAwareScheduler.shared
+        let fireCount = FireCounter()
+        scheduler._testQueueDepthHook = { fireCount.increment() }
+
+        for _ in 0..<5 {
+            scheduler.pendingWorkStorageDidMutate(PendingWorkStorage.shared)
+        }
+        try await Task.sleep(nanoseconds: 600_000_000)
+        XCTAssertEqual(fireCount.value, 1)
+
+        for _ in 0..<5 {
+            scheduler.pendingWorkStorageDidMutate(PendingWorkStorage.shared)
+        }
+        try await Task.sleep(nanoseconds: 600_000_000)
+        XCTAssertEqual(fireCount.value, 2,
+                       "A second burst after the debounce closes must produce a second push")
+    }
+}
+
+/// Thread-safe counter shared between the scheduler's debounce queue and
+/// the test's `@MainActor` assertion.
+private final class FireCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _value = 0
+    var value: Int {
+        lock.lock(); defer { lock.unlock() }
+        return _value
+    }
+    func increment() {
+        lock.lock(); defer { lock.unlock() }
+        _value += 1
+    }
+}

--- a/Desktop/Tests/PendingWorkStorageDelegateTests.swift
+++ b/Desktop/Tests/PendingWorkStorageDelegateTests.swift
@@ -1,0 +1,177 @@
+import XCTest
+@testable import Omi_Computer
+
+/// Tests for the frozen `PendingWorkStorageDelegate` (interface I3) wired into
+/// `PendingWorkStorage`. The contract:
+///   - Every mutator (`enqueue`, `claimNext`, `ack`, `releaseClaim`, `fail`)
+///     fires `pendingWorkStorageDidMutate` exactly once after the
+///     transaction commits, on the actor's own serial executor.
+///   - Read-only methods (`depthSummary`, `pendingCount`, `healthCounts`)
+///     never fire the delegate.
+///
+/// Lane 4 will conform `BatteryAwareScheduler` (or a thin wrapper) to this
+/// protocol; this test isolates the storage half by using a stub delegate
+/// that just counts calls.
+///
+/// We exercise the real `PendingWorkStorage.shared` singleton against the
+/// real `RewindDatabase.shared`, because the fire-after-commit ordering is
+/// the actual contract under test. Each test drains the queue first (with
+/// the delegate unset) so we own the rows we mutate afterwards.
+final class PendingWorkStorageDelegateTests: XCTestCase {
+
+    /// Strong reference so the weak `delegate` property on the storage actor
+    /// doesn't immediately deallocate it; the test owns the lifetime.
+    private final class StubDelegate: PendingWorkStorageDelegate, @unchecked Sendable {
+        private let lock = NSLock()
+        private var _count = 0
+        var count: Int {
+            lock.lock(); defer { lock.unlock() }
+            return _count
+        }
+        func reset() {
+            lock.lock(); defer { lock.unlock() }
+            _count = 0
+        }
+        func pendingWorkStorageDidMutate(_ storage: PendingWorkStorage) {
+            lock.lock(); defer { lock.unlock() }
+            _count += 1
+        }
+    }
+
+    /// Use `.transcribe` because it's a real `PendingWork.Kind` raw value the
+    /// `claimNext` path will accept (it validates `Kind(rawValue:)`).
+    private let workType = PendingWork.Kind.transcribe.rawValue
+
+    /// Drain everything currently claimable in the shared queue. Called with
+    /// the delegate UNSET so these housekeeping mutations don't pollute the
+    /// per-test counts. Runs claim+ack until the queue returns nil; bounded
+    /// to avoid infinite loop in case of an environment glitch.
+    private func drainQueue() async throws {
+        let storage = PendingWorkStorage.shared
+        await storage.setDelegate(nil)
+        for _ in 0..<2_000 {
+            guard let work = try await storage.claimNext(claimedBy: "delegate-test-drain"),
+                  let sid = work.storageId else {
+                return
+            }
+            try? await storage.ack(storageId: sid)
+        }
+    }
+
+    override func tearDown() async throws {
+        // Always clear the delegate so the singleton doesn't carry a stale
+        // reference into the next test class.
+        await PendingWorkStorage.shared.setDelegate(nil)
+        try await super.tearDown()
+    }
+
+    // MARK: - Mutators each fire exactly once
+
+    func test_enqueue_claim_ack_eachFireDelegateOnce() async throws {
+        try await drainQueue()
+        let storage = PendingWorkStorage.shared
+        let stub = StubDelegate()
+        await storage.setDelegate(stub)
+
+        // 1. enqueue → +1.
+        // (Note: the row id returned by `enqueue` is opaque here — the GRDB
+        // record's `didInsert` path is not the test contract; the delegate
+        // count is.)
+        _ = try await storage.enqueue(
+            workType: workType,
+            payload: Data("delegate-test-enqueue".utf8),
+            dedupKey: "delegate-test-\(UUID().uuidString)"
+        )
+        XCTAssertEqual(stub.count, 1, "enqueue must fire the delegate exactly once")
+
+        // 2. claimNext → +1. We just enqueued, so claim must succeed.
+        stub.reset()
+        let claimed = try await storage.claimNext(claimedBy: "delegate-test-worker")
+        XCTAssertEqual(stub.count, 1, "claimNext must fire the delegate exactly once")
+        XCTAssertNotNil(claimed, "claimNext should return our just-enqueued row")
+
+        // 3. ack → +1.
+        stub.reset()
+        guard let storageId = claimed?.storageId else {
+            return XCTFail("claimed row missing storageId")
+        }
+        try await storage.ack(storageId: storageId)
+        XCTAssertEqual(stub.count, 1, "ack must fire the delegate exactly once")
+    }
+
+    func test_releaseClaim_firesDelegateOnce() async throws {
+        try await drainQueue()
+        let storage = PendingWorkStorage.shared
+        let stub = StubDelegate()
+        await storage.setDelegate(stub)
+
+        // Enqueue + claim a fresh row to release. Both pre-steps fire the
+        // delegate; we reset just before the call under test.
+        _ = try await storage.enqueue(
+            workType: workType,
+            payload: Data("delegate-test-release".utf8),
+            dedupKey: "delegate-release-\(UUID().uuidString)"
+        )
+        guard let claimed = try await storage.claimNext(claimedBy: "delegate-test-worker"),
+              let sid = claimed.storageId else {
+            return XCTFail("expected to claim our just-enqueued row")
+        }
+
+        stub.reset()
+        try await storage.releaseClaim(storageId: sid)
+        XCTAssertEqual(stub.count, 1, "releaseClaim must fire the delegate exactly once")
+
+        // Cleanup: claim + ack so the released row doesn't linger.
+        if let again = try await storage.claimNext(claimedBy: "delegate-test-worker"),
+           let aSid = again.storageId {
+            try? await storage.ack(storageId: aSid)
+        }
+    }
+
+    func test_fail_firesDelegateOnce_forFailedTransition() async throws {
+        try await drainQueue()
+        let storage = PendingWorkStorage.shared
+        let stub = StubDelegate()
+        await storage.setDelegate(stub)
+
+        // Enqueue + claim a fresh row.
+        _ = try await storage.enqueue(
+            workType: workType,
+            payload: Data("delegate-test-fail".utf8),
+            dedupKey: "delegate-fail-\(UUID().uuidString)"
+        )
+        guard let claimed = try await storage.claimNext(claimedBy: "delegate-test-worker"),
+              let sid = claimed.storageId else {
+            return XCTFail("expected to claim our just-enqueued row")
+        }
+
+        stub.reset()
+        struct DeliberateError: Error {}
+        try await storage.fail(storageId: sid, error: DeliberateError())
+        XCTAssertEqual(
+            stub.count, 1,
+            "fail must fire the delegate exactly once (failed-state transition)"
+        )
+
+        // Cleanup: this row is now `failed` with a future scheduledFor; the
+        // sweeper will eventually GC it. Leaving as-is is harmless for tests.
+    }
+
+    // MARK: - Read methods do NOT fire
+
+    func test_readMethods_doNotFireDelegate() async throws {
+        let storage = PendingWorkStorage.shared
+        let stub = StubDelegate()
+        await storage.setDelegate(stub)
+
+        stub.reset()
+        _ = try await storage.depthSummary()
+        _ = await storage.pendingCount()
+        _ = try await storage.healthCounts()
+
+        XCTAssertEqual(
+            stub.count, 0,
+            "depthSummary / pendingCount / healthCounts must never fire the delegate"
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- `APIClient.rustBackendURL` now throws `APIError.daemonNotConfigured` instead of silently returning `""`; Activity panel surfaces a clear "daemon not configured" message instead of `HTTP error: 404`.
- New loopback `POST /v1/activity/_internal/queue-depth` carries per-kind `{queued, failed}` from Swift into the Rust snapshot, replacing the hardcoded `0/0`.
- `PendingWorkStorageDelegate` fires post-commit on every mutator; `BatteryAwareScheduler` debounces 250 ms and pushes the full per-kind map, with a one-shot hydration push at scheduler start.

Closes #41. Built parallel via 4-lane fan-out on `gh-41` against frozen interfaces (wire format I1, error case I2, delegate protocol I3, method signature I4).

## Test plan
- [x] `cargo build -p infinite-recall-api` clean.
- [x] `cargo check --features activity_test_wiring -p infinite-recall-api --tests` clean; `queue_depth_loopback_round_trip` passes.
- [x] `swift build` clean.
- [x] New Swift tests pass: `PendingWorkStorageDelegateTests` (4 cases), `BatteryAwareSchedulerQueueDepthDebounceTests` (2 cases), `APIClientRoutingTests.testGetActivitySnapshotThrowsDaemonNotConfiguredWhenIRApiUrlUnset`.
- [ ] Manual: with `IR_API_URL` unset, Activity panel shows the new "daemon not configured" message (not `HTTP error: 404`).
- [ ] Manual: with normal `scripts/run.sh` launch, Activity panel `QUEUED` matches tray `[scheduler] N items waiting` within ~1 s debounce window.
- [ ] Manual: forcing a job to fail mid-handler increments per-kind `failed` counter in the snapshot.

## Known pre-existing failures (not introduced by this PR)
9 unrelated failures persist on `main` and remain on this branch. Triaged file-by-file:
- `CrispManagerLifecycleTests` (4) — observer registration drift; CrispManager source unchanged on this branch.
- `ModelQoSTests` (2) — tier default `"max"` vs expected `"premium"`; source unchanged.
- `OnboardingFlowTests` (2) — step-count drift (19 vs expected 18); source unchanged.
- `APIClientRoutingTests.testSynthesizeSpeechRoutesToRustWithExpectedPayload` (1) — `XCTUnwrap(captured.body)` flake from URLSession streaming `httpBody` into `URLProtocol`; reproduces on `main` independent of the throwing-helper change.

## Follow-up
- #44 — sweeper-reclaim writes still bypass the storage actor; the panel's `QUEUED` count can stale until the next non-sweeper mutation. Fix is to route sweeper SQL through a new `PendingWorkStorage.reclaimExpiredLeases()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)