### PR TITLE
fix(run.sh): warn when IR_SKIP_BACKEND leaves a stale launchd daemon (#48)

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -128,6 +128,33 @@ is_truthy() {
     esac
 }
 
+warn_if_daemon_stale() {
+    local installed="$HOME/Library/Application Support/InfiniteRecall/bin/infinite-recall-api"
+    local src_dir="$(dirname "$0")/Backend-Rust"
+    [ -x "$installed" ] || return 0
+    [ -d "$src_dir" ] || return 0
+    local newer
+    newer=$(find "$src_dir" \( -name '*.rs' -o -name 'Cargo.toml' -o -name 'Cargo.lock' \) -type f -newer "$installed" -print 2>/dev/null)
+    [ -n "$newer" ] || return 0
+    {
+        echo ""
+        echo "=========================================="
+        echo "  WARNING: stale launchd daemon detected"
+        echo "=========================================="
+        echo "  IR_SKIP_BACKEND=1 is set, but the installed daemon at"
+        echo "    $installed"
+        echo "  is older than Backend-Rust/ source files. New routes (e.g."
+        echo "  /v1/activity/snapshot) will 404 until you reinstall."
+        echo ""
+        echo "  Newer source files:"
+        printf '%s\n' "$newer" | head -3 | sed 's/^/    /'
+        echo ""
+        echo "  Fix:  ./scripts/setup-api-server.sh --yes"
+        echo "=========================================="
+        echo ""
+    } >&2
+}
+
 make_temp_file() {
     local var_name="$1"
     local template="$2"
@@ -702,6 +729,7 @@ if [ "${IR_SKIP_BACKEND:-0}" != "1" ]; then
     done
 else
     substep "Skipping backend (IR_SKIP_BACKEND=1) — using IR_API_URL from .env"
+    warn_if_daemon_stale
 fi
 
 # ─── Start Python auth service ────────────────────────────────────────

--- a/run.sh
+++ b/run.sh
@@ -130,7 +130,8 @@ is_truthy() {
 
 warn_if_daemon_stale() {
     local installed="$HOME/Library/Application Support/InfiniteRecall/bin/infinite-recall-api"
-    local src_dir="$(dirname "$0")/Backend-Rust"
+    local src_dir
+    src_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/Backend-Rust" 2>/dev/null && pwd)"
     [ -x "$installed" ] || return 0
     [ -d "$src_dir" ] || return 0
     local newer


### PR DESCRIPTION
## Summary

Adds a `warn_if_daemon_stale` helper to `run.sh` that detects when `IR_SKIP_BACKEND=1` is set but a previously-launched `infinite-recall` launchd daemon is still running against an outdated binary. Prints a clear warning so contributors don't silently test against a stale backend.

The second commit applies code-review feedback by resolving `src_dir` to an absolute path before comparison, so the check works correctly regardless of where `run.sh` is invoked from.

## Review

Completed full 3-reviewer + 3-tiebreaker review pass; consensus was to land with the absolute-path fix included.

Closes #48

## Test plan

- [x] Local syntax check (`bash -n run.sh`) clean
- [x] `shellcheck run.sh` — no new warnings vs `main`
- [ ] Manual: run with `IR_SKIP_BACKEND=1` after a stale daemon is loaded; confirm warning fires
- [ ] Manual: run with no daemon loaded; confirm helper is silent
- [ ] Manual: run from a sibling directory; confirm absolute-path comparison still matches