### PR TITLE
activity: route sweeper writes through PendingWorkStorage actor (closes #44)

### DIFF
--- a/Desktop/Sources/Power/PendingWorkSweeper.swift
+++ b/Desktop/Sources/Power/PendingWorkSweeper.swift
@@ -1,5 +1,4 @@
 import Foundation
-import GRDB
 
 /// Periodic background maintenance task for the `pending_work` table.
 ///
@@ -18,6 +17,10 @@ import GRDB
 /// 3. **Dead-row GC** — rows with `status = 'dead'` older than 30 days are
 ///    hard-deleted. The 30-day window is long enough for a developer to inspect
 ///    them via `sqlite3` CLI.
+///
+/// All three SQL operations live inside `PendingWorkStorage.runMaintenanceSweep`
+/// so they go through the actor's mutation delegate — keeps the Activity panel
+/// in sync without polling.
 ///
 /// Lifecycle: started from `PowerWorkBridge.start()` after
 /// `BatteryAwareScheduler.shared.start()`.
@@ -49,54 +52,12 @@ final class PendingWorkSweeper {
 
     @discardableResult
     func sweep() async -> (recovered: Int, doneGC: Int, deadGC: Int) {
-        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
-            return (0, 0, 0)
-        }
-        let now = Date()
-
         do {
-            return try await dbQueue.write { db -> (Int, Int, Int) in
-                // 1. Reclaim expired leases.
-                let reclaimed = try db.execute(sql: """
-                    UPDATE pending_work
-                    SET status = CASE
-                            WHEN attempts + 1 >= maxAttempts THEN 'dead'
-                            ELSE 'queued'
-                        END,
-                        attempts      = attempts + 1,
-                        lastError     = COALESCE(lastError || ' ', '') || '[lease expired]',
-                        claimedAt     = NULL,
-                        claimedBy     = NULL,
-                        leaseExpiresAt = NULL,
-                        scheduledFor  = datetime(?, '+30 seconds'),
-                        updatedAt     = ?
-                    WHERE status = 'claimed'
-                      AND leaseExpiresAt < ?
-                """, arguments: [now, now, now])
-                let recoveredCount = db.changesCount
-
-                // 2. GC done rows > 24 h old.
-                try db.execute(sql: """
-                    DELETE FROM pending_work
-                    WHERE status = 'done'
-                      AND updatedAt < datetime(?, '-1 day')
-                """, arguments: [now])
-                let doneGCCount = db.changesCount
-
-                // 3. GC dead rows > 30 days old.
-                try db.execute(sql: """
-                    DELETE FROM pending_work
-                    WHERE status = 'dead'
-                      AND updatedAt < datetime(?, '-30 days')
-                """, arguments: [now])
-                let deadGCCount = db.changesCount
-
-                if recoveredCount > 0 || doneGCCount > 0 || deadGCCount > 0 {
-                    log("PendingWorkSweeper: recovered=\(recoveredCount) doneGC=\(doneGCCount) deadGC=\(deadGCCount)")
-                }
-
-                return (recoveredCount, doneGCCount, deadGCCount)
+            let result = try await PendingWorkStorage.shared.runMaintenanceSweep()
+            if result.recovered > 0 || result.doneGC > 0 || result.deadGC > 0 {
+                log("PendingWorkSweeper: recovered=\(result.recovered) doneGC=\(result.doneGC) deadGC=\(result.deadGC)")
             }
+            return result
         } catch {
             logError("PendingWorkSweeper: sweep failed", error: error)
             return (0, 0, 0)

--- a/Desktop/Sources/Rewind/Core/PendingWorkStorage.swift
+++ b/Desktop/Sources/Rewind/Core/PendingWorkStorage.swift
@@ -370,6 +370,55 @@ actor PendingWorkStorage {
         }
     }
 
+    // MARK: - Maintenance sweep
+
+    /// Reclaim expired leases and GC old `done`/`dead` rows in a single
+    /// transaction, then fire the mutation delegate exactly once. This is the
+    /// only path through which `PendingWorkSweeper` should mutate the table —
+    /// going around the actor would skip the delegate and leave the Activity
+    /// panel stale until the next non-sweeper write.
+    @discardableResult
+    func runMaintenanceSweep(now: Date = Date()) async throws -> (recovered: Int, doneGC: Int, deadGC: Int) {
+        let db = try await ensureInitialized()
+        let result = try await db.write { database -> (Int, Int, Int) in
+            try database.execute(sql: """
+                UPDATE pending_work
+                SET status = CASE
+                        WHEN attempts + 1 >= maxAttempts THEN 'dead'
+                        ELSE 'queued'
+                    END,
+                    attempts      = attempts + 1,
+                    lastError     = COALESCE(lastError || ' ', '') || '[lease expired]',
+                    claimedAt     = NULL,
+                    claimedBy     = NULL,
+                    leaseExpiresAt = NULL,
+                    scheduledFor  = datetime(?, '+30 seconds'),
+                    updatedAt     = ?
+                WHERE status = 'claimed'
+                  AND leaseExpiresAt < ?
+            """, arguments: [now, now, now])
+            let recoveredCount = database.changesCount
+
+            try database.execute(sql: """
+                DELETE FROM pending_work
+                WHERE status = 'done'
+                  AND updatedAt < datetime(?, '-1 day')
+            """, arguments: [now])
+            let doneGCCount = database.changesCount
+
+            try database.execute(sql: """
+                DELETE FROM pending_work
+                WHERE status = 'dead'
+                  AND updatedAt < datetime(?, '-30 days')
+            """, arguments: [now])
+            let deadGCCount = database.changesCount
+
+            return (recoveredCount, doneGCCount, deadGCCount)
+        }
+        notifyDidMutate()
+        return result
+    }
+
     // MARK: - Depth summary
 
     func depthSummary() async throws -> PendingWorkDepth {

--- a/Desktop/Tests/PendingWorkStorageDelegateTests.swift
+++ b/Desktop/Tests/PendingWorkStorageDelegateTests.swift
@@ -157,6 +157,44 @@ final class PendingWorkStorageDelegateTests: XCTestCase {
         // sweeper will eventually GC it. Leaving as-is is harmless for tests.
     }
 
+    // MARK: - Maintenance sweep fires delegate
+
+    /// Locks in #44: the sweeper's lease-reclaim path goes through the storage
+    /// actor, so the delegate fires and the Activity panel sees the
+    /// `claimed → queued` (or `claimed → dead`) transition immediately.
+    func test_runMaintenanceSweep_firesDelegateOnce_afterReclaimingExpiredLease() async throws {
+        try await drainQueue()
+        let storage = PendingWorkStorage.shared
+
+        // Set up a row in `claimed` state with an already-expired lease so the
+        // sweep's UPDATE actually changes something.
+        _ = try await storage.enqueue(
+            workType: workType,
+            payload: Data("delegate-test-sweep".utf8),
+            dedupKey: "delegate-sweep-\(UUID().uuidString)"
+        )
+        guard let claimed = try await storage.claimNext(claimedBy: "delegate-test-worker"),
+              claimed.storageId != nil else {
+            return XCTFail("expected to claim our just-enqueued row")
+        }
+
+        // Run the sweep with `now` 1 hour in the future so the 10-minute lease
+        // is guaranteed expired. Attach the delegate AFTER the setup mutators
+        // so we count only the sweep's notification.
+        let stub = StubDelegate()
+        await storage.setDelegate(stub)
+
+        let result = try await storage.runMaintenanceSweep(now: Date().addingTimeInterval(3600))
+        XCTAssertGreaterThanOrEqual(result.recovered, 1, "sweep should reclaim the expired-lease row")
+        XCTAssertEqual(stub.count, 1, "runMaintenanceSweep must fire the delegate exactly once")
+
+        // Cleanup: the row is now `queued` (or `dead`); claim+ack to drain.
+        if let again = try await storage.claimNext(claimedBy: "delegate-test-worker"),
+           let aSid = again.storageId {
+            try? await storage.ack(storageId: aSid)
+        }
+    }
+
     // MARK: - Read methods do NOT fire
 
     func test_readMethods_doNotFireDelegate() async throws {

--- a/Desktop/Tests/PendingWorkStorageDelegateTests.swift
+++ b/Desktop/Tests/PendingWorkStorageDelegateTests.swift
@@ -195,6 +195,54 @@ final class PendingWorkStorageDelegateTests: XCTestCase {
         }
     }
 
+    /// Covers the `attempts + 1 >= maxAttempts` branch of the lease-reclaim
+    /// CASE: a row that's one fail away from `dead` should get pushed to `dead`
+    /// (not back to `queued`) when its lease expires. Locks in the count so a
+    /// regression in the CASE expression can't slip through.
+    func test_runMaintenanceSweep_transitionsExhaustedRowToDead() async throws {
+        try await drainQueue()
+        let storage = PendingWorkStorage.shared
+
+        // Enqueue + claim, then bump `attempts` to maxAttempts - 1 directly so
+        // the next attempt-bump (the sweep's reclaim) tips it into `dead`.
+        // Default maxAttempts is 8 (set by the table schema / record default).
+        _ = try await storage.enqueue(
+            workType: workType,
+            payload: Data("delegate-test-sweep-dead".utf8),
+            dedupKey: "delegate-sweep-dead-\(UUID().uuidString)"
+        )
+        guard let claimed = try await storage.claimNext(claimedBy: "delegate-test-worker"),
+              let sid = claimed.storageId else {
+            return XCTFail("expected to claim our just-enqueued row")
+        }
+
+        // Force attempts up to one-below-max via the same db pool. Read max from
+        // the row so we don't hard-code the schema default.
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+            return XCTFail("database queue unavailable")
+        }
+        try await dbQueue.write { db in
+            try db.execute(sql: """
+                UPDATE pending_work
+                SET attempts = maxAttempts - 1
+                WHERE id = ?
+            """, arguments: [sid])
+        }
+
+        let stub = StubDelegate()
+        await storage.setDelegate(stub)
+
+        let result = try await storage.runMaintenanceSweep(now: Date().addingTimeInterval(3600))
+        XCTAssertGreaterThanOrEqual(result.recovered, 1, "sweep should reclaim our row")
+        XCTAssertEqual(stub.count, 1, "sweep must fire the delegate exactly once even when transitioning to dead")
+
+        // Verify the row landed in `dead`, not `queued`.
+        let landedStatus: String? = try await dbQueue.read { db in
+            try String.fetchOne(db, sql: "SELECT status FROM pending_work WHERE id = ?", arguments: [sid])
+        }
+        XCTAssertEqual(landedStatus, "dead", "exhausted-attempts row should transition to dead, not queued")
+    }
+
     // MARK: - Read methods do NOT fire
 
     func test_readMethods_doNotFireDelegate() async throws {


### PR DESCRIPTION
## Summary
- Adds `PendingWorkStorage.runMaintenanceSweep(now:)` that performs lease-reclaim + done-GC + dead-GC inside the storage actor and fires the mutation delegate once per sweep.
- Refactors `PendingWorkSweeper.sweep()` to a thin wrapper over the new actor method — no more direct `RewindDatabase.shared.getDatabaseQueue()` writes.
- Removes the unused `import GRDB` from the sweeper now that all SQL lives behind the actor.

## Why
Per #44, the sweeper bypassed the `PendingWorkStorageDelegate` added in #41, so reclaiming an orphaned `claimed` row (or GC'ing dead rows) didn't push a depth update to the Rust daemon — Activity panel counts went stale until the next non-sweeper write.

Picked option 1 from the issue (route through the actor) over option 2 (notify after direct writes) so the mutation contract stays inside the actor — future writers can't forget to notify.

## Test plan
- [x] New test `test_runMaintenanceSweep_firesDelegateOnce_afterReclaimingExpiredLease` enqueues + claims a row, then runs the sweep with `now + 1h` to force lease expiry, and asserts the delegate fires exactly once.
- [x] All 5 `PendingWorkStorageDelegateTests` pass.
- [x] `xcrun swift build -c debug --package-path Desktop` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)