### PR TITLE
feat(ai): "Other" custom Hugging Face model input for Local + Vision pickers

### DIFF
--- a/Desktop/Sources/AI/BundledScripts.swift
+++ b/Desktop/Sources/AI/BundledScripts.swift
@@ -228,8 +228,13 @@ else
     # in-flight file's tqdm fraction approximation via os.path.getsize().
     HF_HUB_DISABLE_PROGRESS_BARS=1 \
     uv tool run --from mlx-lm python - <<'PY'
-import os, sys, threading, time
+import os, sys, threading, time, traceback
 from huggingface_hub import snapshot_download, HfApi
+from huggingface_hub.utils import (
+    RepositoryNotFoundError,
+    GatedRepoError,
+    HfHubHTTPError,
+)
 
 MODEL = os.environ.get("INFINITE_RECALL_MODEL") or os.environ.get("INFINITE_RECALL_MLX_MODEL", "mlx-community/Qwen2.5-7B-Instruct-4bit")
 
@@ -265,7 +270,29 @@ def watcher():
 t = threading.Thread(target=watcher, daemon=True)
 t.start()
 try:
-    snapshot_download(MODEL)
+    try:
+        snapshot_download(MODEL)
+    except RepositoryNotFoundError:
+        reason = f"Repository not found: {MODEL}"
+        emit(f"DOWNLOAD_FAIL={reason}")
+        traceback.print_exc(file=sys.stderr)
+        sys.exit(2)
+    except GatedRepoError:
+        reason = f"Repository is gated and requires authentication: {MODEL}"
+        emit(f"DOWNLOAD_FAIL={reason}")
+        traceback.print_exc(file=sys.stderr)
+        sys.exit(2)
+    except HfHubHTTPError as e:
+        status = e.response.status_code if hasattr(e, "response") else "?"
+        reason = f"Hugging Face Hub error ({status}) for {MODEL}: {e}"
+        emit(f"DOWNLOAD_FAIL={reason}")
+        traceback.print_exc(file=sys.stderr)
+        sys.exit(2)
+    except Exception as e:
+        reason = f"Download failed for {MODEL}: {type(e).__name__}: {e}"
+        emit(f"DOWNLOAD_FAIL={reason}")
+        traceback.print_exc(file=sys.stderr)
+        sys.exit(2)
 finally:
     stop.set()
     t.join(timeout=3)
@@ -580,8 +607,13 @@ else
     bold "→ Downloading model (this may take a while)..."
     HF_HUB_DISABLE_PROGRESS_BARS=1 \
     uv tool run --from mlx-vlm python - <<'PY'
-import os, sys, threading, time
+import os, sys, threading, time, traceback
 from huggingface_hub import snapshot_download, HfApi
+from huggingface_hub.utils import (
+    RepositoryNotFoundError,
+    GatedRepoError,
+    HfHubHTTPError,
+)
 
 MODEL = os.environ.get("INFINITE_RECALL_VLM_MODEL", "mlx-community/Qwen3-VL-8B-Instruct-4bit")
 
@@ -616,7 +648,29 @@ def watcher():
 t = threading.Thread(target=watcher, daemon=True)
 t.start()
 try:
-    snapshot_download(MODEL)
+    try:
+        snapshot_download(MODEL)
+    except RepositoryNotFoundError:
+        reason = f"Repository not found: {MODEL}"
+        emit(f"DOWNLOAD_FAIL={reason}")
+        traceback.print_exc(file=sys.stderr)
+        sys.exit(2)
+    except GatedRepoError:
+        reason = f"Repository is gated and requires authentication: {MODEL}"
+        emit(f"DOWNLOAD_FAIL={reason}")
+        traceback.print_exc(file=sys.stderr)
+        sys.exit(2)
+    except HfHubHTTPError as e:
+        status = e.response.status_code if hasattr(e, "response") else "?"
+        reason = f"Hugging Face Hub error ({status}) for {MODEL}: {e}"
+        emit(f"DOWNLOAD_FAIL={reason}")
+        traceback.print_exc(file=sys.stderr)
+        sys.exit(2)
+    except Exception as e:
+        reason = f"Download failed for {MODEL}: {type(e).__name__}: {e}"
+        emit(f"DOWNLOAD_FAIL={reason}")
+        traceback.print_exc(file=sys.stderr)
+        sys.exit(2)
 finally:
     stop.set()
     t.join(timeout=3)

