### PR TITLE
feat(activity): surface IR-spawned local models

### DIFF
--- a/Backend-Rust/api/src/activity/contract.md
+++ b/Backend-Rust/api/src/activity/contract.md
@@ -69,9 +69,10 @@ Field names are snake_case on the wire. Swift mirrors live in
     "on_battery": false,
     "low_power": false,
     "process_breakdown": [
-      { "name": "infinite-recall-api", "pid": 1234, "cpu_percent": 12.4, "rss_mb": 84 },
-      { "name": "Infinite Recall",     "pid": 1235, "cpu_percent": 51.2, "rss_mb": 760 },
-      { "name": "mlx-lm.server",       "pid": 1236, "cpu_percent": 78.4, "rss_mb": 1498 }
+      { "name": "api",     "pid": 1234, "cpu_percent": 12.4, "rss_mb": 84,   "kind": "core" },
+      { "name": "swift",   "pid": 1235, "cpu_percent": 51.2, "rss_mb": 760,  "kind": "core" },
+      { "name": "mlx-lm",  "pid": 1236, "cpu_percent": 78.4, "rss_mb": 1498, "kind": "local_model" },
+      { "name": "mlx-vlm", "pid": 1237, "cpu_percent": 14.0, "rss_mb": 1102, "kind": "local_model" }
     ]
   },
   "processing_gate": {
@@ -83,6 +84,28 @@ Field names are snake_case on the wire. Swift mirrors live in
   "generated_at": "2026-04-26T14:25:30.512Z"
 }
 ```
+
+### `ProcessBreakdown.kind` — optional classifier
+
+Each row in `resources.process_breakdown` may carry an optional `kind`
+discriminator the UI uses to group rows (e.g. a "Local Models" subhead).
+
+| Variant | Wire value | Meaning |
+|---|---|---|
+| `Core` | `"core"` | IR-spawned core process (`api`, `swift`). |
+| `LocalModel` | `"local_model"` | IR-spawned local-model server (`mlx-lm`, `mlx-vlm`). |
+
+The field is **optional in both directions**:
+
+- An older daemon (pre-this-PR) emits no `kind` at all — newer clients must
+  treat that as "unknown" and render the row in the default partition.
+- An older client decoding a payload that contains `kind` must tolerate
+  unknown future variants without throwing; the Swift mirror in
+  `ActivityModels.swift` decodes anything outside the known set as
+  `.unknown`.
+
+Wire-level: serialised with `serde(default, skip_serializing_if = "Option::is_none")`,
+so the field is silently absent when the daemon doesn't know the kind.
 
 ### `GateState` — sum type (issue #35)
 
@@ -123,6 +146,7 @@ and a stringly-typed `waiting_for`.
 | `CaptureRow.kind` / `CaptureKind` | `audio`, `screen` |
 | `PauseRequest.target` / `ResumeRequest.target` / `PauseTargetId` | `kind`, `capture` (with typed `id` payload — see below) |
 | `ResourceSample.thermal_state` / `ThermalState` | `nominal`, `fair`, `serious`, `critical` |
+| `ProcessBreakdown.kind` / `ProcessKind` (optional) | `core`, `local_model`, `unknown` (field omitted when daemon doesn't classify; both Rust and Swift decoders fold any future wire value into `unknown` for forward-compat) |
 | `GateState` (variant tag on `state`) | `allowed`, `blocked` |
 | `GateState.reason` / `BlockReason` (only when `state="blocked"`) | `device_active`, `on_battery`, `thermal`, `locked`, `manual_pause`, `initializing` |
 

--- a/Backend-Rust/api/src/activity/resources.rs
+++ b/Backend-Rust/api/src/activity/resources.rs
@@ -26,18 +26,27 @@ use libproc::proc_pid;
 use libproc::task_info::TaskInfo;
 
 use super::traits::ResourceSampler;
-use super::types::{ProcessBreakdown, ResourceSample, ThermalState};
+use super::types::{ProcessBreakdown, ProcessKind, ResourceSample, ThermalState};
 
 /// `pgrep -f` patterns. The Swift app is launched as a regular `.app` (never
-/// under launchd) so its PID has to come from the bundle path; the mlx-lm
-/// helper is a `uv tool run mlx_lm.server` invocation that uniquely matches
-/// the executable name.
+/// under launchd) so its PID has to come from the bundle path; the mlx-lm /
+/// mlx-vlm helpers are `uv tool run mlx_{lm,vlm}.server` invocations that
+/// uniquely match the executable name.
+///
+/// The mlx patterns are anchored with a leading space so an argv that
+/// happens to mention both names (e.g. a wrapper script) doesn't
+/// double-match the same PID under both labels.
 const SWIFT_PGREP_PATTERN: &str = "Infinite Recall.app/Contents/MacOS";
-const MLX_PGREP_PATTERN: &str = "mlx_lm.server";
+const MLX_PGREP_PATTERN: &str = " mlx_lm.server";
+const MLX_VLM_PGREP_PATTERN: &str = " mlx_vlm.server";
 
-/// Launchd label for `mlx_lm.server`. The Swift app is NOT under launchd, so
-/// no swift-side label is probed.
+/// Launchd labels for the local-model helpers. The Swift app is NOT under
+/// launchd, so no swift-side label is probed.
 const MLX_LAUNCHD_LABEL: &str = "com.infiniterecall.mlx";
+const MLX_VLM_LAUNCHD_LABEL: &str = "com.infiniterecall.vlm";
+
+/// Pidfile basenames under the InfiniteRecall app-support dir.
+const MLX_VLM_PIDFILE: &str = "mlxvlm.pid";
 
 /// How long to hold a sample in cache before re-sampling.
 ///
@@ -63,7 +72,7 @@ struct Inner {
     support_dir_override: Option<PathBuf>,
     /// If `Some`, take this list of pids verbatim instead of discovering.
     /// Tests use this so they do not have to spin up real processes.
-    pid_override: Option<Vec<(String, i32)>>,
+    pid_override: Option<Vec<(String, i32, Option<ProcessKind>)>>,
 }
 
 impl SystemResourceSampler {
@@ -94,7 +103,7 @@ impl SystemResourceSampler {
 
     /// Test constructor: skip PID discovery entirely and sample these pids.
     #[cfg(test)]
-    fn with_pids(pids: Vec<(String, i32)>) -> Self {
+    fn with_pids(pids: Vec<(String, i32, Option<ProcessKind>)>) -> Self {
         Self {
             inner: Mutex::new(Inner {
                 cache: None,
@@ -132,7 +141,7 @@ impl ResourceSampler for SystemResourceSampler {
             )
         };
 
-        let pids: Vec<(String, i32)> = match pid_override {
+        let pids: Vec<(String, i32, Option<ProcessKind>)> = match pid_override {
             Some(v) => v,
             None => discover_pids(support_dir_override.as_deref()),
         };
@@ -173,11 +182,13 @@ impl ResourceSampler for SystemResourceSampler {
 /// Singleton-fixer S7: each discovery path emits a structured tracing
 /// breadcrumb so the next contributor can tell whether a missing pid is
 /// "no pidfile yet" vs "launchctl label renamed" vs "stale pidfile".
-fn discover_pids(support_dir_override: Option<&std::path::Path>) -> Vec<(String, i32)> {
-    let mut out: Vec<(String, i32)> = Vec::with_capacity(3);
+fn discover_pids(
+    support_dir_override: Option<&std::path::Path>,
+) -> Vec<(String, i32, Option<ProcessKind>)> {
+    let mut out: Vec<(String, i32, Option<ProcessKind>)> = Vec::with_capacity(4);
 
     let self_pid = std::process::id() as i32;
-    out.push(("api".to_string(), self_pid));
+    out.push(("api".to_string(), self_pid, Some(ProcessKind::Core)));
 
     let support_dir = support_dir_override
         .map(|p| p.to_path_buf())
@@ -189,7 +200,7 @@ fn discover_pids(support_dir_override: Option<&std::path::Path>) -> Vec<(String,
         SWIFT_PGREP_PATTERN,
         None,
     ) {
-        out.push(("swift".to_string(), pid));
+        out.push(("swift".to_string(), pid, Some(ProcessKind::Core)));
     }
 
     if let Some(pid) = discover_one(
@@ -198,8 +209,39 @@ fn discover_pids(support_dir_override: Option<&std::path::Path>) -> Vec<(String,
         MLX_PGREP_PATTERN,
         Some(MLX_LAUNCHD_LABEL),
     ) {
-        out.push(("mlx-lm".to_string(), pid));
+        out.push(("mlx-lm".to_string(), pid, Some(ProcessKind::LocalModel)));
     }
+
+    if let Some(pid) = discover_one(
+        "mlx-vlm",
+        &support_dir.join(MLX_VLM_PIDFILE),
+        MLX_VLM_PGREP_PATTERN,
+        Some(MLX_VLM_LAUNCHD_LABEL),
+    ) {
+        out.push(("mlx-vlm".to_string(), pid, Some(ProcessKind::LocalModel)));
+    }
+
+    // Dedupe by pid: anchored pgrep patterns + distinct launchd labels make
+    // collisions unlikely, but a wrapper script whose argv contains both
+    // names would otherwise yield two identical rows. Drop later duplicates
+    // so the first-discovered label wins.
+    let mut seen: std::collections::HashMap<i32, String> = std::collections::HashMap::new();
+    out.retain(|(name, pid, _)| match seen.get(pid) {
+        None => {
+            seen.insert(*pid, name.clone());
+            true
+        }
+        Some(kept) => {
+            tracing::warn!(
+                component = "activity.discover",
+                kept_label = %kept,
+                duplicate_label = %name,
+                pid,
+                "dropping duplicate pid from discovery (already discovered under another label)"
+            );
+            false
+        }
+    });
 
     out
 }
@@ -444,7 +486,7 @@ fn pid_alive(pid: i32) -> bool {
 /// (elapsed_ns * num_cores) * 100`. RSS is taken from the second sample.
 ///
 /// Pids that disappear between calls are silently dropped.
