### PR TITLE
feat(ai): inline install progress strip on Settings cards

### DIFF
--- a/Desktop/Sources/AI/LocalAIInstaller.swift
+++ b/Desktop/Sources/AI/LocalAIInstaller.swift
@@ -86,6 +86,9 @@ final class LocalAIInstaller: ObservableObject {
   @Published var modelTotalBytes: Int64 = 0
   @Published var isRunning: Bool = false
   @Published var error: String? = nil
+  /// Set when the user clicks Cancel so terminal-state UI can distinguish a
+  /// deliberate cancel (non-zero exit from SIGTERM) from a real crash.
+  @Published private(set) var wasCancelled: Bool = false
 
   // MARK: - Internal
 
@@ -137,10 +140,29 @@ final class LocalAIInstaller: ObservableObject {
       modelId: modelId)
   }
 
+  /// Clear a terminal `.failed` state so inline UI (e.g. `LocalAIInstallStrip`)
+  /// can be dismissed by the user without retrying. Safe to call from the
+  /// main actor; no-op while an install is still in flight.
+  @MainActor
+  func dismissResult() {
+    guard !isRunning else { return }
+    // Clear only the tier whose terminal state is being dismissed — the other
+    // tier's pending id may still be meaningful (e.g. a recent successful
+    // install that the user hasn't acknowledged yet).
+    switch pendingKind {
+    case .mlx: pendingMLXModelId = nil
+    case .vlm: pendingVLMModelId = nil
+    case .api: break
+    }
+    resetState()
+    modelTotalBytes = 0
+  }
+
   /// Terminate the running install. Sends SIGTERM, then SIGKILL after 2s if
   /// the process is still alive.
   func cancel() {
     guard let p = process, p.isRunning else { return }
+    Task { @MainActor in self.wasCancelled = true }
     p.terminate()
     let proc = p
     DispatchQueue.global().asyncAfter(deadline: .now() + 2) {
@@ -153,20 +175,26 @@ final class LocalAIInstaller: ObservableObject {
 
   // MARK: - Implementation
 
-  private enum Kind { case mlx, api, vlm }
+  /// Which sidecar a given install run targets. Published via `pendingKind`
+  /// so inline UI (e.g. `LocalAIInstallStrip`) can scope itself to the right
+  /// settings card without inspecting model-id state.
+  enum Kind { case mlx, api, vlm }
 
   /// Catalog model id to install when `kind == .mlx`. nil means "use the
   /// shell script's hardcoded default" (preserves the original single-model
-  /// install path).
-  private var pendingMLXModelId: String? = nil
+  /// install path). Published so UI (e.g. `LocalAIInstallSheet`) can render
+  /// the actual id being installed instead of falling back to the catalog
+  /// recommendation when the install was kicked off without an explicit id.
+  @Published private(set) var pendingMLXModelId: String? = nil
 
   /// Catalog model id to install when `kind == .vlm`. Mirrors `pendingMLXModelId`
   /// but for the vision tier. nil means use the VLM script's default.
-  private var pendingVLMModelId: String? = nil
+  @Published private(set) var pendingVLMModelId: String? = nil
 
   /// Tracks which kind we're currently running so refresh + env-setup can branch
-  /// without inspecting the extractor closure.
-  private var pendingKind: Kind = .mlx
+  /// without inspecting the extractor closure. Published so per-tier UI strips
+  /// only render for the install they're scoped to.
+  @Published private(set) var pendingKind: Kind = .mlx
 
   private func start(
     extractor: () throws -> URL,
@@ -265,6 +293,7 @@ final class LocalAIInstaller: ObservableObject {
     modelDownloadedBytes = nil
     error = nil
     lineBuffer = ""
+    wasCancelled = false
   }
 
   private func runProcess(scriptURL: URL, kind: Kind) async {

--- a/Desktop/Sources/MainWindow/Pages/LocalAIInstallSheet.swift
+++ b/Desktop/Sources/MainWindow/Pages/LocalAIInstallSheet.swift
@@ -20,7 +20,7 @@ struct LocalAIInstallSheet: View {
   }
 
   @Environment(\.dismiss) private var dismiss
-  @StateObject private var installer = LocalAIInstaller.shared
+  @ObservedObject private var installer = LocalAIInstaller.shared
   @State private var showLogs: Bool = false
 
   /// Which sidecar to install. See `Kind`.
@@ -28,10 +28,6 @@ struct LocalAIInstallSheet: View {
 
   /// Optional override of the model id (only honored for `.mlx` and `.vlm`).
   var modelId: String? = nil
-
-  /// Legacy back-compat shim: callers that pass `installAPIInstead: true` still
-  /// work and are mapped to `kind = .api`.
-  var installAPIInstead: Bool = false
 
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
@@ -67,11 +63,6 @@ struct LocalAIInstallSheet: View {
       // Kick off the install once the sheet appears, but only if we're not
       // already running (e.g. the sheet got re-presented after being closed).
       if !installer.isRunning && installer.currentStep != .done {
-        // Honor legacy installAPIInstead first, then fall through to `kind`.
-        if installAPIInstead {
-          await installer.startAPIInstall()
-          return
-        }
         switch kind {
         case .mlx:
           if let id = modelId {
@@ -92,11 +83,24 @@ struct LocalAIInstallSheet: View {
 
   /// Human-readable tier label that matches the card title in Settings.
   private var tierLabel: String {
-    let resolvedKind = installAPIInstead ? Kind.api : kind
-    switch resolvedKind {
+    switch kind {
     case .vlm: return "Vision Model"
     case .api: return "API Server"
     case .mlx: return "Local Model"
+    }
+  }
+
+  /// Resolve which model id the sheet should describe. Prefer the explicit
+  /// `modelId` argument, then fall back to the id the installer is currently
+  /// working on (set by `start{MLX,VLM}Install`). This keeps the header and
+  /// step labels aligned with the actual install — including custom HF ids —
+  /// when the call site presents the sheet without threading the id through.
+  private var resolvedModelId: String? {
+    if let id = modelId { return id }
+    switch kind {
+    case .mlx: return installer.pendingMLXModelId
+    case .vlm: return installer.pendingVLMModelId
+    case .api: return nil
     }
   }
 
@@ -106,15 +110,14 @@ struct LocalAIInstallSheet: View {
   /// network probe), so we return "size unknown" rather than seeding a
   /// misleading "0 GB" figure — the real progress comes from the installer.
   private var catalogDiskSizeLabel: String {
-    let resolvedKind = installAPIInstead ? Kind.api : kind
-    switch resolvedKind {
+    switch kind {
     case .mlx:
-      let entry = modelId.map { LocalModelCatalog.entry(forId: $0) }
+      let entry = resolvedModelId.map { LocalModelCatalog.entry(forId: $0) }
         ?? LocalModelCatalog.recommended
       if entry.approxDiskGB == 0 { return "size unknown" }
       return String(format: "%.4g GB", entry.approxDiskGB)
     case .vlm:
-      let entry = modelId.map { VisionModelCatalog.entry(forId: $0) }
+      let entry = resolvedModelId.map { VisionModelCatalog.entry(forId: $0) }
         ?? VisionModelCatalog.recommended
       if entry.approxDiskGB == 0 { return "size unknown" }
       return String(format: "%.4g GB", entry.approxDiskGB)
@@ -241,15 +244,30 @@ struct LocalAIInstallSheet: View {
 
   private var downloadProgressView: some View {
     VStack(alignment: .leading, spacing: 4) {
-      ProgressView(value: installer.modelDownloadProgress ?? 0)
-        .progressViewStyle(LinearProgressViewStyle(tint: OmiColors.purplePrimary))
+      // Custom HF ids skip the catalog-seeded total, so modelTotalBytes is 0
+      // until snapshot_download reports its first chunk. Show an indeterminate
+      // bar in that case rather than a misleading 0%-of-? sliver.
+      let hasTotal = installer.modelTotalBytes > 0
+      if hasTotal {
+        ProgressView(value: installer.modelDownloadProgress ?? 0)
+          .progressViewStyle(LinearProgressViewStyle(tint: OmiColors.purplePrimary))
+      } else {
+        ProgressView()
+          .progressViewStyle(LinearProgressViewStyle(tint: OmiColors.purplePrimary))
+      }
 
-      let pct = Int((installer.modelDownloadProgress ?? 0) * 100)
       let downloaded = LocalAIInstaller.formattedBytes(installer.modelDownloadedBytes)
-      let total = LocalAIInstaller.formattedBytes(installer.modelTotalBytes)
-      Text("\(pct)% — \(downloaded) of \(total)")
-        .scaledFont(size: 11)
-        .foregroundColor(OmiColors.textTertiary)
+      if hasTotal {
+        let pct = Int((installer.modelDownloadProgress ?? 0) * 100)
+        let total = LocalAIInstaller.formattedBytes(installer.modelTotalBytes)
+        Text("\(pct)% — \(downloaded) of \(total)")
+          .scaledFont(size: 11)
+          .foregroundColor(OmiColors.textTertiary)
+      } else {
+        Text("\(downloaded) downloaded")
+          .scaledFont(size: 11)
+          .foregroundColor(OmiColors.textTertiary)
+      }
     }
   }
 

--- a/Desktop/Sources/MainWindow/Pages/LocalAIInstallStrip.swift
+++ b/Desktop/Sources/MainWindow/Pages/LocalAIInstallStrip.swift
@@ -1,0 +1,312 @@
+// Inline progress strip rendered under the active-model summary on the
+// Local Model and Vision Model settings cards. Replaces the prior modal
+// install sheet for the two model tiers — the user can switch tabs,
+// scroll, or close the window mid-install without losing progress, since
+// `LocalAIInstaller.shared` is a singleton whose `@Published` state
+// survives view re-mounts.
+//
+// Scope: text tier (.mlx) and vision tier (.vlm) only. The API server
+// install still uses `LocalAIInstallSheet` because it's rarer and shorter.
+
+import SwiftUI
+
+struct LocalAIInstallStrip: View {
+
+  /// Which tier this strip belongs to. The strip self-hides whenever
+  /// `installer.pendingKind` doesn't match — only the card whose install
+  /// is actually running shows progress.
+  let kind: LocalAIInstaller.Kind
+
+  @ObservedObject private var installer = LocalAIInstaller.shared
+  @State private var expanded: Bool = false
+
+  var body: some View {
+    Group {
+      if shouldShow {
+        VStack(alignment: .leading, spacing: 10) {
+          headerRow
+          progressRow
+          if expanded {
+            detailsView
+              .transition(.opacity.combined(with: .move(edge: .top)))
+          }
+        }
+        .padding(12)
+        .background(OmiColors.backgroundSecondary)
+        .cornerRadius(8)
+        .transition(.opacity)
+      }
+    }
+    .animation(.easeInOut(duration: 0.2), value: shouldShow)
+    .animation(.easeInOut(duration: 0.2), value: expanded)
+  }
+
+  // MARK: - Visibility
+
+  /// Show whenever this tier has an in-flight install, a sticky failure, or a
+  /// completed install the user hasn't acknowledged yet. Without `.done` here
+  /// the strip would vanish the same frame the install completes — after a
+  /// multi-GB download the user gets no confirmation that anything succeeded.
+  private var shouldShow: Bool {
+    guard installer.pendingKind == kind else { return false }
+    return installer.isRunning
+      || installer.currentStep == .failed
+      || installer.currentStep == .done
+  }
+
+  // MARK: - Header row
+
+  private var headerRow: some View {
+    HStack(alignment: .center, spacing: 10) {
+      icon
+      VStack(alignment: .leading, spacing: 2) {
+        Text(titleText)
+          .scaledFont(size: 13, weight: .semibold)
+          .foregroundColor(OmiColors.textPrimary)
+        if let subtitle = subtitleText {
+          Text(subtitle)
+            .scaledFont(size: 11)
+            .foregroundColor(OmiColors.textSecondary)
+            .lineLimit(2)
+            .truncationMode(.middle)
+        }
+      }
+      Spacer(minLength: 8)
+      controlButtons
+    }
+  }
+
+  @ViewBuilder
+  private var icon: some View {
+    if installer.currentStep == .failed {
+      Image(systemName: installer.wasCancelled ? "xmark.circle" : "exclamationmark.triangle.fill")
+        .foregroundColor(installer.wasCancelled ? OmiColors.textSecondary : OmiColors.error)
+        .scaledFont(size: 14)
+    } else if installer.currentStep == .done {
+      Image(systemName: "checkmark.circle.fill")
+        .foregroundColor(OmiColors.success)
+        .scaledFont(size: 14)
+    } else {
+      ProgressView()
+        .progressViewStyle(.circular)
+        .controlSize(.small)
+        .tint(OmiColors.purplePrimary)
+    }
+  }
+
+  private var titleText: String {
+    let tier = tierLabel
+    switch installer.currentStep {
+    case .failed:
+      return installer.wasCancelled ? "\(tier) install cancelled" : "\(tier) install failed"
+    case .done: return "\(tier) ready"
+    default: return "Setting up \(tier)"
+    }
+  }
+
+  private var subtitleText: String? {
+    if installer.currentStep == .failed {
+      if installer.wasCancelled { return "Installation was cancelled." }
+      return installer.error ?? "Something went wrong. Open details for the log."
+    }
+    if installer.currentStep == .done {
+      return activeModelId
+    }
+    if let id = activeModelId { return id }
+    return installer.currentStep.rawValue
+  }
+
+  // MARK: - Controls
+
+  @ViewBuilder
+  private var controlButtons: some View {
+    HStack(spacing: 6) {
+      Button(expanded ? "Hide details" : "Details") {
+        expanded.toggle()
+      }
+      .buttonStyle(.plain)
+      .scaledFont(size: 11, weight: .medium)
+      .foregroundColor(OmiColors.purplePrimary)
+
+      if installer.isRunning {
+        if installer.wasCancelled {
+          Text("Cancelling…")
+            .scaledFont(size: 11, weight: .medium)
+            .foregroundColor(OmiColors.textSecondary)
+        } else {
+          Button("Cancel") {
+            installer.cancel()
+          }
+          .buttonStyle(.plain)
+          .scaledFont(size: 11, weight: .medium)
+          .foregroundColor(OmiColors.error)
+        }
+      } else if installer.currentStep == .failed || installer.currentStep == .done {
+        Button(installer.currentStep == .done ? "Done" : "Dismiss") {
+          installer.dismissResult()
+          expanded = false
+        }
+        .buttonStyle(.plain)
+        .scaledFont(size: 11, weight: .medium)
+        .foregroundColor(OmiColors.textSecondary)
+      }
+    }
+  }
+
+  // MARK: - Progress row
+
+  @ViewBuilder
+  private var progressRow: some View {
+    if installer.currentStep == .failed || installer.currentStep == .done {
+      EmptyView()
+    } else if installer.currentStep == .downloadingModel || installer.modelDownloadProgress != nil {
+      VStack(alignment: .leading, spacing: 4) {
+        let hasTotal = installer.modelTotalBytes > 0
+        if hasTotal {
+          ProgressView(value: installer.modelDownloadProgress ?? 0)
+            .progressViewStyle(LinearProgressViewStyle(tint: OmiColors.purplePrimary))
+        } else {
+          ProgressView()
+            .progressViewStyle(LinearProgressViewStyle(tint: OmiColors.purplePrimary))
+        }
+
+        let downloaded = LocalAIInstaller.formattedBytes(installer.modelDownloadedBytes)
+        if hasTotal {
+          let pct = Int((installer.modelDownloadProgress ?? 0) * 100)
+          let total = LocalAIInstaller.formattedBytes(installer.modelTotalBytes)
+          Text("\(pct)% — \(downloaded) of \(total)")
+            .scaledFont(size: 11)
+            .foregroundColor(OmiColors.textTertiary)
+        } else {
+          Text("\(downloaded) downloaded")
+            .scaledFont(size: 11)
+            .foregroundColor(OmiColors.textTertiary)
+        }
+      }
+    } else {
+      ProgressView()
+        .progressViewStyle(LinearProgressViewStyle(tint: OmiColors.purplePrimary))
+    }
+  }
+
+  // MARK: - Details
+
+  private var detailsView: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      Divider().overlay(OmiColors.backgroundQuaternary)
+      stepList
+      logsView
+    }
+  }
+
+  private var stepList: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      ForEach(LocalAIInstaller.Step.displayed) { step in
+        stepRow(step: step)
+      }
+    }
+  }
+
+  @ViewBuilder
+  private func stepRow(step: LocalAIInstaller.Step) -> some View {
+    let isCompleted = installer.completedSteps.contains(step) || installer.currentStep == .done
+    let isCurrent = installer.currentStep == step && !isCompleted
+    let isFailed = installer.currentStep == .failed
+      && installer.completedSteps.contains(step) == false
+      && LocalAIInstaller.Step.displayed.firstIndex(of: step)
+        == LocalAIInstaller.Step.displayed.firstIndex(where: { !installer.completedSteps.contains($0) })
+
+    HStack(alignment: .center, spacing: 8) {
+      stepIcon(isCompleted: isCompleted, isCurrent: isCurrent, isFailed: isFailed)
+        .frame(width: 14, height: 14)
+      Text(step.rawValue)
+        .scaledFont(size: 12, weight: isCurrent ? .medium : .regular)
+        .foregroundColor(
+          isCompleted || isCurrent ? OmiColors.textPrimary : OmiColors.textSecondary
+        )
+      Spacer(minLength: 0)
+    }
+  }
+
+  @ViewBuilder
+  private func stepIcon(isCompleted: Bool, isCurrent: Bool, isFailed: Bool) -> some View {
+    if isFailed {
+      Image(systemName: "xmark.circle.fill")
+        .scaledFont(size: 12)
+        .foregroundColor(OmiColors.error)
+    } else if isCompleted {
+      Image(systemName: "checkmark.circle.fill")
+        .scaledFont(size: 12)
+        .foregroundColor(OmiColors.success)
+    } else if isCurrent {
+      ProgressView()
+        .progressViewStyle(.circular)
+        .controlSize(.mini)
+        .tint(OmiColors.purplePrimary)
+    } else {
+      Image(systemName: "circle")
+        .scaledFont(size: 12)
+        .foregroundColor(OmiColors.textTertiary.opacity(0.6))
+    }
+  }
+
+  private var logsView: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      HStack {
+        Text("Output")
+          .scaledFont(size: 11, weight: .medium)
+          .foregroundColor(OmiColors.textTertiary)
+        Spacer()
+        Button("Copy") {
+          let pb = NSPasteboard.general
+          pb.clearContents()
+          pb.setString(installer.logLines.joined(separator: "\n"), forType: .string)
+        }
+        .buttonStyle(.plain)
+        .scaledFont(size: 11)
+        .foregroundColor(OmiColors.purplePrimary)
+      }
+      ScrollViewReader { proxy in
+        ScrollView {
+          VStack(alignment: .leading, spacing: 1) {
+            ForEach(Array(installer.logLines.enumerated()), id: \.offset) { (idx, line) in
+              Text(line)
+                .scaledFont(size: 10)
+                .font(.system(size: 10, design: .monospaced))
+                .foregroundColor(OmiColors.textSecondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .id(idx)
+            }
+          }
+          .padding(6)
+        }
+        .frame(height: 100)
+        .background(OmiColors.backgroundPrimary)
+        .cornerRadius(4)
+        .onChange(of: installer.logLines.count) { _, newCount in
+          if newCount > 0 {
+            withAnimation { proxy.scrollTo(newCount - 1, anchor: .bottom) }
+          }
+        }
+      }
+    }
+  }
+
+  // MARK: - Helpers
+
+  private var tierLabel: String {
+    switch kind {
+    case .mlx: return "Local Model"
+    case .vlm: return "Vision Model"
+    case .api: return "API Server"
+    }
+  }
+
+  private var activeModelId: String? {
+    switch kind {
+    case .mlx: return installer.pendingMLXModelId
+    case .vlm: return installer.pendingVLMModelId
+    case .api: return nil
+    }
+  }
+}

--- a/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -321,11 +321,12 @@ struct SettingsContentView: View {
   @ObservedObject private var vlmLifecycle = VLMLifecycleManager.shared
   @ObservedObject private var mcpAPI = MCPAPIService.shared
   @ObservedObject private var idleController = IdleAIController.shared
+  @ObservedObject private var localAIInstaller = LocalAIInstaller.shared
 
-  // In-app installer sheet (replaces the prior Terminal-launch flow).
-  @State private var presentingInstallSheet: Bool = false
-  // Vision-tier installer sheet — mirrors the MLX flow but for mlx-vlm.
-  @State private var presentingVLMInstallSheet: Bool = false
+  // MCP API server installer sheet. Model installs (text + vision) render
+  // inline via `LocalAIInstallStrip`; the API install is rare and short, so
+  // it keeps the modal flow.
+  @State private var presentingAPIInstallSheet: Bool = false
   // Transient feedback from the "Test connection" button on the Vision Model card.
   @State private var vlmTestResult: String? = nil
   @State private var vlmTestInFlight: Bool = false
@@ -1981,17 +1982,11 @@ struct SettingsContentView: View {
         // Active model summary line.
         activeModelSummary
 
-        if let progress = mlxLifecycle.modelDownloadProgress {
-          VStack(alignment: .leading, spacing: 4) {
-            Text("Downloading model — \(Int(progress * 100))%")
-              .scaledFont(size: 11)
-              .foregroundColor(OmiColors.textTertiary)
-            ProgressView(value: progress)
-              .progressViewStyle(
-                LinearProgressViewStyle(tint: OmiColors.purplePrimary)
-              )
-          }
-        }
+        // Inline install progress (replaces the prior modal sheet). Only
+        // renders while the text-tier install is running or has failed; the
+        // user can navigate away and progress continues — `LocalAIInstaller`
+        // is a singleton.
+        LocalAIInstallStrip(kind: .mlx)
 
         if let err = mlxLifecycle.lastError, !err.isEmpty {
           Text(err)
@@ -2046,9 +2041,6 @@ struct SettingsContentView: View {
         // Autonomous Work Mode subsection — keep local AI available while idle.
         powerSavingSubsection
       }
-      .sheet(isPresented: $presentingInstallSheet) {
-        LocalAIInstallSheet()
-      }
     }
   }
 
@@ -2085,6 +2077,11 @@ struct SettingsContentView: View {
         // Active-model summary line — mirrors activeModelSummary on the text card.
         activeVisionModelSummary
 
+        // Inline install progress (replaces the prior modal sheet). Mirrors
+        // the text-tier strip; only renders while the vision install is
+        // running or has failed.
+        LocalAIInstallStrip(kind: .vlm)
+
         if let err = vlmLifecycle.lastError, !err.isEmpty {
           Text(err)
             .scaledFont(size: 11)
@@ -2093,15 +2090,20 @@ struct SettingsContentView: View {
         }
 
         // Install button — enabled until the agent + model are both present.
+        // Kicks the singleton installer directly; progress renders inline
+        // via `LocalAIInstallStrip` above, no modal sheet.
         if !vlmLifecycle.agentInstalled || !vlmLifecycle.modelPresent {
           HStack {
-            Button(action: { presentingVLMInstallSheet = true }) {
+            Button(action: {
+              Task { await LocalAIInstaller.shared.startVLMInstall() }
+            }) {
               Text(vlmLifecycle.modelPresent ? "Register Service" : "Install (~5–6 GB)")
                 .scaledFont(size: 12, weight: .semibold)
             }
             .buttonStyle(.borderedProminent)
             .tint(OmiColors.purplePrimary)
             .controlSize(.small)
+            .disabled(localAIInstaller.isRunning)
             Spacer()
           }
         }
@@ -2160,9 +2162,6 @@ struct SettingsContentView: View {
             .foregroundColor(OmiColors.textTertiary)
             .fixedSize(horizontal: false, vertical: true)
         }
-      }
-      .sheet(isPresented: $presentingVLMInstallSheet) {
-        LocalAIInstallSheet(kind: .vlm)
       }
     }
   }
@@ -2261,7 +2260,11 @@ struct SettingsContentView: View {
     )
     .onAppear {
       if visionModelPickerSelection == nil {
-        visionModelPickerSelection = activeVisionModelID
+        // Custom HF id → highlight "Other" row so the user can see which
+        // row produced the active model.
+        visionModelPickerSelection = VisionModelCatalog.option(forId: activeVisionModelID) == nil
+          ? Self.customRowSentinel
+          : activeVisionModelID
       }
       refreshAllVisionModelDiskSizes()
     }
@@ -2445,7 +2448,6 @@ struct SettingsContentView: View {
   private func installVisionModel(_ modelId: String) {
     Task {
       visionModelPickerSelection = modelId
-      presentingVLMInstallSheet = true
       await LocalAIInstaller.shared.startVLMInstall(modelId: modelId)
     }
   }
@@ -2690,7 +2692,12 @@ struct SettingsContentView: View {
     )
     .onAppear {
       if localModelPickerSelection == nil {
-        localModelPickerSelection = activeLocalModelID
+        // If the active id isn't in the curated catalog it's a custom HF
+        // repo — highlight the "Other" row (sentinel) so the user can see
+        // which row sourced the active model.
+        localModelPickerSelection = LocalModelCatalog.option(forId: activeLocalModelID) == nil
+          ? Self.customRowSentinel
+          : activeLocalModelID
       }
       refreshAllLocalModelDiskSizes()
     }
@@ -3058,14 +3065,12 @@ struct SettingsContentView: View {
     return "\(s) GB"
   }
 
-  /// Triggered by an inline row Install button. Routes through the existing
-  /// install sheet so the user gets the same step list + progress bar UX.
+  /// Triggered by an inline row Install button. Kicks off the install on
+  /// the shared singleton; the inline `LocalAIInstallStrip` rendered above
+  /// the picker self-renders progress while the user is free to navigate.
   private func installLocalModel(_ modelId: String) {
     Task {
-      // Fire-and-forget: the sheet itself awaits LocalAIInstaller via
-      // `.task`. We just need to seed the picker selection and present.
       localModelPickerSelection = modelId
-      presentingInstallSheet = true
       await LocalAIInstaller.shared.startMLXInstall(modelId: modelId)
     }
   }
@@ -3404,7 +3409,7 @@ struct SettingsContentView: View {
 
         // Primary action(s).
         if !mcpAPI.isInstalled {
-          Button(action: { presentingInstallSheet = true }) {
+          Button(action: { presentingAPIInstallSheet = true }) {
             HStack {
               Image(systemName: "arrow.down.circle.fill")
               Text("Install MCP API")
@@ -3418,8 +3423,8 @@ struct SettingsContentView: View {
           .help(
             "Builds the local Rust API daemon and registers a launchd agent so it starts at login."
           )
-          .sheet(isPresented: $presentingInstallSheet) {
-            LocalAIInstallSheet()
+          .sheet(isPresented: $presentingAPIInstallSheet) {
+            LocalAIInstallSheet(kind: .api)
           }
         }
 


### PR DESCRIPTION
## Summary

- Replaces the modal install sheet for Local Model (`.mlx`) and Vision Model (`.vlm`) with an inline `LocalAIInstallStrip` rendered under each card's active-model summary. Users can switch tabs, scroll, or close the window mid-install without losing progress — the singleton installer keeps running.
- Strip handles `.running`, `.failed`, and `.done` terminal states (the latter previously vanished silently after a multi-GB download). User-initiated cancels are distinguished from genuine failures via a new `wasCancelled` flag, with an optimistic "Cancelling…" label while SIGTERM propagates.
- Sheet path is preserved for the API server (`.api`) tier.

## Other fixes (came out of triple-agent code review)

- `dismissResult()` now scopes pending-id clearing to `pendingKind` instead of clobbering both tiers.
- `@ObservedObject` instead of `@StateObject` for `LocalAIInstaller.shared` (singleton ownership semantics).
- `SettingsContentView` now observes `LocalAIInstaller` so the Vision card's "Install" button reactively re-disables while a foreign install runs.
- Untangled MCP API sheet flag (`presentingAPIInstallSheet`) — the prior shared `presentingInstallSheet` would have presented an MLX sheet when the user clicked Install on the API card.
- Picker selection now highlights the "Other" sentinel when the active id isn't in the catalog (custom HF repos).
- Fixed install-sheet "Zero KB" display when `modelTotalBytes` is unknown for custom HF repos (indeterminate progress + "X downloaded").
- Removed dead `installAPIInstead` legacy shim (no callers).

## Test plan

- [x] `xcrun swift build -c debug --package-path Desktop` — green
- [x] `xcrun swift test --package-path Desktop` — same 14 pre-existing failures as `origin/main` (Crisp, onboarding, API speech), none caused by this PR
- [x] `cargo test --locked -p infinite-recall-api` — green
- [x] `cargo test --locked -p infinite-recall-api --features activity_test_wiring` — green
- [ ] Manual: Settings → Local Model → Other → install custom HF id, navigate away mid-install, return → strip still progressing
- [ ] Manual: Settings → Vision Model → install, click Cancel → "Cancelling…" appears, then "Vision Model install cancelled" (not "failed")
- [ ] Manual: Install completes → "Local Model ready" with green check + "Done" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Installation progress now displays inline with expandable details and live logs, replacing modal dialogs
  * Added ability to dismiss failed installations without retrying

* **Improvements**
  * Enhanced progress UI for models with unknown download sizes
  * Improved model selection logic to better highlight custom models

<!-- end of auto-generated comment: release notes by coderabbit.ai -->