### PR TITLE
fix(run.sh): auto-migrate stale 10201 port in Backend-Rust/.env

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -128,6 +128,32 @@ is_truthy() {
     esac
 }
 
+migrate_stale_backend_env() {
+    # Heal Backend-Rust/.env files written from the pre-#73 template, where the
+    # default port was 10201 (Omi-fork era). Those values get auto-exported by
+    # the surrounding `set -a; source ...; set +a` and then propagate into the
+    # bundled app's .env (see ~line 879), reproducing the dead-port symptom
+    # ("snapshot failed: Could not connect to the server").
+    local env_file="$1"
+    [ -f "$env_file" ] || return 0
+    local migrated=0
+    # IR_API_URL=http://host:10201 (with optional trailing path/whitespace).
+    # Use BSD-sed-friendly patterns: anchor on the literal value boundaries
+    # rather than alternation groups.
+    if grep -qE '^IR_API_URL=.*:10201([^0-9]|$)' "$env_file"; then
+        sed -i '' -E 's|^(IR_API_URL=.*):10201$|\1:7331|' "$env_file"
+        sed -i '' -E 's|^(IR_API_URL=.*):10201([^0-9])|\1:7331\2|' "$env_file"
+        migrated=1
+    fi
+    if grep -qE '^PORT=10201[[:space:]]*$' "$env_file"; then
+        sed -i '' -E 's|^PORT=10201[[:space:]]*$|PORT=7331|' "$env_file"
+        migrated=1
+    fi
+    if [ "$migrated" = "1" ]; then
+        substep "Migrated stale port 10201 -> 7331 in $env_file (Omi-fork era default)"
+    fi
+}
+
 warn_if_daemon_stale() {
     local installed="$HOME/Library/Application Support/InfiniteRecall/bin/infinite-recall-api"
     local src_dir
@@ -663,6 +689,7 @@ fi
 
 # Read environment from .env (skip if missing — yolo mode doesn't need it)
 if [ -f "$BACKEND_DIR/.env" ]; then
+    migrate_stale_backend_env "$BACKEND_DIR/.env"
     set -a; source "$BACKEND_DIR/.env"; set +a
 fi
 
@@ -747,6 +774,7 @@ if [ "${IR_SKIP_AUTH:-0}" != "1" ]; then
         (
             cd "$AUTH_DIR"
             if [ -f "$BACKEND_DIR/.env" ]; then
+                migrate_stale_backend_env "$BACKEND_DIR/.env"
                 set -a; source "$BACKEND_DIR/.env"; set +a
             fi
             export GOOGLE_APPLICATION_CREDENTIALS="$CREDS_PATH"


### PR DESCRIPTION
## Summary

Follow-up to #73. That PR updated the template (`Backend-Rust/.env.example`) from the old Omi-fork default port `10201` to the new `7331`, but it doesn't help users who already had a real `Backend-Rust/.env` (gitignored, copied from the old template long ago). For them, `run.sh` still does:

```bash
set -a; source "$BACKEND_DIR/.env"; set +a
```

at lines ~666 and ~750, which auto-exports the stale `PORT=10201` and `IR_API_URL=http://localhost:10201`. Those values then get baked into the bundled app's `.env` (lines ~879-892), reproducing the dead-port symptom — "snapshot failed: Could not connect to the server" — even on a fresh build with #73 merged.

## Fix

New helper `migrate_stale_backend_env "$BACKEND_DIR/.env"` runs immediately before each of the two source sites. It:

- Rewrites `IR_API_URL=...:10201` (with optional trailing path/whitespace) to `:7331` in-place.
- Rewrites bare `PORT=10201` to `PORT=7331` in-place.
- Leaves longer numbers (e.g. `102015`) and the auth port (`10202`) alone.
- Prints a `substep` line announcing the migration so it's not silent.

After migration, the existing `set -a; source ...; set +a` re-sources the now-correct file naturally — no need to re-source from the helper.

## Test plan

- [x] Unit-tested the migrate helper against four cases (stale, trailing slash, already-correct, look-alike `102015`) — all pass on BSD sed.
- [x] `shellcheck run.sh` introduces no new warnings in the new function range.
- [ ] Local manual check: copy `Backend-Rust/.env`, set `PORT=10201` + `IR_API_URL=http://localhost:10201`, run `./run.sh`, confirm:
  - Migration `substep` line appears
  - `Backend-Rust/.env` has been rewritten in place to `7331`
  - The bundled app `.env` ends up with `IR_API_URL=http://localhost:7331`

## Related

- Predecessor: #73

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected legacy backend port configuration values during application startup, ensuring the API service and authentication service initialize with proper settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->