-fn sample_processes(pids: &[(String, i32)]) -> Vec<ProcessBreakdown> {
+fn sample_processes(pids: &[(String, i32, Option<ProcessKind>)]) -> Vec<ProcessBreakdown> {
     if pids.is_empty() {
         return Vec::new();
     }
@@ -452,16 +494,16 @@ fn sample_processes(pids: &[(String, i32)]) -> Vec<ProcessBreakdown> {
     let cores = num_logical_cores().max(1) as f64;
 
     let t0 = Instant::now();
-    let first: Vec<(String, i32, Option<TaskInfo>)> = pids
+    let first: Vec<(String, i32, Option<ProcessKind>, Option<TaskInfo>)> = pids
         .iter()
-        .map(|(n, p)| (n.clone(), *p, proc_pid::pidinfo::<TaskInfo>(*p, 0).ok()))
+        .map(|(n, p, k)| (n.clone(), *p, *k, proc_pid::pidinfo::<TaskInfo>(*p, 0).ok()))
         .collect();
 
     thread::sleep(CPU_SAMPLE_WINDOW);
 
     let elapsed_ns = t0.elapsed().as_nanos() as f64;
     let mut out = Vec::with_capacity(first.len());
-    for (name, pid, before) in first {
+    for (name, pid, kind, before) in first {
         let Some(before) = before else { continue };
         let Ok(after) = proc_pid::pidinfo::<TaskInfo>(pid, 0) else {
             continue;
@@ -482,18 +524,25 @@ fn sample_processes(pids: &[(String, i32)]) -> Vec<ProcessBreakdown> {
         // with Activity Monitor "Memory" column reporting).
         let rss_mb = (after.pti_resident_size / (1024 * 1024)) as u32;
 
-        // Best-effort: prefer the OS-reported short name, fall back to the
-        // discovery label.
-        let display_name = proc_pid::name(pid)
-            .ok()
-            .filter(|s| !s.is_empty())
-            .unwrap_or(name);
+        // For known kinds the discovery label wins: `proc_pid::name` would
+        // collapse mlx-lm and mlx-vlm to `python3.11`/`uv`, making the rows
+        // indistinguishable in the UI. For untyped pids (None), keep the
+        // existing OS-name-preferred behaviour.
+        let display_name = if kind.is_some() {
+            name
+        } else {
+            proc_pid::name(pid)
+                .ok()
+                .filter(|s| !s.is_empty())
+                .unwrap_or(name)
+        };
 
         out.push(ProcessBreakdown {
             name: display_name,
             pid,
             cpu_percent,
             rss_mb,
+            kind,
         });
     }
     out
@@ -775,23 +824,49 @@ mod tests {
     use super::*;
     use std::fs;
 
-    /// PID-from-pidfile happy path: writing our own pid into the support dir
-    /// is enough to be picked up by discover_pids.
+    /// Exercises pidfile precedence in isolation from host pgrep/launchctl
+    /// state by probing `discover_one` once per known label.
     #[test]
     fn pidfile_happy_path() {
         let tmp = tempdir();
         let me = std::process::id() as i32;
+        let cases: &[(&str, &str, &str, Option<&str>)] = &[
+            ("swift", "swift.pid", SWIFT_PGREP_PATTERN, None),
+            ("mlx", "mlxlm.pid", MLX_PGREP_PATTERN, Some(MLX_LAUNCHD_LABEL)),
+            (
+                "mlx-vlm",
+                MLX_VLM_PIDFILE,
+                MLX_VLM_PGREP_PATTERN,
+                Some(MLX_VLM_LAUNCHD_LABEL),
+            ),
+        ];
+        for (target, pidfile_name, pgrep, launchd) in cases {
+            let pidfile = tmp.join(pidfile_name);
+            fs::write(&pidfile, me.to_string()).unwrap();
+            let pid = discover_one(target, &pidfile, pgrep, *launchd);
+            assert_eq!(pid, Some(me), "discover_one({target}) should pick pidfile");
+            fs::remove_file(&pidfile).unwrap();
+        }
+    }
+
+    /// Dedupe path: when mlx-lm and mlx-vlm both resolve to the same pid
+    /// (e.g. an argv that mentions both names so an unanchored pgrep
+    /// double-matches), only one row is emitted.
+    #[test]
+    fn discover_dedupes_colliding_pids() {
+        let tmp = tempdir();
+        let me = std::process::id() as i32;
+        // All four labels (api, swift, mlx-lm, mlx-vlm) resolve to `me`
+        // via pidfile or the implicit api self-pid. Dedupe must collapse
+        // them to a single row, and the surviving row's pid must be unique.
         fs::write(tmp.join("swift.pid"), me.to_string()).unwrap();
         fs::write(tmp.join("mlxlm.pid"), me.to_string()).unwrap();
+        fs::write(tmp.join(MLX_VLM_PIDFILE), me.to_string()).unwrap();
 
         let pids = discover_pids(Some(&tmp));
-        // self + swift + mlx-lm = 3, all pointing at our own pid in this test.
-        assert_eq!(pids.len(), 3, "expected 3 pids, got {pids:?}");
-        assert!(pids.iter().all(|(_, p)| *p == me));
-        let names: Vec<&str> = pids.iter().map(|(n, _)| n.as_str()).collect();
-        assert!(names.contains(&"api"));
-        assert!(names.contains(&"swift"));
-        assert!(names.contains(&"mlx-lm"));
+        let unique: std::collections::HashSet<i32> = pids.iter().map(|(_, p, _)| *p).collect();
+        assert_eq!(unique.len(), pids.len(), "no duplicate pids allowed");
+        assert_eq!(pids.len(), 1, "expected dedupe to collapse to 1 row");
     }
 
     /// PID-not-found: empty support dir + no launchctl labels matching means
@@ -805,7 +880,7 @@ mod tests {
         // unlikely candidate labels — almost certainly nothing matches.
         let pids = discover_pids(Some(&tmp));
         // `self` is always there.
-        assert!(pids.iter().any(|(n, _)| n == "api"));
+        assert!(pids.iter().any(|(n, _, _)| n == "api"));
 
         // sample() with the same support dir override must succeed even when
         // only the self pid is present.
@@ -820,7 +895,11 @@ mod tests {
     #[test]
     fn cache_prevents_back_to_back_resample() {
         let me = std::process::id() as i32;
-        let s = SystemResourceSampler::with_pids(vec![("api".to_string(), me)]);
+        let s = SystemResourceSampler::with_pids(vec![(
+            "api".to_string(),
+            me,
+            Some(ProcessKind::Core),
+        )]);
 
         let a = s.sample();
         let t = Instant::now();

--- a/Backend-Rust/api/src/activity/types.rs
+++ b/Backend-Rust/api/src/activity/types.rs
@@ -188,6 +188,22 @@ pub struct CaptureRow {
     pub paused_until: Option<DateTime<Utc>>,
 }
 
+/// Classifier for `ProcessBreakdown` rows so the UI can group them.
+/// Wire shape: snake_case string. Field is optional on `ProcessBreakdown` —
+/// older daemons emit no `kind`, and clients must tolerate unknown future
+/// variants gracefully. `Unknown` is the catch-all for future variants:
+/// `#[serde(other)]` makes deserialization match Swift's forward-compat
+/// fallback so an older daemon that adds a new wire value doesn't fail
+/// the whole snapshot decode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProcessKind {
+    Core,
+    LocalModel,
+    #[serde(other)]
+    Unknown,
+}
+
 /// Per-process sample line.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProcessBreakdown {
@@ -195,6 +211,8 @@ pub struct ProcessBreakdown {
     pub pid: i32,
     pub cpu_percent: f32,
     pub rss_mb: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<ProcessKind>,
 }
 
 /// One sample tick of system resources.
@@ -358,7 +376,10 @@ mod tests {
         // not be present (the whole point of the sum is that they're not
         // meaningful in this variant).
         assert!(v.get("reason").is_none(), "Allowed must not carry reason");
-        assert!(v.get("waiting_for").is_none(), "Allowed must not carry waiting_for");
+        assert!(
+            v.get("waiting_for").is_none(),
+            "Allowed must not carry waiting_for"
+        );
 
         // Round-trip back through the wire and we get the same variant.
         let back: GateState = serde_json::from_value(v).unwrap();
@@ -386,7 +407,11 @@ mod tests {
         assert!(!back.is_allowed());
         assert_eq!(back.since(), since);
         match back {
-            GateState::Blocked { reason, waiting_for, .. } => {
+            GateState::Blocked {
+                reason,
+                waiting_for,
+                ..
+            } => {
                 assert_eq!(reason, BlockReason::DeviceActive);
                 assert!(matches!(
                     waiting_for,
@@ -422,7 +447,10 @@ mod tests {
                 },
                 serde_json::json!({"type":"idle_for","duration_secs":120}),
             ),
-            (WaitCondition::AcPower, serde_json::json!({"type":"ac_power"})),
+            (
+                WaitCondition::AcPower,
+                serde_json::json!({"type":"ac_power"}),
+            ),
             (
                 WaitCondition::ThermalCooldown,
                 serde_json::json!({"type":"thermal_cooldown"}),
@@ -459,6 +487,16 @@ mod tests {
     }
 
     #[test]
+    fn process_kind_unknown_variant_decodes_future_wire_values() {
+        let json = r#"{"name":"future-proc","pid":9999,"cpu_percent":1.0,"rss_mb":10,"kind":"future_unknown"}"#;
+        let p: ProcessBreakdown = serde_json::from_str(json).unwrap();
+        assert_eq!(p.kind, Some(ProcessKind::Unknown));
+
+        let direct: ProcessKind = serde_json::from_str("\"future_unknown\"").unwrap();
+        assert_eq!(direct, ProcessKind::Unknown);
+    }
+
+    #[test]
     fn gate_state_allowed_rejects_extraneous_reason() {
         // Allowed's untyped extras still parse (serde ignores unknown
         // fields by default), but constructing and round-tripping a clean
@@ -467,7 +505,13 @@ mod tests {
             since: "2026-04-26T14:25:00Z".parse().unwrap(),
         };
         let s = serde_json::to_string(&g).unwrap();
-        assert!(!s.contains("reason"), "Allowed serialization must not contain reason: {s}");
-        assert!(!s.contains("waiting_for"), "Allowed must not contain waiting_for: {s}");
+        assert!(
+            !s.contains("reason"),
+            "Allowed serialization must not contain reason: {s}"
+        );
+        assert!(
+            !s.contains("waiting_for"),
+            "Allowed must not contain waiting_for: {s}"
+        );
     }
 }

--- a/Backend-Rust/api/tests/activity_endpoints.rs
+++ b/Backend-Rust/api/tests/activity_endpoints.rs
@@ -189,6 +189,7 @@ impl ResourceSampler for FakeSampler {
                 pid: 4242,
                 cpu_percent: 12.5,
                 rss_mb: 256,
+                kind: None,
             }],
         }
     }

--- a/Desktop/Sources/Activity/ActivityModels.swift
+++ b/Desktop/Sources/Activity/ActivityModels.swift
@@ -89,6 +89,19 @@ public enum ThermalState: String, Codable, Hashable {
     case critical
 }
 
+public enum ProcessKind: String, Codable, Hashable {
+    case core
+    case localModel = "local_model"
+    case unknown
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.singleValueContainer()
+        let raw = try c.decode(String.self)
+        // Fallback to .unknown for forward-compat with newer daemons.
+        self = ProcessKind(rawValue: raw) ?? .unknown
+    }
+}
+
 /// Issue #35: the pre-#35 `GateReason` (`idle/device_active/on_battery/
 /// thermal/locked/manual_pause/none/stub`) was a stringly-typed enum that
 /// existed alongside an `allowed: Bool` permitting illegal combos like
@@ -242,19 +255,22 @@ public struct ProcessBreakdown: Codable, Hashable {
     public let pid: Int32
     public let cpuPercent: Float
     public let rssMb: UInt32
+    public let kind: ProcessKind?
 
     enum CodingKeys: String, CodingKey {
         case name
         case pid
         case cpuPercent = "cpu_percent"
         case rssMb = "rss_mb"
+        case kind
     }
 
-    public init(name: String, pid: Int32, cpuPercent: Float, rssMb: UInt32) {
+    public init(name: String, pid: Int32, cpuPercent: Float, rssMb: UInt32, kind: ProcessKind? = nil) {
         self.name = name
         self.pid = pid
         self.cpuPercent = cpuPercent
         self.rssMb = rssMb
+        self.kind = kind
     }
 }
 

--- a/Desktop/Sources/Activity/ActivityPage.swift
+++ b/Desktop/Sources/Activity/ActivityPage.swift
@@ -441,28 +441,38 @@ struct ActivityPage: View {
     }
 
     private func processBreakdownView(_ procs: [ProcessBreakdown]) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
+        let sortedProcs = procs.sorted { $0.cpuPercent > $1.cpuPercent }
+        let localModels = sortedProcs.filter { $0.kind == .localModel }
+        let others = sortedProcs.filter { $0.kind != .localModel }
+        return VStack(alignment: .leading, spacing: 6) {
             Text("Process breakdown")
                 .scaledFont(size: 12, weight: .semibold)
                 .foregroundColor(OmiColors.textTertiary)
-            VStack(spacing: 4) {
-                ForEach(procs, id: \.pid) { p in
-                    HStack {
-                        Text(p.name)
-                            .scaledFont(size: 12)
-                            .foregroundColor(OmiColors.textSecondary)
-                        Text("(pid \(p.pid))")
-                            .scaledFont(size: 11)
-                            .foregroundColor(OmiColors.textQuaternary)
-                        Spacer()
-                        Text(String(format: "%.0f%%", p.cpuPercent))
-                            .scaledFont(size: 12, weight: .medium)
-                            .foregroundColor(OmiColors.textPrimary)
-                            .frame(width: 50, alignment: .trailing)
-                        Text(rssString(p.rssMb))
-                            .scaledFont(size: 12)
+            VStack(alignment: .leading, spacing: 8) {
+                if localModels.isEmpty {
+                    VStack(spacing: 4) {
+                        ForEach(others, id: \.pid) { p in
+                            processRow(p)
+                        }
+                    }
+                } else {
+                    Text("Local Models")
+                        .scaledFont(size: 11, weight: .semibold)
+                        .foregroundColor(OmiColors.textTertiary)
+                    VStack(spacing: 4) {
+                        ForEach(localModels, id: \.pid) { p in
+                            processRow(p)
+                        }
+                    }
+                    if !others.isEmpty {
+                        Text("Processes")
+                            .scaledFont(size: 11, weight: .semibold)
                             .foregroundColor(OmiColors.textTertiary)
-                            .frame(width: 70, alignment: .trailing)
+                        VStack(spacing: 4) {
+                            ForEach(others, id: \.pid) { p in
+                                processRow(p)
+                            }
+                        }
                     }
                 }
             }
@@ -471,6 +481,26 @@ struct ActivityPage: View {
                 RoundedRectangle(cornerRadius: 10)
                     .fill(OmiColors.backgroundSecondary)
             )
+        }
+    }
+
+    private func processRow(_ p: ProcessBreakdown) -> some View {
+        HStack {
+            Text(p.name)
+                .scaledFont(size: 12)
+                .foregroundColor(OmiColors.textSecondary)
+            Text("(pid \(p.pid))")
+                .scaledFont(size: 11)
+                .foregroundColor(OmiColors.textQuaternary)
+            Spacer()
+            Text(String(format: "%.0f%%", p.cpuPercent))
+                .scaledFont(size: 12, weight: .medium)
+                .foregroundColor(OmiColors.textPrimary)
+                .frame(width: 50, alignment: .trailing)
+            Text(rssString(p.rssMb))
+                .scaledFont(size: 12)
+                .foregroundColor(OmiColors.textTertiary)
+                .frame(width: 70, alignment: .trailing)
         }
     }
 

--- a/Desktop/Tests/ActivityModelsTests.swift
+++ b/Desktop/Tests/ActivityModelsTests.swift
@@ -589,4 +589,45 @@ final class ActivityModelsTests: XCTestCase {
     func testDefaultsKeyMatchesContract() {
         XCTAssertEqual(ActivityDefaultsKeys.lastGateStateJSON, "activity.lastGateStateJSON")
     }
+
+    // MARK: - ProcessKind decoding (forward-compat with newer daemons)
+
+    func testProcessBreakdownDecodesLocalModelKind() throws {
+        let json = """
+        { "name": "mlx-lm", "pid": 1236, "cpu_percent": 78.4, "rss_mb": 1498,
+          "kind": "local_model" }
+        """
+        let p = try Self.makeDecoder()
+            .decode(ProcessBreakdown.self, from: json.data(using: .utf8)!)
+        XCTAssertEqual(p.kind, .localModel)
+    }
+
+    func testProcessBreakdownDecodesCoreKind() throws {
+        let json = """
+        { "name": "infinite-recall-api", "pid": 1234, "cpu_percent": 12.4, "rss_mb": 84,
+          "kind": "core" }
+        """
+        let p = try Self.makeDecoder()
+            .decode(ProcessBreakdown.self, from: json.data(using: .utf8)!)
+        XCTAssertEqual(p.kind, .core)
+    }
+
+    func testProcessBreakdownDecodesUnknownKindAsUnknown() throws {
+        let json = """
+        { "name": "future-proc", "pid": 9999, "cpu_percent": 1.0, "rss_mb": 10,
+          "kind": "future_unknown" }
+        """
+        let p = try Self.makeDecoder()
+            .decode(ProcessBreakdown.self, from: json.data(using: .utf8)!)
+        XCTAssertEqual(p.kind, .unknown)
+    }
+
+    func testProcessBreakdownDecodesMissingKindAsNil() throws {
+        let json = """
+        { "name": "infinite-recall-api", "pid": 1234, "cpu_percent": 12.4, "rss_mb": 84 }
+        """
+        let p = try Self.makeDecoder()
+            .decode(ProcessBreakdown.self, from: json.data(using: .utf8)!)
+        XCTAssertNil(p.kind)
+    }
 }


### PR DESCRIPTION
## Summary
- Adds mlx-vlm to the Rust daemon's process discovery (mlx-lm was already there). Both servers now appear in the Activity tab with live CPU/RSS.
- Adds an optional `kind` discriminator (`Core | LocalModel | Unknown`) to `ProcessBreakdown`; SwiftUI partitions into a "Local Models" subhead when present.
- Hardens discovery: pgrep patterns are leading-space-anchored, PIDs are deduped with a `kept_label` warn, and `sample_processes` no longer overrides our discovery label with `proc_pid::name`.
- Symmetric forward-compat in both directions: Rust uses `#[serde(other)] Unknown` + `serde(default, skip_serializing_if)`; Swift falls back to `.unknown` for unrecognized variants and `nil` for missing field.

## Test plan
- [x] `cargo test --locked -p infinite-recall-api 'activity::'` (60/60 passing locally including new `process_kind_unknown_variant_decodes_future_wire_values`, `discover_dedupes_colliding_pids`, restructured `pidfile_happy_path`)
- [x] `cargo test --locked -p infinite-recall-api --features activity_test_wiring --test activity_endpoints` (21/21 passing locally)
- [x] `xcrun swift build -c debug --package-path Desktop` clean
- [x] `xcrun swift test --package-path Desktop --filter ActivityModelsTests` (30/30 passing including new `testProcessBreakdownDecodesCoreKind`, `testProcessBreakdownDecodesLocalModelKind`, `testProcessBreakdownDecodesUnknownKindAsUnknown`, `testProcessBreakdownDecodesMissingKindAsNil`)
- [ ] Manual smoke: `launchctl load com.infiniterecall.mlx.plist` + `com.infiniterecall.vlm.plist` → Activity tab shows "Local Models" subhead with both rows; unloading vlm → row disappears within ~2s.
- [ ] Backwards-compat smoke: newer Swift app vs older daemon (no `kind` on wire) → all rows render under "Processes" with no decode error.

## Out of scope (deferred follow-ups)
- Stopped / not-installed model rows (registry + plist detection).
- Per-model Start / Stop / Install affordances.
- Whisper or other not-yet-spawned models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Activity view now organizes processes into separate "Local Models" and "Processes" sections for improved clarity.
  * Process rows are automatically sorted by CPU usage (highest to lowest) to quickly identify resource-intensive operations.
  * Added detection support for additional process types.

* **Tests**
  * Extended test coverage for process classification and forward-compatibility handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->