### PR TITLE
activity: unify _internal/* POST failure handling (closes #45)

### DIFF
--- a/Desktop/Sources/Activity/ActivityMonitorService.swift
+++ b/Desktop/Sources/Activity/ActivityMonitorService.swift
@@ -126,6 +126,13 @@ public final class ActivityMonitorService: ObservableObject {
         self.lastError = nil
     }
 
+    /// Surface a banner when `_internal/*` POSTs (inflight, queue-depth,
+    /// gate-state) have failed `consecutive` times in a row. Routed through
+    /// `InternalPostFailureTracker` so duplicate counters don't drift.
+    func reportInternalPostFailure(category: String, consecutive: Int) {
+        lastError = "Internal reporting failing: \(category) (\(consecutive) consecutive failures)"
+    }
+
     // MARK: - Private
 
     /// Consensus-fix C3: write to local state ONLY after the round-trip

--- a/Desktop/Sources/Activity/InternalPostFailureTracker.swift
+++ b/Desktop/Sources/Activity/InternalPostFailureTracker.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+/// Tracks consecutive failures of `_internal/*` POSTs (inflight, queue-depth,
+/// gate-state) so the user gets a banner when internal reporting is silently
+/// broken. Each category has its own counter; hitting `escalationThreshold`
+/// consecutive failures fires once into `ActivityMonitorService.lastError`.
+/// A subsequent success resets the counter and re-arms escalation.
+@MainActor
+final class InternalPostFailureTracker {
+    static let shared = InternalPostFailureTracker()
+
+    let escalationThreshold: Int
+
+    /// Default initializer used by `shared`. Tests can construct local
+    /// instances by passing a custom `escalationThreshold` (or the default)
+    /// to avoid singleton bleed.
+    init(escalationThreshold: Int = 3) {
+        self.escalationThreshold = escalationThreshold
+    }
+
+    enum Category: String, CaseIterable {
+        case inflight
+        case queueDepth = "queue-depth"
+        case gateState = "gate-state"
+    }
+
+    private weak var monitor: ActivityMonitorService?
+    private var counts: [Category: Int] = [:]
+    private var escalated: Set<Category> = []
+
+    func attach(_ monitor: ActivityMonitorService) {
+        self.monitor = monitor
+    }
+
+    func reportFailure(_ category: Category, error: Error? = nil) {
+        if let error, Self.isDaemonRestartIndicator(error) {
+            // Benign daemon-restart signal (token rotated, socket gone, 5xx
+            // gateway-class) — neither failure nor success. Don't bump the
+            // counter; the next real call will get an honest verdict.
+            return
+        }
+        let next = (counts[category] ?? 0) + 1
+        counts[category] = next
+        if next >= escalationThreshold && !escalated.contains(category) {
+            escalated.insert(category)
+            guard let monitor else {
+                // Production safety: escalation crossed but nobody is
+                // listening. Log loudly so the "attach was forgotten"
+                // failure mode is visible in /private/tmp/omi-dev.log
+                // instead of being silently swallowed.
+                NSLog(
+                    "[internal-post-failure] escalation for category=\(category.rawValue) count=\(next) but monitor is nil — attach was not called"
+                )
+                return
+            }
+            monitor.reportInternalPostFailure(
+                category: category.rawValue,
+                consecutive: next
+            )
+        }
+    }
+
+    func reportSuccess(_ category: Category) {
+        counts[category] = 0
+        escalated.remove(category)
+    }
+
+    func failureCount(_ category: Category) -> Int {
+        counts[category] ?? 0
+    }
+
+    /// True when `error` looks like the Rust daemon just restarted (token
+    /// rotated → 401, socket gone → connection refused, gateway-class 5xx,
+    /// timeout). Mirrored from `ProcessingGateReporter` so the tracker can
+    /// filter benign restarts out of the failure counter without bumping
+    /// the user-visible escalation.
+    private static func isDaemonRestartIndicator(_ error: Error) -> Bool {
+        if let api = error as? APIError {
+            switch api {
+            case .unauthorized:
+                return true
+            case .httpError(let code) where code == 502 || code == 503 || code == 504:
+                return true
+            default:
+                break
+            }
+        }
+        let nsErr = error as NSError
+        if nsErr.domain == NSURLErrorDomain {
+            switch nsErr.code {
+            case NSURLErrorCannotConnectToHost,
+                NSURLErrorNetworkConnectionLost,
+                NSURLErrorNotConnectedToInternet,
+                NSURLErrorTimedOut:
+                return true
+            default:
+                break
+            }
+        }
+        return false
+    }
+}

--- a/Desktop/Sources/Activity/ProcessingGateReporter.swift
+++ b/Desktop/Sources/Activity/ProcessingGateReporter.swift
@@ -263,7 +263,9 @@ public final class ProcessingGateReporter {
     do {
       try await APIClient.shared.reportGateState(newState)
       lastPostedState = newState
+      InternalPostFailureTracker.shared.reportSuccess(.gateState)
     } catch {
+      InternalPostFailureTracker.shared.reportFailure(.gateState, error: error)
       // Surface to console; the next tick will retry. We deliberately do
       // not back off — the daemon is loopback, transient errors are
       // typically "daemon not yet up" or "token file not yet written",

--- a/Desktop/Sources/OmiApp.swift
+++ b/Desktop/Sources/OmiApp.swift
@@ -392,6 +392,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     // per-tab basis from ActivityPage so polling pauses when hidden.
     Task { @MainActor in
       CapturePauseGate.shared.start()
+      InternalPostFailureTracker.shared.attach(ActivityMonitorService.shared)
     }
     // === /activity:C1 ===
 

--- a/Desktop/Sources/Power/BatteryAwareScheduler.swift
+++ b/Desktop/Sources/Power/BatteryAwareScheduler.swift
@@ -476,9 +476,11 @@ public final class BatteryAwareScheduler: ObservableObject {
             kind: Self.toWireWorkKind(work.kind),
             inFlight: inflightEntry
           )
+          InternalPostFailureTracker.shared.reportSuccess(.inflight)
         } catch {
-          await ActivityReportLogger.shared.log(
+          ActivityReportLogger.shared.log(
             error: error, context: "reportInFlight(start:\(work.kind.rawValue))")
+          InternalPostFailureTracker.shared.reportFailure(.inflight, error: error)
         }
       }
       // === /activity:G ===
@@ -497,9 +499,11 @@ public final class BatteryAwareScheduler: ObservableObject {
               kind: Self.toWireWorkKind(work.kind),
               inFlight: nil
             )
+            InternalPostFailureTracker.shared.reportSuccess(.inflight)
           } catch {
-            await ActivityReportLogger.shared.log(
+            ActivityReportLogger.shared.log(
               error: error, context: "reportInFlight(done:\(work.kind.rawValue))")
+            InternalPostFailureTracker.shared.reportFailure(.inflight, error: error)
           }
         }
         // === /activity:G ===
@@ -513,9 +517,11 @@ public final class BatteryAwareScheduler: ObservableObject {
               kind: Self.toWireWorkKind(work.kind),
               inFlight: nil
             )
+            InternalPostFailureTracker.shared.reportSuccess(.inflight)
           } catch {
-            await ActivityReportLogger.shared.log(
+            ActivityReportLogger.shared.log(
               error: error, context: "reportInFlight(fail:\(work.kind.rawValue))")
+            InternalPostFailureTracker.shared.reportFailure(.inflight, error: error)
           }
         }
         // === /activity:G ===
@@ -726,11 +732,13 @@ public final class BatteryAwareScheduler: ObservableObject {
 
     do {
       try await APIClient.shared.reportQueueDepth(depths)
+      InternalPostFailureTracker.shared.reportSuccess(.queueDepth)
     } catch APIError.daemonNotConfigured {
       log("BatteryAwareScheduler: daemon not configured; queue-depth push skipped")
     } catch {
-      await ActivityReportLogger.shared.log(
+      ActivityReportLogger.shared.log(
         error: error, context: "reportQueueDepth")
+      InternalPostFailureTracker.shared.reportFailure(.queueDepth, error: error)
     }
   }
 }

--- a/Desktop/Tests/InternalPostFailureTrackerTests.swift
+++ b/Desktop/Tests/InternalPostFailureTrackerTests.swift
@@ -1,0 +1,210 @@
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class InternalPostFailureTrackerTests: XCTestCase {
+
+  /// Reset every category counter on the shared tracker. Iterates
+  /// `Category.allCases` so adding a new case can't rot the suite.
+  private func resetSharedTracker() {
+    let tracker = InternalPostFailureTracker.shared
+    for category in InternalPostFailureTracker.Category.allCases {
+      tracker.reportSuccess(category)
+    }
+    tracker.attach(ActivityMonitorService.shared)
+    ActivityMonitorService.shared.clearLastError()
+  }
+
+  override func setUp() async throws {
+    try await super.setUp()
+    // The tracker is a singleton; reset state between tests so cases are
+    // independent regardless of run order.
+    resetSharedTracker()
+  }
+
+  override func tearDown() async throws {
+    // Same reset on teardown so leftover state from this suite doesn't
+    // bleed into other suites that touch ActivityMonitorService.shared.
+    resetSharedTracker()
+    try await super.tearDown()
+  }
+
+  func test_belowThreshold_doesNotEscalate() {
+    let tracker = InternalPostFailureTracker.shared
+    tracker.reportFailure(.inflight)
+    tracker.reportFailure(.inflight)
+    XCTAssertEqual(tracker.failureCount(.inflight), 2)
+    XCTAssertNil(ActivityMonitorService.shared.lastError)
+  }
+
+  func test_atThreshold_escalates() {
+    let tracker = InternalPostFailureTracker.shared
+    tracker.reportFailure(.inflight)
+    tracker.reportFailure(.inflight)
+    tracker.reportFailure(.inflight)
+    XCTAssertEqual(tracker.failureCount(.inflight), 3)
+    let banner = ActivityMonitorService.shared.lastError
+    XCTAssertNotNil(banner)
+    XCTAssertTrue(banner?.contains("inflight") == true, "got: \(banner ?? "<nil>")")
+    XCTAssertTrue(banner?.contains("3") == true)
+  }
+
+  func test_doesNotRefireAtFourOrFive() {
+    let tracker = InternalPostFailureTracker.shared
+    tracker.reportFailure(.inflight)
+    tracker.reportFailure(.inflight)
+    tracker.reportFailure(.inflight)
+    let firstBanner = ActivityMonitorService.shared.lastError
+    ActivityMonitorService.shared.clearLastError()
+    tracker.reportFailure(.inflight)
+    tracker.reportFailure(.inflight)
+    XCTAssertNotNil(firstBanner)
+    XCTAssertNil(
+      ActivityMonitorService.shared.lastError,
+      "escalation must not re-fire on n=4,5,...")
+    XCTAssertEqual(tracker.failureCount(.inflight), 5)
+  }
+
+  func test_successResetsCounter() {
+    let tracker = InternalPostFailureTracker.shared
+    tracker.reportFailure(.inflight)
+    tracker.reportFailure(.inflight)
+    tracker.reportSuccess(.inflight)
+    XCTAssertEqual(tracker.failureCount(.inflight), 0)
+  }
+
+  func test_successDoesNotClearLastError() {
+    let tracker = InternalPostFailureTracker.shared
+    tracker.reportFailure(.inflight)
+    tracker.reportFailure(.inflight)
+    tracker.reportFailure(.inflight)
+    XCTAssertNotNil(ActivityMonitorService.shared.lastError)
+    tracker.reportSuccess(.inflight)
+    XCTAssertNotNil(
+      ActivityMonitorService.shared.lastError,
+      "banner is user-dismissible; success must not clear it")
+  }
+
+  func test_reArmsAfterSuccessThenThreeMoreFailures() {
+    let tracker = InternalPostFailureTracker.shared
+    tracker.reportFailure(.inflight)
+    tracker.reportFailure(.inflight)
+    tracker.reportFailure(.inflight)
+    XCTAssertNotNil(ActivityMonitorService.shared.lastError)
+
+    tracker.reportSuccess(.inflight)
+    ActivityMonitorService.shared.clearLastError()
+
+    tracker.reportFailure(.inflight)
+    tracker.reportFailure(.inflight)
+    XCTAssertNil(ActivityMonitorService.shared.lastError)
+    tracker.reportFailure(.inflight)
+    XCTAssertNotNil(
+      ActivityMonitorService.shared.lastError,
+      "tracker must re-arm after a success")
+  }
+
+  func test_perCategoryIsolation() {
+    let tracker = InternalPostFailureTracker.shared
+    tracker.reportFailure(.inflight)
+    tracker.reportFailure(.inflight)
+    tracker.reportFailure(.queueDepth)
+    XCTAssertEqual(tracker.failureCount(.inflight), 2)
+    XCTAssertEqual(tracker.failureCount(.queueDepth), 1)
+    XCTAssertEqual(tracker.failureCount(.gateState), 0)
+    XCTAssertNil(ActivityMonitorService.shared.lastError)
+
+    tracker.reportSuccess(.inflight)
+    XCTAssertEqual(tracker.failureCount(.inflight), 0)
+    XCTAssertEqual(
+      tracker.failureCount(.queueDepth), 1,
+      "success on one category must not reset another")
+  }
+
+  func test_categoryRawValuesMatchWireFormat() {
+    XCTAssertEqual(InternalPostFailureTracker.Category.inflight.rawValue, "inflight")
+    XCTAssertEqual(InternalPostFailureTracker.Category.queueDepth.rawValue, "queue-depth")
+    XCTAssertEqual(InternalPostFailureTracker.Category.gateState.rawValue, "gate-state")
+  }
+
+  // MARK: - Fix 6 — new tests
+
+  /// Reporting failures without a monitor attached must not crash and
+  /// must not produce a banner. We use a local instance so we don't
+  /// disturb the shared singleton's `monitor` weak ref.
+  func test_reportFailure_withoutAttach_doesNotCrash_andLogsWarning() {
+    let local = InternalPostFailureTracker(escalationThreshold: 3)
+    // No `attach(_:)` call.
+    local.reportFailure(.inflight)
+    local.reportFailure(.inflight)
+    local.reportFailure(.inflight)
+    XCTAssertEqual(local.failureCount(.inflight), 3)
+    // Shared monitor must remain untouched (no banner from this local).
+    XCTAssertNil(ActivityMonitorService.shared.lastError)
+  }
+
+  /// An error matching `isDaemonRestartIndicator` is a benign daemon
+  /// restart, not a failure. The counter must stay at 0 and no
+  /// escalation banner must fire.
+  func test_reportFailure_withDaemonRestartError_doesNotCount() {
+    let tracker = InternalPostFailureTracker.shared
+    let restartError = APIError.unauthorized
+    for _ in 0..<5 {
+      tracker.reportFailure(.inflight, error: restartError)
+    }
+    XCTAssertEqual(tracker.failureCount(.inflight), 0)
+    XCTAssertNil(ActivityMonitorService.shared.lastError)
+  }
+
+  /// Each category's escalation re-arms independently of the others:
+  /// escalating .inflight, succeeding, escalating .queueDepth, and
+  /// succeeding must all fire fresh banners.
+  func test_reArm_perCategory_independent() {
+    let tracker = InternalPostFailureTracker.shared
+
+    // Escalate .inflight.
+    tracker.reportFailure(.inflight)
+    tracker.reportFailure(.inflight)
+    tracker.reportFailure(.inflight)
+    XCTAssertNotNil(ActivityMonitorService.shared.lastError)
+    XCTAssertTrue(ActivityMonitorService.shared.lastError?.contains("inflight") == true)
+
+    // Success on .inflight + clear banner.
+    tracker.reportSuccess(.inflight)
+    ActivityMonitorService.shared.clearLastError()
+
+    // Escalate .queueDepth.
+    tracker.reportFailure(.queueDepth)
+    tracker.reportFailure(.queueDepth)
+    tracker.reportFailure(.queueDepth)
+    let qBanner = ActivityMonitorService.shared.lastError
+    XCTAssertNotNil(qBanner)
+    XCTAssertTrue(qBanner?.contains("queue-depth") == true, "got: \(qBanner ?? "<nil>")")
+
+    // Success on .queueDepth + clear banner.
+    tracker.reportSuccess(.queueDepth)
+    ActivityMonitorService.shared.clearLastError()
+
+    // Re-escalate .inflight again — must fire fresh.
+    tracker.reportFailure(.inflight)
+    tracker.reportFailure(.inflight)
+    tracker.reportFailure(.inflight)
+    let again = ActivityMonitorService.shared.lastError
+    XCTAssertNotNil(again, "re-escalation per-category must re-arm independently")
+    XCTAssertTrue(again?.contains("inflight") == true)
+  }
+
+  /// Bonus: the message format produced by
+  /// `ActivityMonitorService.reportInternalPostFailure` is what the
+  /// banner UI binds to. Pin the exact string so renames don't quietly
+  /// regress the user-visible copy.
+  func test_reportInternalPostFailure_messageFormat() {
+    ActivityMonitorService.shared.clearLastError()
+    ActivityMonitorService.shared.reportInternalPostFailure(
+      category: "inflight", consecutive: 3)
+    XCTAssertEqual(
+      ActivityMonitorService.shared.lastError,
+      "Internal reporting failing: inflight (3 consecutive failures)")
+  }
+}


### PR DESCRIPTION
## Summary
- New `InternalPostFailureTracker` escalates `_internal/*` POST failures to `ActivityMonitorService.lastError` after 3 consecutive failures
- Wired into `BatteryAwareScheduler` (inflight + queue-depth) and `ProcessingGateReporter` (gate-state)
- Filters benign cases: `APIError.daemonNotConfigured` (intentional skip) and daemon-restart errors (benign reset)

## Test plan
- [x] `xcrun swift build` — green
- [x] `xcrun swift test --filter InternalPostFailureTracker` — 12/12 pass
- [x] `xcrun swift test` (full) — only pre-existing failures (verified against HEAD~1)
- [x] `cargo build && cargo test` (Backend-Rust) — green
- [ ] Manual: trigger 3 consecutive POST failures → red banner appears
- [ ] Manual: confirm `IR_SKIP_BACKEND=1` does not surface false-positive banner

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Activity Monitor now monitors internal operations and displays alerts when consecutive failures reach defined thresholds
  * Enhanced error detection with proper handling of daemon restart conditions
  * Automatic failure counter reset on successful operations

* **Tests**
  * Added comprehensive test suite covering failure detection, escalation logic, and per-category isolation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->