--- a/Desktop/Sources/AI/CustomHFModelID.swift
+++ b/Desktop/Sources/AI/CustomHFModelID.swift
@@ -1,0 +1,51 @@
+// Pure validator + persistence-key constants for user-supplied Hugging Face
+// model ids in the Local Model and Vision Model pickers.
+//
+// No network calls — this only enforces shape (`org/repo`) so the UI can
+// surface an inline error before kicking off the installer. Real failures
+// (404, gated repo, non-MLX weights) surface from `snapshot_download` via
+// LocalAIInstaller.
+
+import Foundation
+
+enum CustomHFError: LocalizedError, Equatable {
+  case empty
+  case malformed
+  case tooLong
+
+  var errorDescription: String? {
+    switch self {
+    case .empty:
+      return "Enter a Hugging Face repo (e.g. mlx-community/Llama-3.2-3B-Instruct-4bit)."
+    case .malformed:
+      return "Must be in the form org/repo using letters, digits, dot, underscore, or hyphen."
+    case .tooLong:
+      return "Too long — keep it under \(CustomHFModelID.maxLength) characters."
+    }
+  }
+}
+
+enum CustomHFModelID {
+  static let pattern = #"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$"#
+  static let maxLength = 200
+
+  static func validate(_ raw: String) -> Result<String, CustomHFError> {
+    let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmed.isEmpty { return .failure(.empty) }
+    if trimmed.count > maxLength { return .failure(.tooLong) }
+    if trimmed.range(of: pattern, options: .regularExpression) == nil {
+      return .failure(.malformed)
+    }
+    return .success(trimmed)
+  }
+}
+
+/// UserDefaults keys for the freeform HF id the user typed into each picker.
+/// These persist across catalog/custom toggles so the TextField repopulates.
+/// The *active* model id (curated or custom) still lives under the existing
+/// `activeLocalModelID` / `activeVisionModelID` keys read by the lifecycle
+/// managers — these keys hold the draft separately.
+enum CustomHFModelDefaults {
+  static let localKey = "customLocalModelID"
+  static let visionKey = "customVisionModelID"
+}

