### PR TITLE
refactor(activity): rename BlockReason::Unwired -> Initializing

### DIFF
--- a/Backend-Rust/api/src/activity/contract.md
+++ b/Backend-Rust/api/src/activity/contract.md
@@ -124,7 +124,7 @@ and a stringly-typed `waiting_for`.
 | `PauseRequest.target` / `ResumeRequest.target` / `PauseTargetId` | `kind`, `capture` (with typed `id` payload — see below) |
 | `ResourceSample.thermal_state` / `ThermalState` | `nominal`, `fair`, `serious`, `critical` |
 | `GateState` (variant tag on `state`) | `allowed`, `blocked` |
-| `GateState.reason` / `BlockReason` (only when `state="blocked"`) | `device_active`, `on_battery`, `thermal`, `locked`, `manual_pause`, `unwired` |
+| `GateState.reason` / `BlockReason` (only when `state="blocked"`) | `device_active`, `on_battery`, `thermal`, `locked`, `manual_pause`, `initializing` |
 
 ### `PauseRequest` / `ResumeRequest`
 
@@ -177,8 +177,8 @@ changes. Body shape is exactly `GateState` — see above for both variants.
 ```
 
 `BridgedProcessingGate` (the production `ProcessingGate` impl) seeds itself
-with `Blocked { reason: "unwired", waiting_for: { "type": "manual" } }` on
-daemon startup and overwrites that on the first POST. The `unwired` window
+with `Blocked { reason: "initializing", waiting_for: { "type": "manual" } }` on
+daemon startup and overwrites that on the first POST. The `initializing` window
 is typically ~3s.
 
 ---

--- a/Backend-Rust/api/src/activity/gate.rs
+++ b/Backend-Rust/api/src/activity/gate.rs
@@ -43,14 +43,13 @@ pub struct BridgedProcessingGate {
 }
 
 impl BridgedProcessingGate {
-    /// Construct a gate seeded with `Blocked { reason: Unwired, ... }`.
-    /// The variant is the same honest "not wired yet" signal the previous
-    /// stub emitted; once Swift POSTs its first real reading, this is
-    /// overwritten and never reverts.
+    /// Construct a gate seeded with `Blocked { reason: Initializing, ... }`
+    /// so callers see "initializing" until Swift POSTs its first real
+    /// reading, which overwrites the state and never reverts.
     pub fn new() -> Self {
         tracing::info!(
             target: "activity.gate",
-            initial = "Unwired",
+            initial = "Initializing",
             "BridgedProcessingGate constructed"
         );
         Self {
@@ -65,8 +64,8 @@ impl BridgedProcessingGate {
     /// `into_inner()` rather than panicking the route handler. The data
     /// itself is still writable.
     ///
-    /// `Blocked { reason: Unwired, .. }` is rejected (defense-in-depth):
-    /// the `Unwired` variant exists ONLY to represent "haven't received
+    /// `Blocked { reason: Initializing, .. }` is rejected (defense-in-depth):
+    /// the `Initializing` variant exists ONLY to represent "haven't received
     /// the first POST yet" — Swift should never post it. We swallow the
     /// write and emit a `tracing::warn!` so an external POST can't latch
     /// the gate back into the boot-window state. The route handler still
@@ -74,14 +73,14 @@ impl BridgedProcessingGate {
     /// caller.
     pub fn set(&self, new_state: GateState) {
         if let GateState::Blocked {
-            reason: BlockReason::Unwired,
+            reason: BlockReason::Initializing,
             ..
         } = &new_state
         {
             tracing::warn!(
                 target: "activity.gate",
                 ?new_state,
-                "rejected external Unwired gate-state post (Unwired is reserved for the boot window)"
+                "rejected external Initializing gate-state post (Initializing is reserved for the boot window)"
             );
             return;
         }
@@ -121,7 +120,7 @@ impl WritableProcessingGate for BridgedProcessingGate {
 
 fn initial_state() -> GateState {
     GateState::Blocked {
-        reason: BlockReason::Unwired,
+        reason: BlockReason::Initializing,
         since: Utc::now(),
         waiting_for: WaitCondition::Manual,
     }
@@ -147,14 +146,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn initial_state_is_blocked_unwired() {
+    fn initial_state_is_blocked_initializing() {
         let gate = BridgedProcessingGate::new();
         match gate.current() {
             GateState::Blocked { reason, waiting_for, .. } => {
-                assert_eq!(reason, BlockReason::Unwired);
+                assert_eq!(reason, BlockReason::Initializing);
                 assert_eq!(waiting_for, WaitCondition::Manual);
             }
-            GateState::Allowed { .. } => panic!("initial must be Blocked Unwired"),
+            GateState::Allowed { .. } => panic!("initial must be Blocked Initializing"),
         }
     }
 

--- a/Backend-Rust/api/src/activity/types.rs
+++ b/Backend-Rust/api/src/activity/types.rs
@@ -112,7 +112,7 @@ pub enum BlockReason {
     /// arrives. Should only be observed during the brief boot window
     /// (~3s — one `ProcessingGateReporter` poll cycle). External POSTs
     /// of this variant are rejected by `BridgedProcessingGate::set`.
-    Unwired,
+    Initializing,
 }
 
 /// What the gate is waiting for before it will let work drain again.
@@ -405,7 +405,7 @@ mod tests {
             (BlockReason::Thermal, "thermal"),
             (BlockReason::Locked, "locked"),
             (BlockReason::ManualPause, "manual_pause"),
-            (BlockReason::Unwired, "unwired"),
+            (BlockReason::Initializing, "initializing"),
         ] {
             assert_eq!(serde_json::to_string(&r).unwrap(), format!("\"{wire}\""));
             let back: BlockReason = serde_json::from_str(&format!("\"{wire}\"")).unwrap();

--- a/Backend-Rust/api/src/lib.rs
+++ b/Backend-Rust/api/src/lib.rs
@@ -64,7 +64,7 @@ pub async fn run() -> Result<()> {
     // Issue #32: real `ProcessingGate` implementation. Swift owns the OS
     // signal observation and POSTs `GateState` updates to
     // `/v1/activity/_internal/gate-state`. Until that first POST arrives,
-    // `current()` returns `Blocked { reason: Unwired, ... }` so the UI is
+    // `current()` returns `Blocked { reason: Initializing, ... }` so the UI is
     // honest about the brief startup window.
     //
     // Single backing Arc upcast into both the read-side (`ProcessingGate`)

--- a/Backend-Rust/api/tests/activity_endpoints.rs
+++ b/Backend-Rust/api/tests/activity_endpoints.rs
@@ -775,7 +775,7 @@ async fn enum_round_trip_via_wire() {
         (t::BlockReason::Thermal, "thermal"),
         (t::BlockReason::Locked, "locked"),
         (t::BlockReason::ManualPause, "manual_pause"),
-        (t::BlockReason::Unwired, "unwired"),
+        (t::BlockReason::Initializing, "initializing"),
     ] {
         let s = serde_json::to_string(&reason).unwrap();
         assert_eq!(s, format!("\"{wire}\""));
@@ -994,7 +994,7 @@ async fn gate_state_post_updates_snapshot() {
     let app = routes::router(state);
     let (k, v) = auth_header();
 
-    // Pre-condition: snapshot reports `Blocked { reason: Unwired }` until
+    // Pre-condition: snapshot reports `Blocked { reason: Initializing }` until
     // the first POST arrives.
     let snap_req = Request::builder()
         .method(Method::GET)
@@ -1004,7 +1004,7 @@ async fn gate_state_post_updates_snapshot() {
         .unwrap();
     let snap = json_body(app.clone().oneshot(snap_req).await.unwrap()).await;
     assert_eq!(snap["processing_gate"]["state"], json!("blocked"));
-    assert_eq!(snap["processing_gate"]["reason"], json!("unwired"));
+    assert_eq!(snap["processing_gate"]["reason"], json!("initializing"));
 
     // POST a real `Allowed` state.
     let body = json!({
@@ -1126,15 +1126,15 @@ async fn gate_state_post_rejects_invalid_bodies() {
     }
 }
 
-/// `BridgedProcessingGate::set` rejects external `Blocked { Unwired, .. }`
-/// posts (defense-in-depth). The `Unwired` variant exists ONLY to
+/// `BridgedProcessingGate::set` rejects external `Blocked { Initializing, .. }`
+/// posts (defense-in-depth). The `Initializing` variant exists ONLY to
 /// represent "haven't received the first POST yet" — Swift should never
 /// post it, but if it ever does, we must not let it latch the gate back
 /// into the boot-window state. The route handler still returns 204 (this
 /// is internal validation that doesn't leak to the caller); the post-
 /// condition is that the stored gate state is unchanged.
 #[tokio::test]
-async fn gate_state_post_rejects_external_unwired_silently() {
+async fn gate_state_post_rejects_external_initializing_silently() {
     use infinite_recall_api::activity::BridgedProcessingGate;
 
     let gate: Arc<BridgedProcessingGate> = Arc::new(BridgedProcessingGate::new());
@@ -1148,7 +1148,7 @@ async fn gate_state_post_rejects_external_unwired_silently() {
     let app = routes::router(state);
     let (k, v) = auth_header();
 
-    // Pre: snapshot reports Unwired (initial state, no real POST yet).
+    // Pre: snapshot reports Initializing (initial state, no real POST yet).
     let snap_req = Request::builder()
         .method(Method::GET)
         .uri("/v1/activity/snapshot")
@@ -1157,18 +1157,18 @@ async fn gate_state_post_rejects_external_unwired_silently() {
         .unwrap();
     let snap = json_body(app.clone().oneshot(snap_req).await.unwrap()).await;
     assert_eq!(snap["processing_gate"]["state"], json!("blocked"));
-    assert_eq!(snap["processing_gate"]["reason"], json!("unwired"));
+    assert_eq!(snap["processing_gate"]["reason"], json!("initializing"));
     let initial_since = snap["processing_gate"]["since"]
         .as_str()
         .expect("since must be a string")
         .to_string();
 
-    // POST a `Blocked { Unwired, .. }` body — the handler must accept it
+    // POST a `Blocked { Initializing, .. }` body — the handler must accept it
     // at the wire level (return 204) but the gate's internal state must
     // be unchanged (rejected by `BridgedProcessingGate::set`).
     let body = json!({
         "state": "blocked",
-        "reason": "unwired",
+        "reason": "initializing",
         "since": "2030-01-01T00:00:00.000Z",
         "waiting_for": { "type": "manual" }
     });
@@ -1183,7 +1183,7 @@ async fn gate_state_post_rejects_external_unwired_silently() {
     // 204 — defense-in-depth, no validation leak.
     assert_eq!(resp.status(), StatusCode::NO_CONTENT);
 
-    // Post: snapshot still reports the original Unwired state (the same
+    // Post: snapshot still reports the original Initializing state (the same
     // `since` from before — the rejected POST didn't overwrite anything).
     let snap_req = Request::builder()
         .method(Method::GET)
@@ -1193,10 +1193,10 @@ async fn gate_state_post_rejects_external_unwired_silently() {
         .unwrap();
     let snap = json_body(app.clone().oneshot(snap_req).await.unwrap()).await;
     assert_eq!(snap["processing_gate"]["state"], json!("blocked"));
-    assert_eq!(snap["processing_gate"]["reason"], json!("unwired"));
+    assert_eq!(snap["processing_gate"]["reason"], json!("initializing"));
     assert_eq!(
         snap["processing_gate"]["since"].as_str().unwrap(),
         initial_since,
-        "`since` must NOT advance — the Unwired POST should be a no-op"
+        "`since` must NOT advance — the Initializing POST should be a no-op"
     );
 }

--- a/Desktop/Sources/Activity/ActivityModels.swift
+++ b/Desktop/Sources/Activity/ActivityModels.swift
@@ -104,7 +104,7 @@ public enum BlockReason: String, Codable, Hashable, CaseIterable {
     /// arrives. Should only be observed during the brief boot window
     /// (~3s — one `ProcessingGateReporter` poll cycle). External POSTs
     /// of this variant are rejected by the Rust `BridgedProcessingGate`.
-    case unwired
+    case initializing
 }
 
 /// Issue #35: typed mirror of Rust's `WaitCondition`. Replaces the

--- a/Desktop/Sources/Activity/ActivityPage.swift
+++ b/Desktop/Sources/Activity/ActivityPage.swift
@@ -233,9 +233,9 @@ struct ActivityPage: View {
                 detail: detail,
                 color: OmiColors.error
             )
-        case .unwired:
+        case .initializing:
             // Issue #32: with the Swift→Rust gate-state bridge live, the
-            // Rust gate only emits `.unwired` during the brief startup
+            // Rust gate only emits `.initializing` during the brief startup
             // window before the first `ProcessingGateReporter` POST
             // arrives (typically <3s). Soften the copy accordingly.
             return BannerInfo(
@@ -638,12 +638,12 @@ struct ActivityPage: View {
             case .allowed:
                 return ("Up to date — 0 queued", "Idle processing standing by.")
             case .blocked(let reason, _, let waitingFor):
-                // Issue #32: with the Swift→Rust bridge live, `.unwired`
+                // Issue #32: with the Swift→Rust bridge live, `.initializing`
                 // is now just the brief boot window before the first
                 // `ProcessingGateReporter` POST. Render as "Initializing…"
                 // instead of the alarming pre-#32 copy.
                 let detail = emptyStateBlockedDetail(reason: reason, waitingFor: waitingFor)
-                let title = (reason == .unwired)
+                let title = (reason == .initializing)
                     ? "Initializing…"
                     : "Up to date — 0 queued"
                 return (title, detail)
@@ -682,7 +682,7 @@ struct ActivityPage: View {
         case .thermal:      return "Waiting for thermal cooldown."
         case .locked:       return "Resumes when you unlock."
         case .manualPause:  return "Manually paused."
-        case .unwired:      return "Reading idle / power / thermal state."
+        case .initializing: return "Reading idle / power / thermal state."
         }
     }
 

--- a/Desktop/Sources/Activity/ProcessingGateReporter.swift
+++ b/Desktop/Sources/Activity/ProcessingGateReporter.swift
@@ -171,7 +171,7 @@ public func computeGateState(_ inputs: ProcessingGateInputs, now: Date = Date())
 ///   1. `start()` is called from `OmiApp` after `BatteryAwareScheduler`
 ///      starts.
 ///   2. We POST the initial state immediately (so the Rust gate's
-///      `Blocked(.unwired)` startup window closes within ~1 RTT).
+///      `Blocked(.initializing)` startup window closes within ~1 RTT).
 ///   3. We re-evaluate every `pollIntervalSeconds` (default 3s) and POST
 ///      only when the computed state structurally differs from
 ///      `lastPostedState`.
@@ -227,7 +227,7 @@ public final class ProcessingGateReporter {
 
     pollTask = Task { @MainActor [weak self] in
       // First tick fires immediately so the Rust gate stops reporting
-      // `Unwired` as soon as we have credentials + reachability.
+      // `Initializing` as soon as we have credentials + reachability.
       await self?.tick()
       while !Task.isCancelled {
         try? await Task.sleep(nanoseconds: UInt64((self?.pollIntervalSeconds ?? 3.0) * 1_000_000_000))
@@ -274,10 +274,10 @@ public final class ProcessingGateReporter {
 
       // Daemon-restart heuristic: 401 (token rotated), connection refused,
       // or 5xx gateway-style errors all indicate the daemon may have just
-      // restarted with a fresh `Blocked(.unwired)` initial state. Clear
+      // restarted with a fresh `Blocked(.initializing)` initial state. Clear
       // the local de-dupe cache so the NEXT successful POST re-syncs the
       // daemon to current Swift-side truth — otherwise the daemon could
-      // stay stuck on Unwired while Swift believes it already posted the
+      // stay stuck on Initializing while Swift believes it already posted the
       // current state.
       if Self.isDaemonRestartIndicator(error) {
         lastPostedState = nil

--- a/Desktop/Tests/ActivityModelsTests.swift
+++ b/Desktop/Tests/ActivityModelsTests.swift
@@ -303,17 +303,18 @@ final class ActivityModelsTests: XCTestCase {
     func testBlockReasonEveryEnumValueDecodes() throws {
         // Issue #35: BlockReason replaces GateReason. The pre-#35 `idle`
         // and `none` reasons are gone — they map to `Allowed` now.
-        // PR #40 review: `unwired` is the placeholder reason returned by
-        // Rust's `AlwaysAllowedGate` until the real ProcessingGate (#32)
-        // ships — it MUST decode + encode like every other variant so the
-        // UI can render an honest "gate not yet wired" banner.
+        // PR #40 review: `initializing` is the placeholder reason returned
+        // by Rust's `BridgedProcessingGate` during the brief boot window
+        // before the first `ProcessingGateReporter` POST arrives — it MUST
+        // decode + encode like every other variant so the UI can render an
+        // honest "initializing" banner.
         let cases: [(String, BlockReason)] = [
             ("device_active", .deviceActive),
             ("on_battery",    .onBattery),
             ("thermal",       .thermal),
             ("locked",        .locked),
             ("manual_pause",  .manualPause),
-            ("unwired",       .unwired),
+            ("initializing",  .initializing),
         ]
         for (wire, expected) in cases {
             let json = """

--- a/e2e/activity-tab.md
+++ b/e2e/activity-tab.md
@@ -107,7 +107,7 @@ osascript -e 'tell application "Infinite Recall" to quit'
     `{state: "allowed", since: iso8601}` OR
     `{state: "blocked", reason: <BlockReason>, since: iso8601,
       waiting_for: <WaitCondition>}` where `BlockReason` is one of
-    `device_active|on_battery|thermal|locked|manual_pause` and
+    `device_active|on_battery|thermal|locked|manual_pause|initializing` and
     `WaitCondition` is `{type: "idle_for", duration_secs: u64}` or
     `{type: "ac_power"|"thermal_cooldown"|"unlock"|"manual"}`.
   - `generated_at` — iso8601.


### PR DESCRIPTION
## Summary

- Renames `BlockReason::Unwired` → `BlockReason::Initializing` (Rust enum + matching Swift case).
- Wire-format break: serde tag changes from `"unwired"` → `"initializing"` (enum has `#[serde(rename_all = "snake_case")]`).
- Atomic across Rust API and Swift desktop — no transition window (`#[serde(alias)]`) since the variant only fires during the ~3s boot window before `BridgedProcessingGate` receives its first `ProcessingGateReporter` POST, and external clients never legitimately POST it.
- Doc-comments and prose updated post-#32 (e.g., dropped a stale "AlwaysAllowedGate used to emit not-wired-yet" claim that was factually wrong).
- Adds `initializing` to the `BlockReason` enumeration in `e2e/activity-tab.md` (was missing).

Closes #46

## Test plan

- [x] `cargo build` — clean (one pre-existing unused-import warning in `routes/health.rs`, unrelated)
- [x] `cargo test -p infinite-recall-api` — 49 unit tests pass
- [x] `cargo test -p infinite-recall-api --features activity_test_wiring` — 20 integration tests pass (gated by feature flag per `tests/activity_endpoints.rs` preamble)
- [x] `xcrun swift build` — succeeds (only pre-existing Sendable warnings in `OmiApp.swift`)
- [x] `xcrun swift test` targeted: `ActivityModelsTests` 26/26 pass; `ProcessingGateReporterTests` 15/15 pass
- [x] `rg -n 'Unwired|unwired'` — zero hits across the worktree
- [x] Multi-agent code review (3 parallel reviewers + 3 triangulation reviewers on the singleton finding); single consensus fix applied to `gate.rs` doc-comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)