--- a/Desktop/Sources/AI/LocalAIInstaller.swift
+++ b/Desktop/Sources/AI/LocalAIInstaller.swift
@@ -181,16 +181,33 @@ final class LocalAIInstaller: ObservableObject {
     pendingVLMModelId = (kind == .vlm) ? modelId : nil
 
     // Seed modelTotalBytes from the catalog so the progress label never shows
-    // a stale hardcoded number. Fall back to 0 if the id isn't in the catalog.
+    // a stale hardcoded number. For custom (user-supplied) HF ids the catalog
+    // returns nil — leave modelTotalBytes at 0 so the UI runs an indeterminate
+    // progress bar rather than a misleading total. For the default install
+    // (no modelId), fall back to the catalog's recommended entry.
     switch kind {
     case .mlx:
-      let entry = modelId.flatMap { LocalModelCatalog.option(forId: $0) }
-        ?? LocalModelCatalog.recommended
-      modelTotalBytes = Int64(entry.approxDiskGB * 1_000_000_000)
+      if let id = modelId {
+        if let entry = LocalModelCatalog.option(forId: id) {
+          modelTotalBytes = Int64(entry.approxDiskGB * 1_000_000_000)
+        } else {
+          // Custom id — unknown size; leave indeterminate.
+          modelTotalBytes = 0
+        }
+      } else {
+        modelTotalBytes = Int64(LocalModelCatalog.recommended.approxDiskGB * 1_000_000_000)
+      }
     case .vlm:
-      let entry = modelId.flatMap { VisionModelCatalog.option(forId: $0) }
-        ?? VisionModelCatalog.recommended
-      modelTotalBytes = Int64(entry.approxDiskGB * 1_000_000_000)
+      if let id = modelId {
+        if let entry = VisionModelCatalog.option(forId: id) {
+          modelTotalBytes = Int64(entry.approxDiskGB * 1_000_000_000)
+        } else {
+          // Custom id — unknown size; leave indeterminate.
+          modelTotalBytes = 0
+        }
+      } else {
+        modelTotalBytes = Int64(VisionModelCatalog.recommended.approxDiskGB * 1_000_000_000)
+      }
     case .api:
       modelTotalBytes = 0
     }
@@ -432,6 +449,20 @@ final class LocalAIInstaller: ObservableObject {
       if let n = Int64(value) {
         modelDownloadedBytes = n
       }
+
+    case "DOWNLOAD_FAIL":
+      // Embedded Python in the install scripts emits this sentinel when
+      // huggingface_hub.snapshot_download raises (bad id, gated repo, HTTP
+      // error, etc.). Capture the reason verbatim, mark the install failed,
+      // and let the process-exit branch surface our error rather than the
+      // generic "exited with status N" fallback.
+      let reason = value.trimmingCharacters(in: .whitespacesAndNewlines)
+      if !reason.isEmpty {
+        error = "Download failed: \(reason)"
+      } else {
+        error = "Download failed."
+      }
+      currentStep = .failed
 
     default:
       break

--- a/Desktop/Sources/AI/LocalModelCatalog.swift
+++ b/Desktop/Sources/AI/LocalModelCatalog.swift
@@ -87,6 +87,21 @@ enum LocalModelCatalog {
     all.first(where: { $0.id == id })
   }
 
+  /// Display-side accessor. Returns the catalog entry for `id`, or a
+  /// synthesized "Custom" placeholder if the id is user-supplied and not in
+  /// the curated list. Use from UI code that needs *something* to render;
+  /// use `option(forId:)` from logic that must distinguish curated vs custom.
+  static func entry(forId id: String) -> LocalModelOption {
+    option(forId: id) ?? .init(
+      id: id,
+      displayName: id,
+      badge: "Custom",
+      approxRamGB: 0,
+      approxDiskGB: 0,
+      license: "Unknown",
+      contextWindow: 0)
+  }
+
   /// The "default" option to surface when nothing has been chosen yet. We
   /// pick whichever entry matches `MLXLifecycleManager.defaultModelID`, or
   /// the first entry if the default isn't in the catalog.

--- a/Desktop/Sources/AI/VisionModelCatalog.swift
+++ b/Desktop/Sources/AI/VisionModelCatalog.swift
@@ -60,6 +60,21 @@ enum VisionModelCatalog {
     all.first(where: { $0.id == id })
   }
 
+  /// Display-side accessor. Returns the catalog entry for `id`, or a
+  /// synthesized "Custom" placeholder if the id is user-supplied and not in
+  /// the curated list. Use from UI code that needs *something* to render;
+  /// use `option(forId:)` from logic that must distinguish curated vs custom.
+  static func entry(forId id: String) -> VisionModelOption {
+    option(forId: id) ?? .init(
+      id: id,
+      displayName: id,
+      badge: "Custom",
+      approxRamGB: 0,
+      approxDiskGB: 0,
+      license: "Unknown",
+      contextWindow: 0)
+  }
+
   /// The "default" option. Matches `VLMLifecycleManager.defaultModelID`, or
   /// the first entry as a fallback.
   static var recommended: VisionModelOption {

--- a/Desktop/Sources/MainWindow/Pages/LocalAIInstallSheet.swift
+++ b/Desktop/Sources/MainWindow/Pages/LocalAIInstallSheet.swift
@@ -102,16 +102,21 @@ struct LocalAIInstallSheet: View {
 
   /// Disk size string sourced from the catalog entry being installed, e.g.
   /// "5.5 GB". Falls back gracefully when no catalog entry is available.
+  /// For user-supplied custom HF ids we don't know the size up-front (no
+  /// network probe), so we return "size unknown" rather than seeding a
+  /// misleading "0 GB" figure — the real progress comes from the installer.
   private var catalogDiskSizeLabel: String {
     let resolvedKind = installAPIInstead ? Kind.api : kind
     switch resolvedKind {
     case .mlx:
-      let entry = modelId.flatMap { LocalModelCatalog.option(forId: $0) }
+      let entry = modelId.map { LocalModelCatalog.entry(forId: $0) }
         ?? LocalModelCatalog.recommended
+      if entry.approxDiskGB == 0 { return "size unknown" }
       return String(format: "%.4g GB", entry.approxDiskGB)
     case .vlm:
-      let entry = modelId.flatMap { VisionModelCatalog.option(forId: $0) }
+      let entry = modelId.map { VisionModelCatalog.entry(forId: $0) }
         ?? VisionModelCatalog.recommended
+      if entry.approxDiskGB == 0 { return "size unknown" }
       return String(format: "%.4g GB", entry.approxDiskGB)
     case .api:
       return ""

--- a/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -364,6 +364,13 @@ struct SettingsContentView: View {
   // approximation by a few hundred MB).
   @State private var localModelDiskSizes: [String: Int64] = [:]
 
+  // "Other (Hugging Face repo)" row state. The freeform draft persists so
+  // it repopulates the TextField even after toggling rows or sheets. The
+  // sentinel id "__custom__" is used in `localModelPickerSelection` to
+  // mark the custom row as highlighted (it's not a valid HF repo path so
+  // it can't collide with any real id).
+  @AppStorage(CustomHFModelDefaults.localKey) private var customLocalModelDraft: String = ""
+
   // Vision Model picker — mirrors the text-tier state block above but
   // pointed at `VLMLifecycleManager` / `VisionModelCatalog`.
   @AppStorage("activeVisionModelID") private var activeVisionModelID: String =
@@ -388,6 +395,10 @@ struct SettingsContentView: View {
 
   // Cached on-disk sizes for vision models.
   @State private var visionModelDiskSizes: [String: Int64] = [:]
+
+  // "Other (Hugging Face repo)" row state for the vision tier — mirrors
+  // the text-tier draft above, persisted under a separate key.
+  @AppStorage(CustomHFModelDefaults.visionKey) private var customVisionModelDraft: String = ""
 
   // MCP API card — expandable response viewer + transient "copied" feedback.
   @State private var mcpAPIShowResponse: Bool = false
@@ -2159,8 +2170,10 @@ struct SettingsContentView: View {
   // MARK: Vision Model — active summary
 
   private var activeVisionModelSummary: some View {
-    let active = VisionModelCatalog.option(forId: activeVisionModelID)
-      ?? VisionModelCatalog.recommended
+    // Mirror the text-tier summary: use `entry(forId:)` so a custom HF id
+    // renders as "<id> · Custom · size unknown" instead of falling back to
+    // the recommended catalog entry.
+    let active = VisionModelCatalog.entry(forId: activeVisionModelID)
     let installed = vlmLifecycle.isModelInstalled(modelId: active.id)
     return HStack(spacing: 8) {
       Text("Active:")
@@ -2175,6 +2188,10 @@ struct SettingsContentView: View {
           .foregroundColor(OmiColors.success)
         if let bytes = visionModelDiskSizes[active.id], bytes > 0 {
           Text("Installed (\(formatBytes(bytes)) on disk)")
+            .scaledFont(size: 12)
+            .foregroundColor(OmiColors.textSecondary)
+        } else if active.approxDiskGB == 0 {
+          Text("Installed (size unknown)")
             .scaledFont(size: 12)
             .foregroundColor(OmiColors.textSecondary)
         } else {
@@ -2206,8 +2223,12 @@ struct SettingsContentView: View {
             visionModelRow(option)
           }
 
+          // "Other (Hugging Face repo)" — mirrors the text tier.
+          customVisionModelRow
+
           if let pendingId = visionModelPickerSelection,
              pendingId != activeVisionModelID,
+             pendingId != Self.customRowSentinel,
              vlmLifecycle.isModelInstalled(modelId: pendingId)
           {
             HStack {
@@ -2568,8 +2589,10 @@ struct SettingsContentView: View {
   // MARK: Active model summary (top of card)
 
   private var activeModelSummary: some View {
-    let active = LocalModelCatalog.option(forId: activeLocalModelID)
-      ?? LocalModelCatalog.recommended
+    // Use `entry(forId:)` so user-supplied custom ids render with a
+    // synthesized "Custom" placeholder instead of falling back to the
+    // recommended catalog entry.
+    let active = LocalModelCatalog.entry(forId: activeLocalModelID)
     let installed = mlxLifecycle.isModelInstalled(modelId: active.id)
     return HStack(spacing: 8) {
       Text("Active:")
@@ -2583,9 +2606,14 @@ struct SettingsContentView: View {
           .scaledFont(size: 11)
           .foregroundColor(OmiColors.success)
         // Prefer the real on-disk figure if we've measured it; fall back to
-        // the catalog approximation otherwise.
+        // the catalog approximation otherwise. Custom ids have no catalog
+        // size — render "size unknown" rather than a misleading "0.0 GB".
         if let bytes = localModelDiskSizes[active.id], bytes > 0 {
           Text("Installed (\(formatBytes(bytes)) on disk)")
+            .scaledFont(size: 12)
+            .foregroundColor(OmiColors.textSecondary)
+        } else if active.approxDiskGB == 0 {
+          Text("Installed (size unknown)")
             .scaledFont(size: 12)
             .foregroundColor(OmiColors.textSecondary)
         } else {
@@ -2622,8 +2650,14 @@ struct SettingsContentView: View {
             localModelRow(option)
           }
 
+          // "Other (Hugging Face repo)" — freeform id entry. Selecting the
+          // row reveals a TextField with inline validation; the Install
+          // button stays disabled until validation succeeds.
+          customLocalModelRow
+
           if let pendingId = localModelPickerSelection,
              pendingId != activeLocalModelID,
+             pendingId != Self.customRowSentinel,
              mlxLifecycle.isModelInstalled(modelId: pendingId)
           {
             HStack {
@@ -2834,6 +2868,177 @@ struct SettingsContentView: View {
     .onTapGesture {
       localModelPickerSelection = option.id
     }
+  }
+
+  // MARK: Custom HF repo row (text tier)
+
+  /// Sentinel id used in `localModelPickerSelection` /
+  /// `visionModelPickerSelection` to mark the "Other (Hugging Face repo)"
+  /// row as highlighted. Contains a slash so it can never collide with a
+  /// real catalog id, but isn't a valid HF repo path either (the regex
+  /// rejects leading underscores so this can't be a typed-in collision).
+  fileprivate static let customRowSentinel = "__custom__/__custom__"
+
+  /// Validation result for the current local-tier draft. Surfaces both for
+  /// the inline error label and to gate the Install button.
+  private var customLocalModelValidation: Result<String, CustomHFError> {
+    CustomHFModelID.validate(customLocalModelDraft)
+  }
+
+  /// Validation result for the current vision-tier draft.
+  private var customVisionModelValidation: Result<String, CustomHFError> {
+    CustomHFModelID.validate(customVisionModelDraft)
+  }
+
+  /// "Other (Hugging Face repo)" row for the text-tier picker. Tapping the
+  /// row highlights it (sentinel selection). When highlighted, the body
+  /// reveals a TextField bound to `customLocalModelDraft` with inline
+  /// validation. The Install button stays disabled until validation
+  /// succeeds; on click it persists the trimmed valid id as the active
+  /// model and kicks the existing install sheet flow.
+  @ViewBuilder
+  private var customLocalModelRow: some View {
+    let isSelected = localModelPickerSelection == Self.customRowSentinel
+    HStack(alignment: .top, spacing: 10) {
+      Image(systemName: isSelected ? "largecircle.fill.circle" : "circle")
+        .scaledFont(size: 14)
+        .foregroundColor(
+          isSelected ? OmiColors.purplePrimary : OmiColors.textTertiary
+        )
+        .padding(.top, 1)
+
+      VStack(alignment: .leading, spacing: 6) {
+        HStack(spacing: 8) {
+          Text("Other (Hugging Face repo)")
+            .scaledFont(size: 13, weight: .semibold)
+            .foregroundColor(OmiColors.textPrimary)
+          Text("Custom")
+            .scaledFont(size: 11)
+            .foregroundColor(OmiColors.textSecondary)
+          Spacer()
+        }
+
+        Text("Paste any MLX-compatible repo, e.g. mlx-community/Llama-3.2-3B-Instruct-4bit.")
+          .scaledFont(size: 11)
+          .foregroundColor(OmiColors.textTertiary)
+
+        if isSelected {
+          TextField("org/repo", text: $customLocalModelDraft)
+            .textFieldStyle(.roundedBorder)
+            .scaledFont(size: 12)
+            .disableAutocorrection(true)
+
+          if case .failure(let err) = customLocalModelValidation,
+             !customLocalModelDraft.isEmpty || err != .empty
+          {
+            Text(err.errorDescription ?? "Invalid id")
+              .scaledFont(size: 11)
+              .foregroundColor(OmiColors.error)
+          }
+
+          HStack(spacing: 8) {
+            Spacer()
+            Button("Install") {
+              if case .success(let trimmed) = customLocalModelValidation {
+                installCustomLocalModel(trimmed)
+              }
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(OmiColors.purplePrimary)
+            .controlSize(.small)
+            .disabled({
+              if case .success = customLocalModelValidation { return false }
+              return true
+            }())
+          }
+        }
+      }
+    }
+    .contentShape(Rectangle())
+    .onTapGesture {
+      localModelPickerSelection = Self.customRowSentinel
+    }
+  }
+
+  /// Persist the trimmed valid id as the active model and route into the
+  /// existing install sheet so the user gets the same step list + progress
+  /// bar UX. Stream C wires up the installer side (custom id → snapshot).
+  private func installCustomLocalModel(_ modelId: String) {
+    setActiveModel(modelId)
+    installLocalModel(modelId)
+  }
+
+  // MARK: Custom HF repo row (vision tier)
+
+  /// Vision-tier mirror of `customLocalModelRow`.
+  @ViewBuilder
+  private var customVisionModelRow: some View {
+    let isSelected = visionModelPickerSelection == Self.customRowSentinel
+    HStack(alignment: .top, spacing: 10) {
+      Image(systemName: isSelected ? "largecircle.fill.circle" : "circle")
+        .scaledFont(size: 14)
+        .foregroundColor(
+          isSelected ? OmiColors.purplePrimary : OmiColors.textTertiary
+        )
+        .padding(.top, 1)
+
+      VStack(alignment: .leading, spacing: 6) {
+        HStack(spacing: 8) {
+          Text("Other (Hugging Face repo)")
+            .scaledFont(size: 13, weight: .semibold)
+            .foregroundColor(OmiColors.textPrimary)
+          Text("Custom")
+            .scaledFont(size: 11)
+            .foregroundColor(OmiColors.textSecondary)
+          Spacer()
+        }
+
+        Text("Paste any mlx-vlm-compatible repo, e.g. mlx-community/Qwen2-VL-7B-Instruct-4bit.")
+          .scaledFont(size: 11)
+          .foregroundColor(OmiColors.textTertiary)
+
+        if isSelected {
+          TextField("org/repo", text: $customVisionModelDraft)
+            .textFieldStyle(.roundedBorder)
+            .scaledFont(size: 12)
+            .disableAutocorrection(true)
+
+          if case .failure(let err) = customVisionModelValidation,
+             !customVisionModelDraft.isEmpty || err != .empty
+          {
+            Text(err.errorDescription ?? "Invalid id")
+              .scaledFont(size: 11)
+              .foregroundColor(OmiColors.error)
+          }
+
+          HStack(spacing: 8) {
+            Spacer()
+            Button("Install") {
+              if case .success(let trimmed) = customVisionModelValidation {
+                installCustomVisionModel(trimmed)
+              }
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(OmiColors.purplePrimary)
+            .controlSize(.small)
+            .disabled({
+              if case .success = customVisionModelValidation { return false }
+              return true
+            }())
+          }
+        }
+      }
+    }
+    .contentShape(Rectangle())
+    .onTapGesture {
+      visionModelPickerSelection = Self.customRowSentinel
+    }
+  }
+
+  /// Vision-tier mirror of `installCustomLocalModel`.
+  private func installCustomVisionModel(_ modelId: String) {
+    setActiveVisionModel(modelId)
+    installVisionModel(modelId)
   }
 
   // MARK: Local Model picker — helpers


### PR DESCRIPTION
Closes #42

## Summary

- Add an "Other (Hugging Face repo)" radio row to the Local Model and Vision Model pickers in Settings → AI / Models. Selecting it reveals a `TextField` that takes a freeform `org/repo` string (e.g. `mlx-community/Llama-3.2-3B-Instruct-4bit`) with inline validation; the Install button stays disabled until the validator (`org/repo` shape, 200-char cap, no network) succeeds.
- The validated id flows through the existing UserDefaults key (`activeLocalModelID` / `activeVisionModelID`) and the existing plist regeneration path — `mlx_lm.server` / `mlx_vlm.server --model __MODEL__` substitution and `snapshot_download(MODEL)` already accept any HF id end-to-end.
- Harden the Python install scripts in `BundledScripts.swift`: catch `RepositoryNotFoundError`, `GatedRepoError`, `HfHubHTTPError`, and any generic `Exception` from `snapshot_download`, emit `PROGRESS:DOWNLOAD_FAIL=<reason>`, and `sys.exit(2)` instead of silently flowing to `DOWNLOAD_OK=1`. **This fixes a pre-existing bug** where 404 / gated / non-MLX failures reported success and only surfaced when launchd couldn't start the server. `LocalAIInstaller` parses the new sentinel and surfaces the reason as the user-visible error.
- Display polish: `entry(forId:)` on both catalogs synthesizes a "Custom" placeholder so the active-model summaries and install sheet render `<id> · Custom · size unknown` rather than falling back to the recommended entry. Strict `option(forId:)` keeps nil semantics for branching code (installer skips the byte-count seed for custom ids → indeterminate progress bar).

## Files

- `Desktop/Sources/AI/CustomHFModelID.swift` (new) — pure validator + persistence-key constants
- `Desktop/Sources/AI/LocalModelCatalog.swift`, `VisionModelCatalog.swift` — `entry(forId:)` accessor
- `Desktop/Sources/MainWindow/Pages/SettingsPage.swift` — "Other" row, sentinel selection, inline validation, Install gating; summary cards switched to `entry(forId:)`
- `Desktop/Sources/MainWindow/Pages/LocalAIInstallSheet.swift` — "size unknown" rendering
- `Desktop/Sources/AI/LocalAIInstaller.swift` — no byte seed for custom ids, `PROGRESS:DOWNLOAD_FAIL=` parser
- `Desktop/Sources/AI/BundledScripts.swift` — Python `snapshot_download` hardening (MLX + VLM)

## Test plan

- [ ] Local Model → Other → `mlx-community/Llama-3.2-3B-Instruct-4bit` → Install. Expect "size unknown", indeterminate progress, success; summary card shows the custom id.
- [ ] Vision Model → Other → `mlx-community/Qwen2.5-VL-3B-Instruct-4bit` → Install. Same.
- [ ] Failure path: `someuser/does-not-exist` → expect "Repository not found" surfaced within ~5s, **not** silent success.
- [ ] Validator path: `bogus` (no slash) → inline TextField error, Install button disabled.
- [ ] `curl http://127.0.0.1:8080/v1/models` (text) / `:8081/v1/models` (vision) → custom id reported.
- [ ] Toggle to a catalog model, then back to Other → custom id is still in TextField (persisted under `customLocalModelID` / `customVisionModelID`).

## Out of scope

- HF API preflight (`HfApi().model_info(...)` for true disk size — adds gated-repo auth complexity)
- MLX-compatibility scanner (`.safetensors` markers — Stream C's hard-fail is enough)
- Custom-id history / autocomplete

🤖 Generated with [Claude Code](https://claude.com/claude-code)