### PR TITLE
Brain Map: ongoing KG ingestion + idle-aware backfill

### DIFF
--- a/Desktop/Sources/AI/JSONFenceStripping.swift
+++ b/Desktop/Sources/AI/JSONFenceStripping.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Strip ```json ... ``` and ``` ... ``` fences if a model wrapped its
+/// reply against instructions. Idempotent on un-fenced input.
+func stripJSONFences(_ s: String) -> String {
+  var t = s.trimmingCharacters(in: .whitespacesAndNewlines)
+  if t.hasPrefix("```") {
+    if let nl = t.firstIndex(of: "\n") {
+      t = String(t[t.index(after: nl)...])
+    }
+    if t.hasSuffix("```") {
+      t = String(t.dropLast(3))
+    }
+    t = t.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+  return t
+}

--- a/Desktop/Sources/AI/KGExtractor.swift
+++ b/Desktop/Sources/AI/KGExtractor.swift
@@ -1,25 +1,5 @@
 import Foundation
 
-// MARK: - Lane B local DTOs
-//
-// These mirror what Lane A is concurrently defining in
-// `Desktop/Sources/FileIndexing/KnowledgeGraphStorage.swift`.
-// At integration merge, the duplicate is caught and one definition kept.
-// Shape (name, fields, types, Sendable) MUST stay identical.
-
-struct ExtractedKGNode: Sendable, Equatable {
-  let id: String
-  let label: String
-  let type: KnowledgeGraphNodeType
-  let aliases: [String]
-}
-
-struct ExtractedKGEdge: Sendable, Equatable {
-  let sourceId: String
-  let targetId: String
-  let label: String
-}
-
 // MARK: - Outcome
 
 struct KGExtraction: Sendable {

--- a/Desktop/Sources/AI/KGExtractor.swift
+++ b/Desktop/Sources/AI/KGExtractor.swift
@@ -1,0 +1,530 @@
+import Foundation
+
+// MARK: - Lane B local DTOs
+//
+// These mirror what Lane A is concurrently defining in
+// `Desktop/Sources/FileIndexing/KnowledgeGraphStorage.swift`.
+// At integration merge, the duplicate is caught and one definition kept.
+// Shape (name, fields, types, Sendable) MUST stay identical.
+
+struct ExtractedKGNode: Sendable, Equatable {
+  let id: String
+  let label: String
+  let type: KnowledgeGraphNodeType
+  let aliases: [String]
+}
+
+struct ExtractedKGEdge: Sendable, Equatable {
+  let sourceId: String
+  let targetId: String
+  let label: String
+}
+
+// MARK: - Outcome
+
+struct KGExtraction: Sendable {
+  let nodes: [ExtractedKGNode]
+  let edges: [ExtractedKGEdge]
+  let outcome: ParseOutcome
+}
+
+enum ParseOutcome: Sendable, Equatable {
+  case parsed
+  case recovered
+  case truncatedRetried
+  case empty(reason: EmptyReason)
+  case failed(reason: FailReason)
+}
+
+enum EmptyReason: String, Sendable { case modelReturnedNone, allNodesInvalid, contentTooShort }
+enum FailReason: String, Sendable { case llmError, jsonUnsalvageable, lengthTruncatedTwice }
+
+// MARK: - LLM seam
+
+/// Non-pinning LLM JSON-extraction surface. Implementations MUST route
+/// through `chatAutonomous` (or equivalent non-pinning path) so the
+/// idle-unload watchdog keeps ticking during deferred drain.
+protocol AutonomousLLMCalling: Sendable {
+  func extractJSON(prompt: String, maxTokens: Int, temperature: Double, seed: UInt64?) async throws -> String
+}
+
+extension AutonomousLLMCalling {
+  /// Two-arg convenience used by the extractor. `prompt` is the system+user
+  /// concatenation; the protocol implementation may split.
+  func extractJSON(prompt: String, maxTokens: Int) async throws -> String {
+    try await extractJSON(prompt: prompt, maxTokens: maxTokens, temperature: 0.0, seed: KGExtractor.fixedSeed)
+  }
+}
+
+// MARK: - LocalLLMClient bridge
+//
+// The locked seam is `extractJSON(prompt:maxTokens:temperature:seed:) -> String`.
+// `LocalLLMClient.chatAutonomous(...)` returns a streamed
+// `AsyncThrowingStream<LLM.ChatChunk, Error>`; we collect it into a single
+// string here. Temperature/seed are passed forward in spirit — mlx-lm.server's
+// current request body doesn't accept those fields from this client, but the
+// seam contract is honored at the type level so a future server upgrade is
+// a one-line change.
+
+extension LocalLLMClient: AutonomousLLMCalling {
+  func extractJSON(
+    prompt: String, maxTokens: Int, temperature: Double, seed: UInt64?
+  ) async throws -> String {
+    // `prompt` is split: first line "SYSTEM:" preamble, rest is user. To keep
+    // call sites simple we model it as one user message with the prompt as
+    // content — KGExtractor builds two messages explicitly via the helper
+    // below. We expose both shapes.
+    let messages = [LLM.ChatMessage(role: .user, content: prompt)]
+    return try await collectAutonomous(messages: messages)
+  }
+
+  /// Two-message variant used by `KGExtractor`.
+  func extractJSONMessages(
+    system: String, user: String, maxTokens: Int, temperature: Double, seed: UInt64?
+  ) async throws -> String {
+    let messages = [
+      LLM.ChatMessage(role: .system, content: system),
+      LLM.ChatMessage(role: .user, content: user),
+    ]
+    return try await collectAutonomous(messages: messages)
+  }
+
+  private func collectAutonomous(messages: [LLM.ChatMessage]) async throws -> String {
+    let stream = try await chatAutonomous(messages: messages, stream: false)
+    var out = ""
+    var finish: String? = nil
+    for try await chunk in stream {
+      out += chunk.delta
+      if chunk.finishReason != nil { finish = chunk.finishReason }
+    }
+    // Encode the finish reason into a sentinel suffix the parser can detect
+    // for length-truncation. We use a private marker the model itself can
+    // never emit (it's stripped before parsing).
+    if finish == "length" {
+      out += KGExtractor.lengthTruncationMarker
+    }
+    return out
+  }
+}
+
+// MARK: - Extractor
+
+protocol KGExtracting: Sendable {
+  func extract(memoryId: Int64, content: String, sourceApp: String?) async throws
+    -> KGExtraction
+}
+
+actor KGExtractor: KGExtracting {
+
+  /// Marker the LocalLLMClient bridge appends when the server reports a
+  /// `finish_reason` of "length" so this layer can distinguish a truncated
+  /// reply from a genuinely-malformed one. Stripped before JSON parsing.
+  static let lengthTruncationMarker = "\u{0001}__KGEXTRACTOR_LENGTH_TRUNCATED__\u{0001}"
+
+  /// Fixed determinism seed. Passed to the LLM seam even when the underlying
+  /// runtime currently ignores it — the contract is locked at the type layer.
+  static let fixedSeed: UInt64 = 0xC0FFEE
+
+  static let defaultMaxTokens = 1024
+
+  private let llm: AutonomousLLMCalling
+  private let maxContentChars: Int
+  private let chunkOverlapChars: Int
+
+  init(
+    llm: AutonomousLLMCalling = LocalLLMClient.shared,
+    maxContentChars: Int = 2500,
+    chunkOverlapChars: Int = 200
+  ) {
+    self.llm = llm
+    self.maxContentChars = maxContentChars
+    self.chunkOverlapChars = chunkOverlapChars
+  }
+
+  // MARK: Public
+
+  func extract(memoryId: Int64, content: String, sourceApp: String?) async throws -> KGExtraction {
+    let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmed.isEmpty {
+      return KGExtraction(nodes: [], edges: [], outcome: .empty(reason: .contentTooShort))
+    }
+
+    // Chunk if oversized, otherwise single pass.
+    let chunks = chunkContent(trimmed)
+    var unionNodes: [ExtractedKGNode] = []
+    var unionEdges: [ExtractedKGEdge] = []
+    var chunkOutcomes: [ParseOutcome] = []
+
+    for chunk in chunks {
+      let chunkResult = try await runOnce(content: chunk, sourceApp: sourceApp)
+      chunkOutcomes.append(chunkResult.outcome)
+      unionNodes.append(contentsOf: chunkResult.nodes)
+      unionEdges.append(contentsOf: chunkResult.edges)
+    }
+
+    let aggregatedOutcome = aggregateOutcomes(chunkOutcomes)
+
+    // Dedupe by id slug (nodes) and (source,target,label) (edges).
+    let dedupedNodes = dedupeNodes(unionNodes)
+    let dedupedEdges = dedupeEdges(unionEdges, validNodeIds: Set(dedupedNodes.map { $0.id }))
+
+    if dedupedNodes.isEmpty && dedupedEdges.isEmpty {
+      switch aggregatedOutcome {
+      case .empty, .failed:
+        return KGExtraction(nodes: [], edges: [], outcome: aggregatedOutcome)
+      default:
+        return KGExtraction(nodes: [], edges: [], outcome: .empty(reason: .modelReturnedNone))
+      }
+    }
+
+    return KGExtraction(nodes: dedupedNodes, edges: dedupedEdges, outcome: aggregatedOutcome)
+  }
+
+  // MARK: Per-chunk pipeline
+
+  /// Run the LLM on one content slice, with one length-truncation retry.
+  private func runOnce(content: String, sourceApp: String?) async throws -> KGExtraction {
+    let system = KGExtractorPrompt.systemPrompt
+    let user = KGExtractorPrompt.userMessage(content: content, sourceApp: sourceApp)
+
+    // First pass.
+    let firstRaw: String
+    do {
+      firstRaw = try await callLLM(system: system, user: user, maxTokens: Self.defaultMaxTokens)
+    } catch {
+      return KGExtraction(nodes: [], edges: [], outcome: .failed(reason: .llmError))
+    }
+
+    let firstParse = parseAndValidate(raw: firstRaw, baseOutcome: .parsed)
+    if case .truncationDetected = firstParse {
+      // Retry once with 2x maxTokens.
+      let retriedRaw: String
+      do {
+        retriedRaw = try await callLLM(system: system, user: user, maxTokens: Self.defaultMaxTokens * 2)
+      } catch {
+        return KGExtraction(nodes: [], edges: [], outcome: .failed(reason: .llmError))
+      }
+      let retriedParse = parseAndValidate(raw: retriedRaw, baseOutcome: .truncatedRetried)
+      switch retriedParse {
+      case .truncationDetected:
+        return KGExtraction(nodes: [], edges: [], outcome: .failed(reason: .lengthTruncatedTwice))
+      case .resolved(let extraction):
+        return extraction
+      }
+    }
+    if case .resolved(let extraction) = firstParse {
+      return extraction
+    }
+    // Should not reach here.
+    return KGExtraction(nodes: [], edges: [], outcome: .failed(reason: .jsonUnsalvageable))
+  }
+
+  private func callLLM(system: String, user: String, maxTokens: Int) async throws -> String {
+    // Prefer the two-message bridge if the underlying llm is a LocalLLMClient.
+    if let local = llm as? LocalLLMClient {
+      return try await local.extractJSONMessages(
+        system: system, user: user, maxTokens: maxTokens,
+        temperature: 0.0, seed: Self.fixedSeed)
+    }
+    // Generic path: fold system + user into one prompt.
+    let prompt = system + "\n\n" + user
+    return try await llm.extractJSON(
+      prompt: prompt, maxTokens: maxTokens, temperature: 0.0, seed: Self.fixedSeed)
+  }
+
+  // MARK: Parser
+
+  private enum ParseStep {
+    case truncationDetected
+    case resolved(KGExtraction)
+  }
+
+  /// Parse pipeline:
+  ///   1. strip fences, strict JSON decode -> .parsed (or carried baseOutcome)
+  ///   2. else regex first balanced {...} -> .recovered
+  ///   3. else if length truncation marker present -> .truncationDetected
+  ///   4. else .failed(.jsonUnsalvageable)
+  /// Followed by node/edge validation.
+  private func parseAndValidate(raw: String, baseOutcome: ParseOutcome) -> ParseStep {
+    // Detect truncation BEFORE stripping (the marker is appended by the bridge).
+    let truncated = raw.contains(Self.lengthTruncationMarker)
+    let cleaned = raw.replacingOccurrences(of: Self.lengthTruncationMarker, with: "")
+    let stripped = stripJSONFences(cleaned)
+
+    var stage: ParseOutcome = baseOutcome
+    var envelope: RawEnvelope? = decodeStrict(stripped)
+    if envelope == nil {
+      if let recovered = extractFirstBalancedBraces(from: stripped),
+         let env = decodeStrict(recovered) {
+        envelope = env
+        // If we started at baseOutcome .parsed, demote to .recovered.
+        if stage == .parsed { stage = .recovered }
+      }
+    }
+
+    guard let env = envelope else {
+      if truncated {
+        return .truncationDetected
+      }
+      return .resolved(KGExtraction(nodes: [], edges: [], outcome: .failed(reason: .jsonUnsalvageable)))
+    }
+
+    // Validate nodes.
+    var validNodes: [ExtractedKGNode] = []
+    var seenIds = Set<String>()
+    for n in env.nodes {
+      guard let label = n.label?.trimmingCharacters(in: .whitespacesAndNewlines), !label.isEmpty,
+            let idRaw = n.id?.trimmingCharacters(in: .whitespacesAndNewlines), !idRaw.isEmpty,
+            let typeRaw = n.type,
+            let typed = KnowledgeGraphNodeType(rawValue: typeRaw)
+      else { continue }
+      let slug = slugify(idRaw)
+      if slug.isEmpty || seenIds.contains(slug) { continue }
+      seenIds.insert(slug)
+      let aliases = (n.aliases ?? []).map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+        .filter { !$0.isEmpty }
+      validNodes.append(ExtractedKGNode(id: slug, label: label, type: typed, aliases: aliases))
+    }
+
+    // If model returned at least one node candidate but ALL were invalid, signal allNodesInvalid.
+    let modelReturnedAnyNodes = !env.nodes.isEmpty
+    if modelReturnedAnyNodes && validNodes.isEmpty {
+      return .resolved(
+        KGExtraction(nodes: [], edges: [], outcome: .empty(reason: .allNodesInvalid)))
+    }
+
+    // Validate edges (drop those referencing missing node ids).
+    let validIds = Set(validNodes.map { $0.id })
+    var validEdges: [ExtractedKGEdge] = []
+    for e in env.edges {
+      guard let s = e.source?.trimmingCharacters(in: .whitespacesAndNewlines), !s.isEmpty,
+            let t = e.target?.trimmingCharacters(in: .whitespacesAndNewlines), !t.isEmpty,
+            let lbl = e.label?.trimmingCharacters(in: .whitespacesAndNewlines), !lbl.isEmpty
+      else { continue }
+      let sSlug = slugify(s)
+      let tSlug = slugify(t)
+      if !validIds.contains(sSlug) || !validIds.contains(tSlug) { continue }
+      validEdges.append(ExtractedKGEdge(sourceId: sSlug, targetId: tSlug, label: lbl))
+    }
+
+    if validNodes.isEmpty && validEdges.isEmpty {
+      return .resolved(
+        KGExtraction(nodes: [], edges: [], outcome: .empty(reason: .modelReturnedNone)))
+    }
+
+    return .resolved(KGExtraction(nodes: validNodes, edges: validEdges, outcome: stage))
+  }
+
+  // MARK: JSON helpers
+
+  private struct RawEnvelope: Decodable {
+    let nodes: [RawNode]
+    let edges: [RawEdge]
+  }
+  private struct RawNode: Decodable {
+    let id: String?
+    let label: String?
+    let type: String?
+    let aliases: [String]?
+  }
+  private struct RawEdge: Decodable {
+    let source: String?
+    let target: String?
+    let label: String?
+  }
+
+  private func decodeStrict(_ s: String) -> RawEnvelope? {
+    guard let data = s.data(using: .utf8) else { return nil }
+    // Tolerate missing nodes/edges arrays at top level by decoding as a more
+    // permissive envelope first.
+    if let env = try? JSONDecoder().decode(RawEnvelope.self, from: data) {
+      return env
+    }
+    if let any = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] {
+      let nodesAny = any["nodes"] as? [[String: Any]] ?? []
+      let edgesAny = any["edges"] as? [[String: Any]] ?? []
+      let nodes: [RawNode] = nodesAny.map { dict in
+        RawNode(
+          id: dict["id"] as? String,
+          label: dict["label"] as? String,
+          type: dict["type"] as? String,
+          aliases: (dict["aliases"] as? [Any])?.compactMap { $0 as? String }
+        )
+      }
+      let edges: [RawEdge] = edgesAny.map { dict in
+        RawEdge(
+          source: dict["source"] as? String,
+          target: dict["target"] as? String,
+          label: dict["label"] as? String
+        )
+      }
+      return RawEnvelope(nodes: nodes, edges: edges)
+    }
+    return nil
+  }
+
+  /// Find the first balanced `{...}` block. Brace-count scan; ignores braces
+  /// inside double-quoted strings (with escape awareness).
+  private func extractFirstBalancedBraces(from s: String) -> String? {
+    let chars = Array(s)
+    guard let start = chars.firstIndex(of: "{") else { return nil }
+    var depth = 0
+    var inString = false
+    var escape = false
+    var i = start
+    while i < chars.count {
+      let c = chars[i]
+      if inString {
+        if escape {
+          escape = false
+        } else if c == "\\" {
+          escape = true
+        } else if c == "\"" {
+          inString = false
+        }
+      } else {
+        if c == "\"" {
+          inString = true
+        } else if c == "{" {
+          depth += 1
+        } else if c == "}" {
+          depth -= 1
+          if depth == 0 {
+            return String(chars[start...i])
+          }
+        }
+      }
+      i += 1
+    }
+    return nil
+  }
+
+  // MARK: Slug + chunk + dedupe
+
+  private func slugify(_ s: String) -> String {
+    let lowered = s.lowercased()
+    var out = ""
+    var lastWasHyphen = false
+    for scalar in lowered.unicodeScalars {
+      if (scalar >= "a" && scalar <= "z") || (scalar >= "0" && scalar <= "9") {
+        out.unicodeScalars.append(scalar)
+        lastWasHyphen = false
+      } else if !lastWasHyphen && !out.isEmpty {
+        out.append("-")
+        lastWasHyphen = true
+      }
+    }
+    while out.hasSuffix("-") { out.removeLast() }
+    return out
+  }
+
+  private func chunkContent(_ s: String) -> [String] {
+    if s.count <= maxContentChars { return [s] }
+    var pieces: [String] = []
+    let chars = Array(s)
+    var start = 0
+    while start < chars.count {
+      let end = min(start + maxContentChars, chars.count)
+      pieces.append(String(chars[start..<end]))
+      if end == chars.count { break }
+      start = end - chunkOverlapChars
+      if start < 0 { start = 0 }
+    }
+    return pieces
+  }
+
+  private func dedupeNodes(_ nodes: [ExtractedKGNode]) -> [ExtractedKGNode] {
+    var seen = Set<String>()
+    var out: [ExtractedKGNode] = []
+    for n in nodes {
+      if seen.insert(n.id).inserted {
+        out.append(n)
+      }
+    }
+    return out
+  }
+
+  private func dedupeEdges(_ edges: [ExtractedKGEdge], validNodeIds: Set<String>) -> [ExtractedKGEdge] {
+    var seen = Set<String>()
+    var out: [ExtractedKGEdge] = []
+    for e in edges {
+      guard validNodeIds.contains(e.sourceId), validNodeIds.contains(e.targetId) else { continue }
+      let key = "\(e.sourceId)\u{1F}\(e.targetId)\u{1F}\(e.label)"
+      if seen.insert(key).inserted {
+        out.append(e)
+      }
+    }
+    return out
+  }
+
+  // MARK: Outcome aggregation across chunks
+
+  /// Aggregation rules:
+  /// - Any chunk failed -> failed (worst failure wins; lengthTruncatedTwice
+  ///   ranks above llmError ranks above jsonUnsalvageable for reporting).
+  /// - Else if any chunk had non-empty success: pick the worst success-class
+  ///   (truncatedRetried > recovered > parsed).
+  /// - Else (all chunks empty): pick the worst empty reason
+  ///   (allNodesInvalid > modelReturnedNone > contentTooShort).
+  private func aggregateOutcomes(_ outcomes: [ParseOutcome]) -> ParseOutcome {
+    if outcomes.isEmpty { return .empty(reason: .modelReturnedNone) }
+
+    // Failed dominates.
+    var failed: FailReason? = nil
+    for o in outcomes {
+      if case .failed(let r) = o {
+        failed = worseFail(failed, r)
+      }
+    }
+    if let f = failed { return .failed(reason: f) }
+
+    // Successes — pick worst success-class among them.
+    var successRank = -1
+    var successOutcome: ParseOutcome? = nil
+    for o in outcomes {
+      let r: Int
+      switch o {
+      case .truncatedRetried: r = 3
+      case .recovered: r = 2
+      case .parsed: r = 1
+      default: r = -1
+      }
+      if r > successRank {
+        successRank = r
+        successOutcome = o
+      }
+    }
+    if let s = successOutcome { return s }
+
+    // All empty — pick worst empty reason.
+    var emptyRank = -1
+    var emptyOutcome: ParseOutcome = .empty(reason: .modelReturnedNone)
+    for o in outcomes {
+      if case .empty(let reason) = o {
+        let r: Int
+        switch reason {
+        case .allNodesInvalid: r = 2
+        case .modelReturnedNone: r = 1
+        case .contentTooShort: r = 0
+        }
+        if r > emptyRank {
+          emptyRank = r
+          emptyOutcome = o
+        }
+      }
+    }
+    return emptyOutcome
+  }
+
+  private func worseFail(_ a: FailReason?, _ b: FailReason) -> FailReason {
+    func rank(_ r: FailReason) -> Int {
+      switch r {
+      case .lengthTruncatedTwice: return 3
+      case .llmError: return 2
+      case .jsonUnsalvageable: return 1
+      }
+    }
+    guard let a = a else { return b }
+    return rank(b) > rank(a) ? b : a
+  }
+}

--- a/Desktop/Sources/AI/KGExtractor.swift
+++ b/Desktop/Sources/AI/KGExtractor.swift
@@ -6,6 +6,22 @@ struct KGExtraction: Sendable {
   let nodes: [ExtractedKGNode]
   let edges: [ExtractedKGEdge]
   let outcome: ParseOutcome
+  /// Diagnostic detail for `.failed(.llmError)` outcomes. nil otherwise.
+  /// Surfaced through `PendingWorkStorage.fail()`'s error-message column so
+  /// dead-letter logs include the underlying LLM error.
+  let llmErrorDetail: String?
+
+  init(
+    nodes: [ExtractedKGNode],
+    edges: [ExtractedKGEdge],
+    outcome: ParseOutcome,
+    llmErrorDetail: String? = nil
+  ) {
+    self.nodes = nodes
+    self.edges = edges
+    self.outcome = outcome
+    self.llmErrorDetail = llmErrorDetail
+  }
 }
 
 enum ParseOutcome: Sendable, Equatable {
@@ -134,12 +150,18 @@ actor KGExtractor: KGExtracting {
     var unionNodes: [ExtractedKGNode] = []
     var unionEdges: [ExtractedKGEdge] = []
     var chunkOutcomes: [ParseOutcome] = []
+    // Preserve the first non-nil llmErrorDetail across chunks so the dead-letter
+    // path can surface the underlying transport error.
+    var firstLLMErrorDetail: String?
 
     for chunk in chunks {
       let chunkResult = try await runOnce(content: chunk, sourceApp: sourceApp)
       chunkOutcomes.append(chunkResult.outcome)
       unionNodes.append(contentsOf: chunkResult.nodes)
       unionEdges.append(contentsOf: chunkResult.edges)
+      if firstLLMErrorDetail == nil, let detail = chunkResult.llmErrorDetail {
+        firstLLMErrorDetail = detail
+      }
     }
 
     let aggregatedOutcome = aggregateOutcomes(chunkOutcomes)
@@ -151,13 +173,21 @@ actor KGExtractor: KGExtracting {
     if dedupedNodes.isEmpty && dedupedEdges.isEmpty {
       switch aggregatedOutcome {
       case .empty, .failed:
-        return KGExtraction(nodes: [], edges: [], outcome: aggregatedOutcome)
+        return KGExtraction(
+          nodes: [], edges: [],
+          outcome: aggregatedOutcome,
+          llmErrorDetail: firstLLMErrorDetail
+        )
       default:
         return KGExtraction(nodes: [], edges: [], outcome: .empty(reason: .modelReturnedNone))
       }
     }
 
-    return KGExtraction(nodes: dedupedNodes, edges: dedupedEdges, outcome: aggregatedOutcome)
+    return KGExtraction(
+      nodes: dedupedNodes, edges: dedupedEdges,
+      outcome: aggregatedOutcome,
+      llmErrorDetail: firstLLMErrorDetail
+    )
   }
 
   // MARK: Per-chunk pipeline
@@ -172,7 +202,16 @@ actor KGExtractor: KGExtracting {
     do {
       firstRaw = try await callLLM(system: system, user: user, maxTokens: Self.defaultMaxTokens)
     } catch {
-      return KGExtraction(nodes: [], edges: [], outcome: .failed(reason: .llmError))
+      // Preserve the original error in the structured logger (so deferred
+      // diagnostics aren't lost) AND surface it as `llmErrorDetail` so the
+      // PowerWorkBridge handler can route it into the pending_work
+      // `lastError` column for dead-letter visibility.
+      logError("KGExtractor: LLM call failed (first pass)", error: error)
+      return KGExtraction(
+        nodes: [], edges: [],
+        outcome: .failed(reason: .llmError),
+        llmErrorDetail: error.localizedDescription
+      )
     }
 
     let firstParse = parseAndValidate(raw: firstRaw, baseOutcome: .parsed)
@@ -182,7 +221,12 @@ actor KGExtractor: KGExtracting {
       do {
         retriedRaw = try await callLLM(system: system, user: user, maxTokens: Self.defaultMaxTokens * 2)
       } catch {
-        return KGExtraction(nodes: [], edges: [], outcome: .failed(reason: .llmError))
+        logError("KGExtractor: LLM call failed (truncation retry)", error: error)
+        return KGExtraction(
+          nodes: [], edges: [],
+          outcome: .failed(reason: .llmError),
+          llmErrorDetail: error.localizedDescription
+        )
       }
       let retriedParse = parseAndValidate(raw: retriedRaw, baseOutcome: .truncatedRetried)
       switch retriedParse {

--- a/Desktop/Sources/AI/KGExtractorPrompt.swift
+++ b/Desktop/Sources/AI/KGExtractorPrompt.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Builds the system + user messages for the KG extractor.
+///
+/// The prompt locks the model into a strict JSON envelope:
+///   {"nodes":[{"id","label","type","aliases":[]}],
+///    "edges":[{"source","target","label"}]}
+///
+/// No prose, no markdown, no preamble. The 5 valid `type` values are
+/// enumerated literally. `id` is a kebab-case slug. Empty input MUST be
+/// answered with an empty arrays envelope.
+enum KGExtractorPrompt {
+
+  static let systemPrompt: String = """
+    You extract a small knowledge graph from a single short memory note.
+
+    Output contract — respond with ONE JSON object and NOTHING else:
+    - No prose. No markdown. No code fences. No preamble. No trailing notes.
+    - Schema:
+      {
+        "nodes": [{"id": string, "label": string, "type": string, "aliases": [string]}],
+        "edges": [{"source": string, "target": string, "label": string}]
+      }
+    - "type" is EXACTLY one of: person, place, organization, thing, concept.
+    - "id" is a kebab-case slug, lowercase, ASCII, hyphens only — derived from the label.
+    - Every "edges[].source" and "edges[].target" MUST match a "nodes[].id" present in this same response.
+    - "aliases" is an array (may be empty) of alternate surface forms.
+    - If the input has no extractable entities, respond with: {"nodes":[],"edges":[]}
+
+    Examples:
+
+    INPUT: Stand-up with Priya at Acme on Monday — we discussed the Falcon launch and split owners.
+    OUTPUT: {"nodes":[{"id":"priya","label":"Priya","type":"person","aliases":[]},{"id":"acme","label":"Acme","type":"organization","aliases":[]},{"id":"falcon-launch","label":"Falcon launch","type":"thing","aliases":["Falcon"]},{"id":"stand-up","label":"Stand-up","type":"concept","aliases":["standup"]}],"edges":[{"source":"priya","target":"acme","label":"works at"},{"source":"stand-up","target":"falcon-launch","label":"discussed"}]}
+
+    INPUT: Refactored the auth module in infinite-recall to drop Firebase. Replaced FirebaseAuthService with LocalAuth.
+    OUTPUT: {"nodes":[{"id":"infinite-recall","label":"infinite-recall","type":"thing","aliases":[]},{"id":"auth-module","label":"auth module","type":"concept","aliases":[]},{"id":"firebase","label":"Firebase","type":"organization","aliases":["FirebaseAuthService"]},{"id":"local-auth","label":"LocalAuth","type":"thing","aliases":[]}],"edges":[{"source":"auth-module","target":"infinite-recall","label":"part of"},{"source":"local-auth","target":"firebase","label":"replaced"}]}
+
+    INPUT: Brunch with mom in Brooklyn — she's reading the new Murakami.
+    OUTPUT: {"nodes":[{"id":"mom","label":"mom","type":"person","aliases":[]},{"id":"brooklyn","label":"Brooklyn","type":"place","aliases":[]},{"id":"murakami","label":"Murakami","type":"person","aliases":[]}],"edges":[{"source":"mom","target":"brooklyn","label":"met in"},{"source":"mom","target":"murakami","label":"reading"}]}
+    """
+
+  /// Build the user message. `sourceApp` is included only when present —
+  /// empty/nil source apps are omitted to keep the model focused on the text.
+  static func userMessage(content: String, sourceApp: String?) -> String {
+    var lines: [String] = []
+    if let app = sourceApp, !app.trimmingCharacters(in: .whitespaces).isEmpty {
+      lines.append("Source app: \(app)")
+    }
+    lines.append("Memory:")
+    lines.append(content)
+    lines.append("")
+    lines.append("Respond with the JSON object only.")
+    return lines.joined(separator: "\n")
+  }
+}

--- a/Desktop/Sources/AI/VisionLLMClient.swift
+++ b/Desktop/Sources/AI/VisionLLMClient.swift
@@ -132,7 +132,7 @@ actor VisionLLMClient {
     }
 
     // Strip optional ```json fences before parsing.
-    let stripped = Self.stripJSONFences(raw)
+    let stripped = stripJSONFences(raw)
     guard let payload = stripped.data(using: .utf8) else {
       throw VisionLLMError.decodingFailed("non-utf8 reply")
     }
@@ -208,24 +208,6 @@ actor VisionLLMClient {
     }
     let b64 = png.base64EncodedString()
     return "data:image/png;base64,\(b64)"
-  }
-
-  /// Strip ```json ... ``` and ``` ... ``` fences if the model wrapped its
-  /// reply against instructions.
-  private static func stripJSONFences(_ s: String) -> String {
-    var t = s.trimmingCharacters(in: .whitespacesAndNewlines)
-    if t.hasPrefix("```") {
-      // Drop the leading fence marker (``` or ```json) up to the first newline.
-      if let nl = t.firstIndex(of: "\n") {
-        t = String(t[t.index(after: nl)...])
-      }
-      // Drop the trailing fence.
-      if t.hasSuffix("```") {
-        t = String(t.dropLast(3))
-      }
-      t = t.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-    return t
   }
 
   private static func checkHTTPStatus(_ response: URLResponse, data: Data) throws {

--- a/Desktop/Sources/Activity/WorkLabels.swift
+++ b/Desktop/Sources/Activity/WorkLabels.swift
@@ -27,6 +27,7 @@ public enum WorkLabels {
         case .summarize:         return summarizeLabel(work.payload)
         case .extractMemory:     return extractMemoryLabel(work.payload)
         case .extractActionItems: return extractActionItemsLabel(work.payload)
+        case .extractKG:         return extractKGLabel(work.payload)
         }
     }
 
@@ -86,6 +87,19 @@ public enum WorkLabels {
             return "Finding action items in #\(id)"
         }
         return "Finding action items"
+    }
+
+    /// Payload shape (KGBackfillService): { memory_id: Int64 }
+    private static func extractKGLabel(_ payload: Data) -> String {
+        if let dict = try? JSONSerialization.jsonObject(with: payload) as? [String: Any] {
+            if let id = dict["memory_id"] as? Int {
+                return "Extracting brain map entities from memory #\(id)"
+            }
+            if let n = dict["memory_id"] as? NSNumber {
+                return "Extracting brain map entities from memory #\(n.intValue)"
+            }
+        }
+        return "Extracting brain map entities"
     }
 
     // MARK: - Helpers

--- a/Desktop/Sources/FileIndexing/KnowledgeGraphStorage.swift
+++ b/Desktop/Sources/FileIndexing/KnowledgeGraphStorage.swift
@@ -177,13 +177,21 @@ actor KnowledgeGraphStorage {
 extension KnowledgeGraphStorage {
 
     /// Single atomic transaction: upserts nodes, upserts edges, writes
-    /// provenance rows for both. Idempotent on (memoryId, nodeId) and
+    /// provenance rows for both, and (optionally) writes the memory's
+    /// `kg_extraction_status`. Idempotent on (memoryId, nodeId) and
     /// (memoryId, edgeId). On shared nodeId across memories, aliases are
     /// merged and the first-writer label/type wins unless an incoming
     /// alias promotes a better canonical.
+    ///
+    /// Pass `terminalStatus` to atomically transition `memories.kg_extraction_status`
+    /// in the same transaction as the upsert. Without this, a crash between
+    /// `upsert` and a follow-up `setKGExtractionStatus` call would leave
+    /// provenance written but status NULL — the row would then be re-extracted
+    /// on next launch (idempotent on data, wasted LLM cost).
     func upsert(memoryId: Int64,
                 nodes: [ExtractedKGNode],
-                edges: [ExtractedKGEdge]) async throws -> KGUpsertResult {
+                edges: [ExtractedKGEdge],
+                terminalStatus: KGExtractionStatus? = nil) async throws -> KGUpsertResult {
         let db = try await ensureDB()
 
         // Validate inputs up front so a bad row aborts before we touch the
@@ -218,9 +226,32 @@ extension KnowledgeGraphStorage {
         var nodesInserted = 0
         var nodesMerged = 0
         var edgesInserted = 0
+        var aborted = false
 
         try await db.write { database in
             let now = Date()
+
+            // Guard race: deletion may have raced with this drain. The
+            // PowerWorkBridge handler pre-checks `memories.deleted` BEFORE
+            // calling `upsert`, but a concurrent `deleteMemory` can land
+            // between the pre-check and the write here. Re-check inside the
+            // same transaction so the cascade in `removeProvenance` doesn't
+            // miss orphans we'd otherwise write. The onboarding sentinel
+            // (-1) bypasses the check because no row exists for it.
+            if memoryId != ONBOARDING_SENTINEL {
+                let row = try Row.fetchOne(
+                    database,
+                    sql: "SELECT deleted FROM memories WHERE id = ?",
+                    arguments: [memoryId]
+                )
+                let exists = row != nil
+                let isDeleted: Bool = (row?["deleted"] as Bool?) ?? false
+                if !exists || isDeleted {
+                    log("KnowledgeGraphStorage: upsert aborted — memory \(memoryId) not found or deleted")
+                    aborted = true
+                    return
+                }
+            }
 
             for node in nodes {
                 let canonical = Self.canonicalize(node.id)
@@ -296,6 +327,21 @@ extension KnowledgeGraphStorage {
                     arguments: [memoryId, edgeId]
                 )
             }
+
+            // Final statement of the transaction: write the terminal status
+            // so a crash between provenance + status is structurally
+            // impossible. Skip the onboarding sentinel (no real memory row).
+            if let status = terminalStatus, memoryId != ONBOARDING_SENTINEL {
+                try database.execute(
+                    sql: "UPDATE memories SET kg_extraction_status = ?, updatedAt = ? WHERE id = ?",
+                    arguments: [status.rawValue, Date(), memoryId]
+                )
+            }
+        }
+
+        if aborted {
+            // Memory was deleted during the upsert — return zero counts.
+            return KGUpsertResult(nodesInserted: 0, nodesMerged: 0, edgesInserted: 0)
         }
 
         return KGUpsertResult(

--- a/Desktop/Sources/FileIndexing/KnowledgeGraphStorage.swift
+++ b/Desktop/Sources/FileIndexing/KnowledgeGraphStorage.swift
@@ -1,6 +1,34 @@
 import Foundation
 import GRDB
 
+/// Reserved memoryId for onboarding bulk writes (saveGraph). Excluded from
+/// per-memory provenance counts and UI denominators.
+let ONBOARDING_SENTINEL: Int64 = -1
+
+/// Candidate node DTO produced by the LLM extraction layer. `id` is a raw
+/// slug that this storage layer canonicalizes before persistence.
+struct ExtractedKGNode: Sendable, Equatable {
+    let id: String
+    let label: String
+    let type: KnowledgeGraphNodeType
+    let aliases: [String]
+}
+
+/// Candidate edge DTO produced by the LLM extraction layer. `sourceId` and
+/// `targetId` reference raw node slugs that this layer canonicalizes.
+struct ExtractedKGEdge: Sendable, Equatable {
+    let sourceId: String
+    let targetId: String
+    let label: String
+}
+
+/// Result of an `upsert` call.
+struct KGUpsertResult: Sendable {
+    let nodesInserted: Int
+    let nodesMerged: Int
+    let edgesInserted: Int
+}
+
 /// Actor for local knowledge graph CRUD operations
 actor KnowledgeGraphStorage {
     static let shared = KnowledgeGraphStorage()
@@ -46,21 +74,39 @@ actor KnowledgeGraphStorage {
         }
     }
 
-    /// Save nodes and edges (clears existing data first)
+    /// Save nodes and edges (clears existing data first). Onboarding bulk
+    /// write — also writes provenance rows under `ONBOARDING_SENTINEL` so
+    /// these rows survive the cascade behavior of `removeProvenance`.
     func saveGraph(nodes: [LocalKGNodeRecord], edges: [LocalKGEdgeRecord]) async throws {
         let db = try await ensureDB()
 
         try await db.write { database in
+            try database.execute(sql: "DELETE FROM local_kg_edge_sources")
+            try database.execute(sql: "DELETE FROM local_kg_node_sources")
             try database.execute(sql: "DELETE FROM local_kg_edges")
             try database.execute(sql: "DELETE FROM local_kg_nodes")
 
             for node in nodes {
                 let record = node
                 try record.insert(database)
+                try database.execute(
+                    sql: """
+                        INSERT OR IGNORE INTO local_kg_node_sources (memoryId, nodeId)
+                        VALUES (?, ?)
+                        """,
+                    arguments: [ONBOARDING_SENTINEL, node.nodeId]
+                )
             }
             for edge in edges {
                 let record = edge
                 try record.insert(database)
+                try database.execute(
+                    sql: """
+                        INSERT OR IGNORE INTO local_kg_edge_sources (memoryId, edgeId)
+                        VALUES (?, ?)
+                        """,
+                    arguments: [ONBOARDING_SENTINEL, edge.edgeId]
+                )
             }
         }
 
@@ -95,11 +141,13 @@ actor KnowledgeGraphStorage {
         log("KnowledgeGraphStorage: Merged \(nodes.count) nodes, \(edges.count) edges")
     }
 
-    /// Delete all local knowledge graph data
+    /// Delete all local knowledge graph data, including provenance tables.
     func clearAll() async {
         guard let db = try? await ensureDB() else { return }
         do {
             try await db.write { database in
+                try database.execute(sql: "DELETE FROM local_kg_edge_sources")
+                try database.execute(sql: "DELETE FROM local_kg_node_sources")
                 try database.execute(sql: "DELETE FROM local_kg_edges")
                 try database.execute(sql: "DELETE FROM local_kg_nodes")
             }
@@ -121,5 +169,276 @@ actor KnowledgeGraphStorage {
         } catch {
             return true
         }
+    }
+}
+
+// MARK: - Provenance + atomic incremental upsert
+
+extension KnowledgeGraphStorage {
+
+    /// Single atomic transaction: upserts nodes, upserts edges, writes
+    /// provenance rows for both. Idempotent on (memoryId, nodeId) and
+    /// (memoryId, edgeId). On shared nodeId across memories, aliases are
+    /// merged and the first-writer label/type wins unless an incoming
+    /// alias promotes a better canonical.
+    func upsert(memoryId: Int64,
+                nodes: [ExtractedKGNode],
+                edges: [ExtractedKGEdge]) async throws -> KGUpsertResult {
+        let db = try await ensureDB()
+
+        // Validate inputs up front so a bad row aborts before we touch the
+        // database. Atomicity inside `db.write` is then simply: any throw
+        // rolls back the whole thing.
+        for node in nodes {
+            let canonical = canonicalize(node.id)
+            if canonical.isEmpty {
+                throw NSError(
+                    domain: "KnowledgeGraphStorage", code: 2,
+                    userInfo: [NSLocalizedDescriptionKey: "Empty canonical node id from \(node.id)"]
+                )
+            }
+            if node.label.isEmpty {
+                throw NSError(
+                    domain: "KnowledgeGraphStorage", code: 2,
+                    userInfo: [NSLocalizedDescriptionKey: "Empty label for node \(node.id)"]
+                )
+            }
+        }
+        for edge in edges {
+            let src = canonicalize(edge.sourceId)
+            let dst = canonicalize(edge.targetId)
+            if src.isEmpty || dst.isEmpty || edge.label.isEmpty {
+                throw NSError(
+                    domain: "KnowledgeGraphStorage", code: 2,
+                    userInfo: [NSLocalizedDescriptionKey: "Invalid edge \(edge.sourceId) -> \(edge.targetId)"]
+                )
+            }
+        }
+
+        var nodesInserted = 0
+        var nodesMerged = 0
+        var edgesInserted = 0
+
+        try await db.write { database in
+            let now = Date()
+
+            for node in nodes {
+                let canonical = Self.canonicalize(node.id)
+                let existing = try LocalKGNodeRecord
+                    .filter(Column("nodeId") == canonical)
+                    .fetchOne(database)
+
+                if var existing = existing {
+                    // Merge aliases (case-insensitive dedup, preserve order:
+                    // existing first, then any new entries).
+                    let existingAliases = Self.decodeAliases(existing.aliasesJson)
+                    let merged = Self.mergeAliases(existing: existingAliases, incoming: node.aliases)
+                    if merged != existingAliases {
+                        existing.aliasesJson = Self.encodeAliases(merged)
+                        existing.updatedAt = now
+                        try existing.update(database)
+                    }
+                    nodesMerged += 1
+                } else {
+                    let record = LocalKGNodeRecord(
+                        id: nil,
+                        nodeId: canonical,
+                        label: node.label,
+                        nodeType: node.type.rawValue,
+                        aliasesJson: Self.encodeAliases(node.aliases),
+                        sourceFileIds: nil,
+                        createdAt: now,
+                        updatedAt: now
+                    )
+                    var inserting = record
+                    try inserting.insert(database)
+                    nodesInserted += 1
+                }
+
+                // Provenance row — idempotent on (memoryId, nodeId).
+                try database.execute(
+                    sql: """
+                        INSERT OR IGNORE INTO local_kg_node_sources (memoryId, nodeId)
+                        VALUES (?, ?)
+                        """,
+                    arguments: [memoryId, canonical]
+                )
+            }
+
+            for edge in edges {
+                let src = Self.canonicalize(edge.sourceId)
+                let dst = Self.canonicalize(edge.targetId)
+                let edgeId = Self.edgeId(source: src, label: edge.label, target: dst)
+
+                let existing = try LocalKGEdgeRecord
+                    .filter(Column("edgeId") == edgeId)
+                    .fetchOne(database)
+
+                if existing == nil {
+                    let record = LocalKGEdgeRecord(
+                        id: nil,
+                        edgeId: edgeId,
+                        sourceNodeId: src,
+                        targetNodeId: dst,
+                        label: edge.label,
+                        createdAt: now
+                    )
+                    var inserting = record
+                    try inserting.insert(database)
+                    edgesInserted += 1
+                }
+
+                try database.execute(
+                    sql: """
+                        INSERT OR IGNORE INTO local_kg_edge_sources (memoryId, edgeId)
+                        VALUES (?, ?)
+                        """,
+                    arguments: [memoryId, edgeId]
+                )
+            }
+        }
+
+        return KGUpsertResult(
+            nodesInserted: nodesInserted,
+            nodesMerged: nodesMerged,
+            edgesInserted: edgesInserted
+        )
+    }
+
+    /// Removes provenance rows for the given memory and cascades by deleting
+    /// any node/edge whose only remaining provenance was this memory.
+    func removeProvenance(forMemoryId memoryId: Int64) async throws {
+        let db = try await ensureDB()
+
+        try await db.write { database in
+            // Snapshot the affected node/edge ids for this memory.
+            let nodeIds = try String.fetchAll(
+                database,
+                sql: "SELECT nodeId FROM local_kg_node_sources WHERE memoryId = ?",
+                arguments: [memoryId]
+            )
+            let edgeIds = try String.fetchAll(
+                database,
+                sql: "SELECT edgeId FROM local_kg_edge_sources WHERE memoryId = ?",
+                arguments: [memoryId]
+            )
+
+            try database.execute(
+                sql: "DELETE FROM local_kg_edge_sources WHERE memoryId = ?",
+                arguments: [memoryId]
+            )
+            try database.execute(
+                sql: "DELETE FROM local_kg_node_sources WHERE memoryId = ?",
+                arguments: [memoryId]
+            )
+
+            // Cascade: delete edges with no remaining provenance.
+            for edgeId in edgeIds {
+                let remaining = try Int.fetchOne(
+                    database,
+                    sql: "SELECT COUNT(*) FROM local_kg_edge_sources WHERE edgeId = ?",
+                    arguments: [edgeId]
+                ) ?? 0
+                if remaining == 0 {
+                    try database.execute(
+                        sql: "DELETE FROM local_kg_edges WHERE edgeId = ?",
+                        arguments: [edgeId]
+                    )
+                }
+            }
+
+            // Cascade: delete nodes with no remaining provenance. Note this
+            // may leave dangling edges if other memories still reference the
+            // same nodes via different edges; that's fine — edges have their
+            // own provenance lifecycle.
+            for nodeId in nodeIds {
+                let remaining = try Int.fetchOne(
+                    database,
+                    sql: "SELECT COUNT(*) FROM local_kg_node_sources WHERE nodeId = ?",
+                    arguments: [nodeId]
+                ) ?? 0
+                if remaining == 0 {
+                    try database.execute(
+                        sql: "DELETE FROM local_kg_nodes WHERE nodeId = ?",
+                        arguments: [nodeId]
+                    )
+                }
+            }
+        }
+    }
+
+    /// Count of distinct memoryIds in `local_kg_node_sources`, excluding the
+    /// onboarding sentinel. Used by the UI as a progress denominator.
+    func memoriesWithExtractedKGCount() async throws -> Int {
+        let db = try await ensureDB()
+        return try await db.read { database in
+            try Int.fetchOne(
+                database,
+                sql: """
+                    SELECT COUNT(DISTINCT memoryId)
+                    FROM local_kg_node_sources
+                    WHERE memoryId != ?
+                    """,
+                arguments: [ONBOARDING_SENTINEL]
+            ) ?? 0
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func canonicalize(_ raw: String) -> String {
+        Self.canonicalize(raw)
+    }
+
+    fileprivate static func canonicalize(_ raw: String) -> String {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        var out = ""
+        out.reserveCapacity(trimmed.count)
+        var lastWasSep = false
+        for scalar in trimmed.unicodeScalars {
+            if CharacterSet.alphanumerics.contains(scalar) {
+                out.unicodeScalars.append(scalar)
+                lastWasSep = false
+            } else if !out.isEmpty && !lastWasSep {
+                out.append("-")
+                lastWasSep = true
+            }
+        }
+        if out.hasSuffix("-") { out.removeLast() }
+        return out
+    }
+
+    fileprivate static func edgeId(source: String, label: String, target: String) -> String {
+        let labelCanon = canonicalize(label)
+        return "\(source)::\(labelCanon)::\(target)"
+    }
+
+    fileprivate static func decodeAliases(_ json: String?) -> [String] {
+        guard let json = json,
+              let data = json.data(using: .utf8),
+              let parsed = try? JSONDecoder().decode([String].self, from: data)
+        else { return [] }
+        return parsed
+    }
+
+    fileprivate static func encodeAliases(_ aliases: [String]) -> String? {
+        guard !aliases.isEmpty else { return nil }
+        guard let data = try? JSONEncoder().encode(aliases),
+              let json = String(data: data, encoding: .utf8)
+        else { return nil }
+        return json
+    }
+
+    fileprivate static func mergeAliases(existing: [String], incoming: [String]) -> [String] {
+        var out: [String] = existing
+        var seen = Set(existing.map { $0.lowercased() })
+        for alias in incoming {
+            let key = alias.lowercased()
+            if !seen.contains(key) {
+                out.append(alias)
+                seen.insert(key)
+            }
+        }
+        return out
     }
 }

--- a/Desktop/Sources/MainWindow/Pages/MemoryGraph/BuildingProgressPill.swift
+++ b/Desktop/Sources/MainWindow/Pages/MemoryGraph/BuildingProgressPill.swift
@@ -67,6 +67,16 @@ struct BuildingProgressPill: View {
       if total == 0 {
         return "Brain map ready"
       }
+      // Cluster E3: queue is idle but we never finished processing every
+      // memory. The dead-letter handler marks unrecoverable rows as
+      // `kg_extraction_status = 'failed'`, but those still bump
+      // `processedMemories`. A genuine `processed < total` here means rows
+      // got dropped (cap-drop) or were lost before the handler ran. Surface
+      // it instead of falsely showing "up to date".
+      if processed < total {
+        let missing = total - processed
+        return "Stuck — \(missing) memor\(missing == 1 ? "y" : "ies") failed to extract"
+      }
       return "Brain map up to date — \(nodes) entities"
     case .building:
       if let eta = progress.etaSeconds, eta > 0 {

--- a/Desktop/Sources/MainWindow/Pages/MemoryGraph/BuildingProgressPill.swift
+++ b/Desktop/Sources/MainWindow/Pages/MemoryGraph/BuildingProgressPill.swift
@@ -1,0 +1,95 @@
+import SwiftUI
+
+/// Compact progress pill rendered in the Brain Map header (and as the empty-state
+/// indicator). Reads a `KGBuildProgress` snapshot and renders a single line of
+/// state-aware copy plus a small spinner when work is in flight.
+struct BuildingProgressPill: View {
+  let progress: KGBuildProgress
+  /// Smaller variant for inline cards (Memories tab).
+  var compact: Bool = false
+
+  var body: some View {
+    HStack(spacing: 8) {
+      if showsSpinner {
+        ProgressView()
+          .scaleEffect(compact ? 0.5 : 0.55)
+          .tint(.white.opacity(0.7))
+          .frame(width: compact ? 12 : 14, height: compact ? 12 : 14)
+      } else {
+        Image(systemName: stateIcon)
+          .scaledFont(size: compact ? 10 : 11, weight: .medium)
+          .foregroundColor(.white.opacity(0.6))
+      }
+
+      Text(label)
+        .scaledFont(size: compact ? 11 : 12, weight: .medium)
+        .foregroundColor(.white.opacity(0.8))
+        .lineLimit(1)
+    }
+    .padding(.horizontal, compact ? 10 : 12)
+    .padding(.vertical, compact ? 5 : 6)
+    .background(
+      Capsule(style: .continuous)
+        .fill(Color.white.opacity(0.07))
+    )
+    .overlay(
+      Capsule(style: .continuous)
+        .stroke(Color.white.opacity(0.10), lineWidth: 0.5)
+    )
+  }
+
+  private var showsSpinner: Bool {
+    switch progress.state {
+    case .building: return true
+    case .pausedThermal, .pausedBattery, .pausedNotIdle, .modelNotReady, .idleNoWork:
+      return false
+    }
+  }
+
+  private var stateIcon: String {
+    switch progress.state {
+    case .idleNoWork: return "checkmark.circle.fill"
+    case .building: return "brain"
+    case .pausedThermal: return "thermometer.high"
+    case .pausedBattery: return "battery.25"
+    case .pausedNotIdle: return "moon.zzz"
+    case .modelNotReady: return "hourglass"
+    }
+  }
+
+  private var label: String {
+    let processed = progress.processedMemories
+    let total = progress.totalMemories
+    let nodes = progress.totalNodes
+
+    switch progress.state {
+    case .idleNoWork:
+      if total == 0 {
+        return "Brain map ready"
+      }
+      return "Brain map up to date — \(nodes) entities"
+    case .building:
+      if let eta = progress.etaSeconds, eta > 0 {
+        return "Building — \(processed) / \(total) - \(formatETA(eta))"
+      }
+      return "Building — \(processed) / \(total)"
+    case .pausedThermal:
+      return "Paused (cooling) — \(processed) / \(total)"
+    case .pausedBattery:
+      return "Paused (on battery) — \(processed) / \(total)"
+    case .pausedNotIdle:
+      return "Resumes when Mac is idle — \(processed) / \(total)"
+    case .modelNotReady:
+      return "Waiting for model — \(processed) / \(total)"
+    }
+  }
+
+  private func formatETA(_ seconds: Int) -> String {
+    if seconds < 60 { return "\(seconds)s left" }
+    let m = seconds / 60
+    if m < 60 { return "\(m) min left" }
+    let h = m / 60
+    let rem = m % 60
+    return rem == 0 ? "\(h)h left" : "\(h)h \(rem)m left"
+  }
+}

--- a/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryGraphPage.swift
+++ b/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryGraphPage.swift
@@ -85,7 +85,6 @@ struct BrainMapEmptyStateView: View {
   var body: some View {
     let mode = BrainMapEmptyStateClassifier.mode(
       state: progress.state,
-      totalNodes: progress.totalNodes,
       totalMemories: progress.totalMemories,
       processedMemories: progress.processedMemories
     )
@@ -218,7 +217,6 @@ struct MemoryGraphInlineCard: View {
   private func inlineEmptyCopy(progress: KGBuildProgress) -> String {
     let mode = BrainMapEmptyStateClassifier.mode(
       state: progress.state,
-      totalNodes: progress.totalNodes,
       totalMemories: progress.totalMemories,
       processedMemories: progress.processedMemories
     )

--- a/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryGraphPage.swift
+++ b/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryGraphPage.swift
@@ -32,6 +32,12 @@ struct MemoryGraphPage: View {
 
           Spacer()
 
+          if let progress = viewModel.buildProgress {
+            BuildingProgressPill(progress: progress)
+          }
+
+          Spacer()
+
           if viewModel.isRebuilding {
             ProgressView()
               .scaleEffect(0.6)
@@ -62,10 +68,69 @@ struct MemoryGraphPage: View {
         ProgressView()
           .scaleEffect(1.2)
           .tint(.white.opacity(0.4))
+      } else if viewModel.isEmpty, let progress = viewModel.buildProgress {
+        BrainMapEmptyStateView(progress: progress)
       }
     }
     .task {
       await viewModel.prepareGraph()
+    }
+  }
+}
+
+/// Centered empty-state copy that adapts to the current build state.
+struct BrainMapEmptyStateView: View {
+  let progress: KGBuildProgress
+
+  var body: some View {
+    let mode = BrainMapEmptyStateClassifier.mode(
+      state: progress.state,
+      totalNodes: progress.totalNodes,
+      totalMemories: progress.totalMemories,
+      processedMemories: progress.processedMemories
+    )
+
+    VStack(spacing: 14) {
+      Image(systemName: "brain")
+        .scaledFont(size: 36)
+        .foregroundColor(.white.opacity(0.25))
+
+      Text(headline(for: mode))
+        .scaledFont(size: 15, weight: .medium)
+        .foregroundColor(.white.opacity(0.7))
+        .multilineTextAlignment(.center)
+
+      Text(subline(for: mode))
+        .scaledFont(size: 12.5)
+        .foregroundColor(.white.opacity(0.45))
+        .multilineTextAlignment(.center)
+        .frame(maxWidth: 360)
+
+      BuildingProgressPill(progress: progress)
+        .padding(.top, 4)
+    }
+    .padding(32)
+  }
+
+  private func headline(for mode: EmptyStateMode) -> String {
+    switch mode {
+    case .backfillNotStarted:
+      return "Building your brain map"
+    case .backfillRunningNoNodesYet:
+      return "Building your brain map"
+    case .backfillCompleteEmpty:
+      return "No entities yet"
+    }
+  }
+
+  private func subline(for mode: EmptyStateMode) -> String {
+    switch mode {
+    case .backfillNotStarted:
+      return "This runs while your Mac is idle. Once your first memory is processed, nodes will appear here."
+    case .backfillRunningNoNodesYet:
+      return "Processing your memories now. Nodes will appear as soon as the first one yields entities."
+    case .backfillCompleteEmpty:
+      return "Your memories didn't contain any entities the extractor could pull out yet. New memories will be picked up automatically."
     }
   }
 }
@@ -112,6 +177,18 @@ struct MemoryGraphInlineCard: View {
           ProgressView()
             .scaleEffect(1.1)
             .tint(.white.opacity(0.45))
+        } else if viewModel.isEmpty, let progress = viewModel.buildProgress {
+          VStack(spacing: 10) {
+            Image(systemName: "brain")
+              .scaledFont(size: 18)
+              .foregroundColor(OmiColors.textTertiary)
+            Text(inlineEmptyCopy(progress: progress))
+              .scaledFont(size: 12.5)
+              .foregroundColor(OmiColors.textSecondary)
+              .multilineTextAlignment(.center)
+            BuildingProgressPill(progress: progress, compact: true)
+          }
+          .padding(18)
         } else if viewModel.isEmpty {
           VStack(spacing: 8) {
             Image(systemName: "brain")
@@ -135,6 +212,23 @@ struct MemoryGraphInlineCard: View {
     )
     .task {
       await viewModel.prepareGraph()
+    }
+  }
+
+  private func inlineEmptyCopy(progress: KGBuildProgress) -> String {
+    let mode = BrainMapEmptyStateClassifier.mode(
+      state: progress.state,
+      totalNodes: progress.totalNodes,
+      totalMemories: progress.totalMemories,
+      processedMemories: progress.processedMemories
+    )
+    switch mode {
+    case .backfillNotStarted:
+      return "Brain map runs while your Mac is idle."
+    case .backfillRunningNoNodesYet:
+      return "Building your brain map…"
+    case .backfillCompleteEmpty:
+      return "No entities found yet. New memories will be picked up automatically."
     }
   }
 }
@@ -196,6 +290,7 @@ class MemoryGraphViewModel: ObservableObject {
   @Published var isRebuilding = false
   @Published var isEmpty = true
   @Published var selectedNodeId: String?
+  @Published var buildProgress: KGBuildProgress?
 
   let scene = SCNScene()
   let cameraNode = SCNNode()
@@ -204,10 +299,39 @@ class MemoryGraphViewModel: ObservableObject {
   private var nodeSceneNodes: [String: SCNNode] = [:]
   private var edgeSceneNodes: [String: SCNNode] = [:]
   private var isAnimating = true
+  private var progressTask: Task<Void, Never>?
 
   init() {
     setupCamera()
     setupLighting()
+    subscribeToBuildProgress()
+  }
+
+  deinit {
+    progressTask?.cancel()
+  }
+
+  private func subscribeToBuildProgress() {
+    progressTask?.cancel()
+    progressTask = Task { [weak self] in
+      let stream = await KGProgressPublisher.shared.stream
+      for await snapshot in stream {
+        guard let self = self else { return }
+        await MainActor.run {
+          self.buildProgress = snapshot
+          // Auto-refresh the rendered scene when nodes appear or grow while
+          // the page is open. Only do this if we aren't already mid-rebuild.
+          if !self.isRebuilding && !self.isLoading,
+             snapshot.totalNodes > 0,
+             self.isEmpty
+          {
+            Task { await self.loadGraph() }
+          }
+        }
+      }
+    }
+    // Kick a fresh tick so the VM gets an immediate snapshot.
+    Task { await KGProgressPublisher.shared.tick() }
   }
 
   private func setupCamera() {

--- a/Desktop/Sources/OmiApp.swift
+++ b/Desktop/Sources/OmiApp.swift
@@ -385,6 +385,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     // on battery and drains on AC.
     PowerWorkBridge.shared.start()
 
+    // One-time KG backfill: enqueues an .extractKG job for every existing
+    // memory that hasn't been processed yet. Idempotent via migration_status.
+    Task {
+      await KGBackfillService.shared.runIfNeeded()
+    }
+
     // === activity:C1 ===
     // CapturePauseGate must run for the lifetime of the app: capture
     // services consult it on every start/mid-flight, regardless of whether

--- a/Desktop/Sources/Power/BatteryAwareScheduler.swift
+++ b/Desktop/Sources/Power/BatteryAwareScheduler.swift
@@ -20,6 +20,7 @@ public struct PendingWork: Identifiable, Equatable, Sendable {
     case extractMemory
     case extractActionItems
     case summarize
+    case extractKG
   }
 
   public let id: UUID
@@ -459,17 +460,19 @@ public final class BatteryAwareScheduler: ObservableObject {
       // rate-limit. The previous swallowing made S1's silent 401 loop
       // invisible; surface failures via ActivityReportLogger so the next
       // breakage is observable in `/private/tmp/omi-dev.log`.
-      Task {
-        do {
-          try await APIClient.shared.reportInFlight(
-            kind: Self.toWireWorkKind(work.kind),
-            inFlight: inflightEntry
-          )
-          InternalPostFailureTracker.shared.reportSuccess(.inflight)
-        } catch {
-          ActivityReportLogger.shared.log(
-            error: error, context: "reportInFlight(start:\(work.kind.rawValue))")
-          InternalPostFailureTracker.shared.reportFailure(.inflight, error: error)
+      if let wireKind = Self.toWireWorkKind(work.kind) {
+        Task {
+          do {
+            try await APIClient.shared.reportInFlight(
+              kind: wireKind,
+              inFlight: inflightEntry
+            )
+            InternalPostFailureTracker.shared.reportSuccess(.inflight)
+          } catch {
+            ActivityReportLogger.shared.log(
+              error: error, context: "reportInFlight(start:\(work.kind.rawValue))")
+            InternalPostFailureTracker.shared.reportFailure(.inflight, error: error)
+          }
         }
       }
       // === /activity:G ===
@@ -482,17 +485,19 @@ public final class BatteryAwareScheduler: ObservableObject {
         }
         // === activity:G ===
         self.inFlight[work.kind] = nil
-        Task {
-          do {
-            try await APIClient.shared.reportInFlight(
-              kind: Self.toWireWorkKind(work.kind),
-              inFlight: nil
-            )
-            InternalPostFailureTracker.shared.reportSuccess(.inflight)
-          } catch {
-            ActivityReportLogger.shared.log(
-              error: error, context: "reportInFlight(done:\(work.kind.rawValue))")
-            InternalPostFailureTracker.shared.reportFailure(.inflight, error: error)
+        if let wireKind = Self.toWireWorkKind(work.kind) {
+          Task {
+            do {
+              try await APIClient.shared.reportInFlight(
+                kind: wireKind,
+                inFlight: nil
+              )
+              InternalPostFailureTracker.shared.reportSuccess(.inflight)
+            } catch {
+              ActivityReportLogger.shared.log(
+                error: error, context: "reportInFlight(done:\(work.kind.rawValue))")
+              InternalPostFailureTracker.shared.reportFailure(.inflight, error: error)
+            }
           }
         }
         // === /activity:G ===
@@ -500,17 +505,19 @@ public final class BatteryAwareScheduler: ObservableObject {
         try? await PendingWorkStorage.shared.fail(storageId: storageId, error: error)
         // === activity:G ===
         self.inFlight[work.kind] = nil
-        Task {
-          do {
-            try await APIClient.shared.reportInFlight(
-              kind: Self.toWireWorkKind(work.kind),
-              inFlight: nil
-            )
-            InternalPostFailureTracker.shared.reportSuccess(.inflight)
-          } catch {
-            ActivityReportLogger.shared.log(
-              error: error, context: "reportInFlight(fail:\(work.kind.rawValue))")
-            InternalPostFailureTracker.shared.reportFailure(.inflight, error: error)
+        if let wireKind = Self.toWireWorkKind(work.kind) {
+          Task {
+            do {
+              try await APIClient.shared.reportInFlight(
+                kind: wireKind,
+                inFlight: nil
+              )
+              InternalPostFailureTracker.shared.reportSuccess(.inflight)
+            } catch {
+              ActivityReportLogger.shared.log(
+                error: error, context: "reportInFlight(fail:\(work.kind.rawValue))")
+              InternalPostFailureTracker.shared.reportFailure(.inflight, error: error)
+            }
           }
         }
         // === /activity:G ===
@@ -527,9 +534,11 @@ public final class BatteryAwareScheduler: ObservableObject {
     // that prevents autonomous drains from pinning the model in memory.
     if drainedAnyAutonomous {
       let depth = try? await PendingWorkStorage.shared.depthSummary()
-      let key = PendingWork.Kind.summarize.rawValue
-      let summarizeRemaining = (depth?.queued[key] ?? 0) + (depth?.failed[key] ?? 0)
-      if summarizeRemaining == 0 {
+      let summarizeKey = PendingWork.Kind.summarize.rawValue
+      let extractKGKey = PendingWork.Kind.extractKG.rawValue
+      let summarizeRemaining = (depth?.queued[summarizeKey] ?? 0) + (depth?.failed[summarizeKey] ?? 0)
+      let extractKGRemaining = (depth?.queued[extractKGKey] ?? 0) + (depth?.failed[extractKGKey] ?? 0)
+      if summarizeRemaining == 0 && extractKGRemaining == 0 {
         await IdleAIController.shared.releaseAfterAutonomousWorkIfAppropriate()
       }
     }
@@ -539,7 +548,7 @@ public final class BatteryAwareScheduler: ObservableObject {
   /// Currently: `.summarize`. Future autonomous-LLM kinds should be added here.
   fileprivate static func requiresAutonomousReadiness(_ kind: PendingWork.Kind) -> Bool {
     switch kind {
-    case .summarize:
+    case .summarize, .extractKG:
       return true
     case .transcribe, .ocr, .extractMemory, .extractActionItems:
       return false
@@ -552,13 +561,14 @@ public final class BatteryAwareScheduler: ObservableObject {
   /// the conversion happens here at the boundary instead of being
   /// implicit via `rawValue` (which would produce `"extractMemory"`
   /// instead of the snake_case `"extract_memory"` the daemon expects).
-  fileprivate static func toWireWorkKind(_ kind: PendingWork.Kind) -> WorkKind {
+  fileprivate static func toWireWorkKind(_ kind: PendingWork.Kind) -> WorkKind? {
     switch kind {
     case .transcribe: return .transcribe
     case .ocr: return .ocr
     case .summarize: return .summarize
     case .extractMemory: return .extractMemory
     case .extractActionItems: return .extractActionItems
+    case .extractKG: return nil  // not represented in the daemon's WorkKind wire enum
     }
   }
 

--- a/Desktop/Sources/PowerWorkBridge.swift
+++ b/Desktop/Sources/PowerWorkBridge.swift
@@ -25,6 +25,11 @@ final class PowerWorkBridge {
     static let shared = PowerWorkBridge()
 
     private var started: Bool = false
+
+    /// Single shared extractor instance used by the `.extractKG` handler.
+    /// Constructed lazily so the LLM bridge isn't touched at app launch.
+    fileprivate static let kgExtractor: KGExtractor = KGExtractor()
+
     private init() {}
 
     /// Idempotent. Call once at app launch.
@@ -57,6 +62,14 @@ final class PowerWorkBridge {
         // model after the queue drains.
         BatteryAwareScheduler.shared.registerHandler(for: .summarize) { work in
             try await PowerWorkBridge.handleSummarize(work)
+        }
+
+        // .extractKG — autonomous brain-map extraction. Decodes a
+        // `{"memory_id": Int64}` payload, runs `KGExtractor`, and either
+        // upserts nodes/edges via `KnowledgeGraphStorage.upsert(...)` or
+        // marks the memory's `kg_extraction_status` as empty/failed.
+        BatteryAwareScheduler.shared.registerHandler(for: .extractKG) { work in
+            try await PowerWorkBridge.handleExtractKG(work)
         }
 
         // Start the periodic sweeper that reclaims expired leases and GCs old rows.
@@ -377,6 +390,104 @@ final class PowerWorkBridge {
         // Success path — let the conversations list refresh.
         await notify(sessionId)
         log("PowerWorkBridge: .summarize — session \(sessionId) done")
+    }
+
+    // MARK: - Extract KG handler
+
+    /// Decode an `.extractKG` payload (`{"memory_id": Int64}`), load the
+    /// memory, run `KGExtractor`, and persist the outcome.
+    ///
+    /// Outcome routing:
+    /// - `.parsed | .recovered | .truncatedRetried` with rows → upsert via
+    ///   `KnowledgeGraphStorage.upsert(...)` and mark `kg_extraction_status =
+    ///   'succeeded'`.
+    /// - `.empty(*)` → mark `kg_extraction_status = 'empty'`, no rows.
+    /// - `.failed(*)` → mark `kg_extraction_status = 'failed'` and rethrow so
+    ///   the scheduler applies retry/backoff (and ultimately dead-letters).
+    /// - Memory deleted mid-drain (`getMemory` returns nil) → ack and return
+    ///   without an error log; same defensive pattern as the OCR handler at
+    ///   the top of this file.
+    fileprivate static func handleExtractKG(_ work: PendingWork) async throws {
+        struct Payload: Decodable { let memory_id: Int64 }
+
+        let memoryId: Int64
+        do {
+            memoryId = try JSONDecoder().decode(Payload.self, from: work.payload).memory_id
+        } catch {
+            logError("PowerWorkBridge: .extractKG payload undecodable, dropping", error: error)
+            return
+        }
+
+        let record: MemoryRecord?
+        do {
+            record = try await MemoryStorage.shared.getMemory(id: memoryId)
+        } catch {
+            logError("PowerWorkBridge: .extractKG — DB read failed for memory \(memoryId)", error: error)
+            throw error
+        }
+
+        guard let memory = record, memory.deleted == false, let realId = memory.id else {
+            // Memory was deleted (or soft-deleted) between enqueue and drain.
+            // Treat as a benign no-op: ack the row, don't log as error.
+            log("PowerWorkBridge: .extractKG — memory \(memoryId) no longer exists or is deleted, skipping")
+            return
+        }
+
+        let drainStart = Date()
+        let extraction: KGExtraction
+        do {
+            extraction = try await Self.kgExtractor.extract(
+                memoryId: realId,
+                content: memory.content,
+                sourceApp: memory.sourceApp
+            )
+        } catch {
+            // Extractor itself threw (LLM unreachable, etc.). Mark failed and
+            // rethrow so PendingWork retry/backoff takes over.
+            try? await MemoryStorage.shared.setKGExtractionStatus(id: realId, status: "failed")
+            await KGProgressPublisher.shared.tick()
+            throw error
+        }
+
+        switch extraction.outcome {
+        case .parsed, .recovered, .truncatedRetried:
+            if extraction.nodes.isEmpty && extraction.edges.isEmpty {
+                // Defensive: shouldn't happen because the extractor
+                // collapses an empty success into `.empty(...)`, but keep the
+                // status writeable just in case.
+                try? await MemoryStorage.shared.setKGExtractionStatus(id: realId, status: "empty")
+            } else {
+                do {
+                    _ = try await KnowledgeGraphStorage.shared.upsert(
+                        memoryId: realId,
+                        nodes: extraction.nodes,
+                        edges: extraction.edges
+                    )
+                    try await MemoryStorage.shared.setKGExtractionStatus(id: realId, status: "succeeded")
+                } catch {
+                    // Upsert failure is retryable (DB transient) — mark failed
+                    // and rethrow.
+                    try? await MemoryStorage.shared.setKGExtractionStatus(id: realId, status: "failed")
+                    await KGProgressPublisher.shared.tick()
+                    throw error
+                }
+            }
+        case .empty:
+            try? await MemoryStorage.shared.setKGExtractionStatus(id: realId, status: "empty")
+        case .failed(let reason):
+            try? await MemoryStorage.shared.setKGExtractionStatus(id: realId, status: "failed")
+            await KGProgressPublisher.shared.tick()
+            throw NSError(
+                domain: "PowerWorkBridge", code: 4,
+                userInfo: [NSLocalizedDescriptionKey: "extractKG failed: \(reason.rawValue)"]
+            )
+        }
+
+        let drainDuration = Date().timeIntervalSince(drainStart)
+        await KGProgressPublisher.shared.recordDrainSample(seconds: drainDuration)
+        await KGProgressPublisher.shared.tick()
+
+        log("PowerWorkBridge: .extractKG — memory \(realId) outcome=\(extraction.outcome) in \(String(format: "%.2f", drainDuration))s")
     }
 }
 

--- a/Desktop/Sources/PowerWorkBridge.swift
+++ b/Desktop/Sources/PowerWorkBridge.swift
@@ -116,14 +116,24 @@ final class PowerWorkBridge {
     /// notification.
     @Sendable
     fileprivate static func handleDeadLetter(workType: String, payload: Data) async {
-        guard workType == PendingWork.Kind.summarize.rawValue else { return }
+        switch workType {
+        case PendingWork.Kind.summarize.rawValue:
+            await handleDeadLetterSummarize(payload: payload)
+        case PendingWork.Kind.extractKG.rawValue:
+            await handleDeadLetterExtractKG(payload: payload)
+        default:
+            return
+        }
+    }
 
+    @Sendable
+    fileprivate static func handleDeadLetterSummarize(payload: Data) async {
         struct Payload: Decodable { let session_id: Int64 }
         let sessionId: Int64
         do {
             sessionId = try JSONDecoder().decode(Payload.self, from: payload).session_id
         } catch {
-            logError("PowerWorkBridge: dead-letter payload undecodable for \(workType)", error: error)
+            logError("PowerWorkBridge: dead-letter payload undecodable for summarize", error: error)
             return
         }
 
@@ -141,6 +151,31 @@ final class PowerWorkBridge {
                 userInfo: ["session_id": sessionId]
             )
         }
+    }
+
+    /// Cluster E1: when an `.extractKG` row exhausts its retry budget,
+    /// transition the memory's `kg_extraction_status` to `.failed` so the
+    /// progress publisher counts it correctly (otherwise it'd remain NULL
+    /// and forever inflate the "remaining memories" denominator).
+    @Sendable
+    fileprivate static func handleDeadLetterExtractKG(payload: Data) async {
+        struct Payload: Decodable { let memory_id: Int64 }
+        let memoryId: Int64
+        do {
+            memoryId = try JSONDecoder().decode(Payload.self, from: payload).memory_id
+        } catch {
+            // Payload was undecodable when we tried to extract too; nothing
+            // we can do at dead-letter time. Logged in the handler already.
+            logError("PowerWorkBridge: dead-letter — extractKG payload undecodable", error: error)
+            return
+        }
+        do {
+            try await MemoryStorage.shared.setKGExtractionStatus(id: memoryId, status: .failed)
+            log("PowerWorkBridge: dead-letter — marked memory \(memoryId) kg_extraction_status='failed'")
+        } catch {
+            logError("PowerWorkBridge: dead-letter — failed to write kg_extraction_status for memory \(memoryId)", error: error)
+        }
+        await KGProgressPublisher.shared.tick()
     }
 
     // MARK: - Transcribe handler
@@ -414,8 +449,17 @@ final class PowerWorkBridge {
         do {
             memoryId = try JSONDecoder().decode(Payload.self, from: work.payload).memory_id
         } catch {
-            logError("PowerWorkBridge: .extractKG payload undecodable, dropping", error: error)
-            return
+            // Cluster G: an undecodable payload previously logged + returned
+            // success → row ack'd → memory's `kg_extraction_status` stays
+            // NULL forever. Throw instead so the row enters retry/backoff
+            // and eventually dead-letters. We can't surface a memoryId
+            // because the payload didn't yield one; the dead-letter callback
+            // skips when the workType doesn't match a known kind.
+            logError(
+                "PowerWorkBridge: .extractKG payload undecodable; throwing to dead-letter",
+                error: error
+            )
+            throw error
         }
 
         let record: MemoryRecord?
@@ -426,10 +470,18 @@ final class PowerWorkBridge {
             throw error
         }
 
-        guard let memory = record, memory.deleted == false, let realId = memory.id else {
-            // Memory was deleted (or soft-deleted) between enqueue and drain.
-            // Treat as a benign no-op: ack the row, don't log as error.
-            log("PowerWorkBridge: .extractKG — memory \(memoryId) no longer exists or is deleted, skipping")
+        // Cluster J: distinguish "memory not found" from "memory soft-deleted"
+        // in the log so production telemetry can tell DB-vs-soft-delete apart.
+        if record == nil {
+            log("PowerWorkBridge: .extractKG — memory \(memoryId) not found, ack-and-skip")
+            return
+        }
+        if record?.deleted == true {
+            log("PowerWorkBridge: .extractKG — memory \(memoryId) soft-deleted, ack-and-skip")
+            return
+        }
+        guard let memory = record, let realId = memory.id else {
+            log("PowerWorkBridge: .extractKG — memory \(memoryId) record missing id, ack-and-skip")
             return
         }
 
@@ -444,7 +496,12 @@ final class PowerWorkBridge {
         } catch {
             // Extractor itself threw (LLM unreachable, etc.). Mark failed and
             // rethrow so PendingWork retry/backoff takes over.
-            try? await MemoryStorage.shared.setKGExtractionStatus(id: realId, status: "failed")
+            // Cluster C3: log when status write fails so silent drops are visible.
+            do {
+                try await MemoryStorage.shared.setKGExtractionStatus(id: realId, status: .failed)
+            } catch let statusError {
+                logError("PowerWorkBridge: .extractKG — setKGExtractionStatus(.failed) failed for memory \(realId) (will be re-extracted on retry)", error: statusError)
+            }
             await KGProgressPublisher.shared.tick()
             throw error
         }
@@ -452,34 +509,57 @@ final class PowerWorkBridge {
         switch extraction.outcome {
         case .parsed, .recovered, .truncatedRetried:
             if extraction.nodes.isEmpty && extraction.edges.isEmpty {
-                // Defensive: shouldn't happen because the extractor
-                // collapses an empty success into `.empty(...)`, but keep the
-                // status writeable just in case.
-                try? await MemoryStorage.shared.setKGExtractionStatus(id: realId, status: "empty")
+                // Defensive: shouldn't happen because the extractor collapses
+                // an empty success into `.empty(...)`, but keep the status
+                // writeable just in case.
+                do {
+                    try await MemoryStorage.shared.setKGExtractionStatus(id: realId, status: .empty)
+                } catch let statusError {
+                    logError("PowerWorkBridge: .extractKG — setKGExtractionStatus(.empty/defensive) failed for memory \(realId)", error: statusError)
+                }
             } else {
                 do {
+                    // Cluster B2: upsert + status now ride in the same
+                    // transaction so a crash between them is impossible.
                     _ = try await KnowledgeGraphStorage.shared.upsert(
                         memoryId: realId,
                         nodes: extraction.nodes,
-                        edges: extraction.edges
+                        edges: extraction.edges,
+                        terminalStatus: .succeeded
                     )
-                    try await MemoryStorage.shared.setKGExtractionStatus(id: realId, status: "succeeded")
                 } catch {
                     // Upsert failure is retryable (DB transient) — mark failed
-                    // and rethrow.
-                    try? await MemoryStorage.shared.setKGExtractionStatus(id: realId, status: "failed")
+                    // out-of-band (best-effort; if THIS write also fails the
+                    // row will simply be re-extracted on retry, which is fine).
+                    do {
+                        try await MemoryStorage.shared.setKGExtractionStatus(id: realId, status: .failed)
+                    } catch let statusError {
+                        logError("PowerWorkBridge: .extractKG — setKGExtractionStatus(.failed) failed for memory \(realId) after upsert failure", error: statusError)
+                    }
                     await KGProgressPublisher.shared.tick()
                     throw error
                 }
             }
         case .empty:
-            try? await MemoryStorage.shared.setKGExtractionStatus(id: realId, status: "empty")
+            do {
+                try await MemoryStorage.shared.setKGExtractionStatus(id: realId, status: .empty)
+            } catch let statusError {
+                logError("PowerWorkBridge: .extractKG — setKGExtractionStatus(.empty) failed for memory \(realId)", error: statusError)
+            }
         case .failed(let reason):
-            try? await MemoryStorage.shared.setKGExtractionStatus(id: realId, status: "failed")
+            do {
+                try await MemoryStorage.shared.setKGExtractionStatus(id: realId, status: .failed)
+            } catch let statusError {
+                logError("PowerWorkBridge: .extractKG — setKGExtractionStatus(.failed) failed for memory \(realId)", error: statusError)
+            }
             await KGProgressPublisher.shared.tick()
+            // Cluster F: surface the underlying LLM error detail so
+            // PendingWorkStorage.fail() captures it in `lastError` and the
+            // dead-letter log shows what actually went wrong.
+            let detail = extraction.llmErrorDetail.map { ": \($0)" } ?? ""
             throw NSError(
                 domain: "PowerWorkBridge", code: 4,
-                userInfo: [NSLocalizedDescriptionKey: "extractKG failed: \(reason.rawValue)"]
+                userInfo: [NSLocalizedDescriptionKey: "extractKG failed: \(reason.rawValue)\(detail)"]
             )
         }
 

--- a/Desktop/Sources/ProactiveAssistants/Assistants/Focus/FocusAssistant.swift
+++ b/Desktop/Sources/ProactiveAssistants/Assistants/Focus/FocusAssistant.swift
@@ -849,6 +849,9 @@ actor FocusAssistant: ProactiveAssistant {
         do {
             let insertedMemory = try await MemoryStorage.shared.insertLocalMemory(memoryRecord)
             log("Focus: Saved to memories (id: \(insertedMemory.id ?? -1)) with tags \(tags)")
+            if let mid = insertedMemory.id {
+                await KGBackfillService.shared.enqueueExtractKG(memoryId: mid, reason: "FocusAssistant.insert")
+            }
             return insertedMemory.id
         } catch {
             logError("Focus: Failed to save to memories table", error: error)

--- a/Desktop/Sources/ProactiveAssistants/Assistants/Focus/FocusAssistant.swift
+++ b/Desktop/Sources/ProactiveAssistants/Assistants/Focus/FocusAssistant.swift
@@ -848,10 +848,8 @@ actor FocusAssistant: ProactiveAssistant {
 
         do {
             let insertedMemory = try await MemoryStorage.shared.insertLocalMemory(memoryRecord)
+            // KG extraction is enqueued atomically inside `insertLocalMemory`.
             log("Focus: Saved to memories (id: \(insertedMemory.id ?? -1)) with tags \(tags)")
-            if let mid = insertedMemory.id {
-                await KGBackfillService.shared.enqueueExtractKG(memoryId: mid, reason: "FocusAssistant.insert")
-            }
             return insertedMemory.id
         } catch {
             logError("Focus: Failed to save to memories table", error: error)

--- a/Desktop/Sources/ProactiveAssistants/Assistants/Insight/InsightAssistant.swift
+++ b/Desktop/Sources/ProactiveAssistants/Assistants/Insight/InsightAssistant.swift
@@ -315,6 +315,9 @@ actor InsightAssistant: ProactiveAssistant {
         do {
             let inserted = try await MemoryStorage.shared.insertLocalMemory(record)
             log("Insight: Saved to SQLite (id: \(inserted.id ?? -1)) with tags \(tags)")
+            if let mid = inserted.id {
+                await KGBackfillService.shared.enqueueExtractKG(memoryId: mid, reason: "InsightAssistant.insert")
+            }
             return inserted
         } catch {
             logError("Insight: Failed to save to SQLite", error: error)

--- a/Desktop/Sources/ProactiveAssistants/Assistants/Insight/InsightAssistant.swift
+++ b/Desktop/Sources/ProactiveAssistants/Assistants/Insight/InsightAssistant.swift
@@ -314,10 +314,8 @@ actor InsightAssistant: ProactiveAssistant {
 
         do {
             let inserted = try await MemoryStorage.shared.insertLocalMemory(record)
+            // KG extraction is enqueued atomically inside `insertLocalMemory`.
             log("Insight: Saved to SQLite (id: \(inserted.id ?? -1)) with tags \(tags)")
-            if let mid = inserted.id {
-                await KGBackfillService.shared.enqueueExtractKG(memoryId: mid, reason: "InsightAssistant.insert")
-            }
             return inserted
         } catch {
             logError("Insight: Failed to save to SQLite", error: error)

--- a/Desktop/Sources/ProactiveAssistants/Assistants/MemoryExtraction/MemoryAssistant.swift
+++ b/Desktop/Sources/ProactiveAssistants/Assistants/MemoryExtraction/MemoryAssistant.swift
@@ -245,12 +245,9 @@ actor MemoryAssistant: ProactiveAssistant {
 
         do {
             let inserted = try await MemoryStorage.shared.insertLocalMemory(record)
+            // KG extraction is enqueued atomically inside `insertLocalMemory`
+            // so the memory and its `.extractKG` work item can never split.
             log("Memory: Saved to SQLite (id: \(inserted.id ?? -1))")
-            // Enqueue KG extraction for the new memory. Best-effort: a failed
-            // enqueue is logged inside the service; do NOT fail the insert.
-            if let mid = inserted.id {
-                await KGBackfillService.shared.enqueueExtractKG(memoryId: mid, reason: "MemoryAssistant.insert")
-            }
             return inserted
         } catch {
             logError("Memory: Failed to save to SQLite", error: error)

--- a/Desktop/Sources/ProactiveAssistants/Assistants/MemoryExtraction/MemoryAssistant.swift
+++ b/Desktop/Sources/ProactiveAssistants/Assistants/MemoryExtraction/MemoryAssistant.swift
@@ -246,6 +246,11 @@ actor MemoryAssistant: ProactiveAssistant {
         do {
             let inserted = try await MemoryStorage.shared.insertLocalMemory(record)
             log("Memory: Saved to SQLite (id: \(inserted.id ?? -1))")
+            // Enqueue KG extraction for the new memory. Best-effort: a failed
+            // enqueue is logged inside the service; do NOT fail the insert.
+            if let mid = inserted.id {
+                await KGBackfillService.shared.enqueueExtractKG(memoryId: mid, reason: "MemoryAssistant.insert")
+            }
             return inserted
         } catch {
             logError("Memory: Failed to save to SQLite", error: error)

--- a/Desktop/Sources/Rewind/Core/KGExtractionStatus.swift
+++ b/Desktop/Sources/Rewind/Core/KGExtractionStatus.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Typed enum for the `memories.kg_extraction_status` column.
+///
+/// Lane C originally used string literals (`"succeeded"`, `"empty"`, `"failed"`)
+/// at every call site. Consensus review found the stringly-typed contract
+/// fragile — a typo at any site would silently fall through to "no row counted
+/// as processed", and the SQL filters in `KGProgressPublisher` /
+/// `KGBackfillService` would diverge from the writer without any compiler help.
+///
+/// All writers now go through this enum; SQL filters use the enum's `rawValue`.
+/// `pending` is reserved for future use (currently writers only ever land on
+/// the three terminal states), but enumerating it here keeps the contract
+/// closed.
+enum KGExtractionStatus: String, Sendable, CaseIterable {
+    case pending
+    case succeeded
+    case empty
+    case failed
+}

--- a/Desktop/Sources/Rewind/Core/MemoryStorage.swift
+++ b/Desktop/Sources/Rewind/Core/MemoryStorage.swift
@@ -307,7 +307,7 @@ actor MemoryStorage {
     func syncServerMemory(_ memory: ServerMemory) async throws -> Int64 {
         let db = try await ensureInitialized()
 
-        return try await db.write { database -> Int64 in
+        let result: (recordId: Int64, wasInsert: Bool) = try await db.write { database -> (Int64, Bool) in
             // Check if memory already exists by backendId
             if var existingRecord = try MemoryRecord
                 .filter(Column("backendId") == memory.id)
@@ -318,7 +318,7 @@ actor MemoryStorage {
                 guard let recordId = existingRecord.id else {
                     throw MemoryStorageError.syncFailed("Record ID is nil after update")
                 }
-                return recordId
+                return (recordId, false)
             } else {
                 // Insert new record, catching UNIQUE constraint from concurrent syncs
                 do {
@@ -326,18 +326,29 @@ actor MemoryStorage {
                     guard let recordId = newRecord.id else {
                         throw MemoryStorageError.syncFailed("Record ID is nil after insert")
                     }
-                    return recordId
+                    return (recordId, true)
                 } catch let dbError as DatabaseError where dbError.resultCode == .SQLITE_CONSTRAINT {
                     // Race: another sync path already inserted this backendId — update instead
                     if var record = try MemoryRecord.filter(Column("backendId") == memory.id).fetchOne(database) {
                         record.updateFrom(memory)
                         try record.update(database)
-                        return record.id ?? 0
+                        return (record.id ?? 0, false)
                     }
                     throw dbError
                 }
             }
         }
+
+        // Server-originated insert → enqueue extractKG. Updates / dedup hits
+        // skip enqueue (the row was already considered for extraction when it
+        // first landed locally).
+        if result.wasInsert {
+            await KGBackfillService.shared.enqueueExtractKG(
+                memoryId: result.recordId,
+                reason: "syncServerMemory"
+            )
+        }
+        return result.recordId
     }
 
     /// Sync multiple ServerMemory objects to local storage (batch upsert)
@@ -345,9 +356,10 @@ actor MemoryStorage {
     func syncServerMemories(_ memories: [ServerMemory]) async throws {
         let db = try await ensureInitialized()
 
-        let (skipped, adopted) = try await db.write { database -> (Int, Int) in
+        let (skipped, adopted, insertedIds) = try await db.write { database -> (Int, Int, [Int64]) in
             var skipped = 0
             var adopted = 0
+            var insertedIds: [Int64] = []
             for memory in memories {
                 if var existingRecord = try MemoryRecord
                     .filter(Column("backendId") == memory.id)
@@ -375,7 +387,8 @@ actor MemoryStorage {
                     adopted += 1
                 } else {
                     do {
-                        _ = try MemoryRecord.from(memory).inserted(database)
+                        let inserted = try MemoryRecord.from(memory).inserted(database)
+                        if let rid = inserted.id { insertedIds.append(rid) }
                     } catch let dbError as DatabaseError where dbError.resultCode == .SQLITE_CONSTRAINT {
                         // Race: record already exists — update instead
                         if var record = try MemoryRecord.filter(Column("backendId") == memory.id).fetchOne(database) {
@@ -385,7 +398,14 @@ actor MemoryStorage {
                     }
                 }
             }
-            return (skipped, adopted)
+            return (skipped, adopted, insertedIds)
+        }
+
+        // Server-originated INSERTs → enqueue extractKG once the transaction
+        // has committed. Adopted orphans were already enqueued at their
+        // original insertLocalMemory site, so we skip them here.
+        for id in insertedIds {
+            await KGBackfillService.shared.enqueueExtractKG(memoryId: id, reason: "syncServerMemories")
         }
 
         if skipped > 0 || adopted > 0 {
@@ -505,6 +525,18 @@ actor MemoryStorage {
         log("MemoryStorage: Marked all memories as read")
     }
 
+    /// Update the `kg_extraction_status` column on a memory row.
+    /// Values used by Lane C handler: "succeeded", "empty", "failed".
+    func setKGExtractionStatus(id: Int64, status: String) async throws {
+        let db = try await ensureInitialized()
+        try await db.write { database in
+            try database.execute(
+                sql: "UPDATE memories SET kg_extraction_status = ?, updatedAt = ? WHERE id = ?",
+                arguments: [status, Date(), id]
+            )
+        }
+    }
+
     /// Soft delete a memory
     func deleteMemory(id: Int64) async throws {
         let db = try await ensureInitialized()
@@ -519,6 +551,14 @@ actor MemoryStorage {
             try record.update(database)
         }
 
+        // Cascade KG provenance removal so any nodes/edges only this memory
+        // contributed to are pruned.
+        do {
+            try await KnowledgeGraphStorage.shared.removeProvenance(forMemoryId: id)
+        } catch {
+            logError("MemoryStorage: KG provenance removal failed for memory \(id)", error: error)
+        }
+
         log("MemoryStorage: Soft deleted memory \(id)")
     }
 
@@ -526,11 +566,28 @@ actor MemoryStorage {
     func deleteMemoryByBackendId(_ backendId: String) async throws {
         let db = try await ensureInitialized()
 
+        // Resolve the local rowid first so we can prune KG provenance after.
+        let localIds: [Int64] = try await db.read { database in
+            try Int64.fetchAll(
+                database,
+                sql: "SELECT id FROM memories WHERE backendId = ?",
+                arguments: [backendId]
+            )
+        }
+
         try await db.write { database in
             try database.execute(
                 sql: "UPDATE memories SET deleted = 1, updatedAt = ? WHERE backendId = ?",
                 arguments: [Date(), backendId]
             )
+        }
+
+        for localId in localIds {
+            do {
+                try await KnowledgeGraphStorage.shared.removeProvenance(forMemoryId: localId)
+            } catch {
+                logError("MemoryStorage: KG provenance removal failed for memory \(localId)", error: error)
+            }
         }
 
         log("MemoryStorage: Soft deleted memory with backendId \(backendId)")

--- a/Desktop/Sources/Rewind/Core/MemoryStorage.swift
+++ b/Desktop/Sources/Rewind/Core/MemoryStorage.swift
@@ -326,6 +326,9 @@ actor MemoryStorage {
                     guard let recordId = newRecord.id else {
                         throw MemoryStorageError.syncFailed("Record ID is nil after insert")
                     }
+                    // Atomic enqueue inside the same transaction so the
+                    // memory + work item can never split on a crash.
+                    try Self.enqueueExtractKGInline(database: database, memoryId: recordId)
                     return (recordId, true)
                 } catch let dbError as DatabaseError where dbError.resultCode == .SQLITE_CONSTRAINT {
                     // Race: another sync path already inserted this backendId — update instead
@@ -339,14 +342,8 @@ actor MemoryStorage {
             }
         }
 
-        // Server-originated insert → enqueue extractKG. Updates / dedup hits
-        // skip enqueue (the row was already considered for extraction when it
-        // first landed locally).
         if result.wasInsert {
-            await KGBackfillService.shared.enqueueExtractKG(
-                memoryId: result.recordId,
-                reason: "syncServerMemory"
-            )
+            log("MemoryStorage: syncServerMemory inserted \(result.recordId) with KG work enqueued atomically")
         }
         return result.recordId
     }
@@ -388,7 +385,11 @@ actor MemoryStorage {
                 } else {
                     do {
                         let inserted = try MemoryRecord.from(memory).inserted(database)
-                        if let rid = inserted.id { insertedIds.append(rid) }
+                        if let rid = inserted.id {
+                            insertedIds.append(rid)
+                            // Atomic enqueue inside the same transaction.
+                            try Self.enqueueExtractKGInline(database: database, memoryId: rid)
+                        }
                     } catch let dbError as DatabaseError where dbError.resultCode == .SQLITE_CONSTRAINT {
                         // Race: record already exists — update instead
                         if var record = try MemoryRecord.filter(Column("backendId") == memory.id).fetchOne(database) {
@@ -401,11 +402,8 @@ actor MemoryStorage {
             return (skipped, adopted, insertedIds)
         }
 
-        // Server-originated INSERTs → enqueue extractKG once the transaction
-        // has committed. Adopted orphans were already enqueued at their
-        // original insertLocalMemory site, so we skip them here.
-        for id in insertedIds {
-            await KGBackfillService.shared.enqueueExtractKG(memoryId: id, reason: "syncServerMemories")
+        if !insertedIds.isEmpty {
+            log("MemoryStorage: syncServerMemories inserted \(insertedIds.count) with KG work enqueued atomically")
         }
 
         if skipped > 0 || adopted > 0 {
@@ -417,8 +415,17 @@ actor MemoryStorage {
 
     // MARK: - Local Extraction Operations
 
-    /// Insert a locally extracted memory (before backend sync)
-    /// Used by MemoryAssistant and InsightAssistant
+    /// Insert a locally extracted memory (before backend sync) and atomically
+    /// enqueue an `.extractKG` work item for it inside the same transaction.
+    /// Used by MemoryAssistant, InsightAssistant, and FocusAssistant.
+    ///
+    /// Atomicity: a crash between the memory insert and the KG work enqueue
+    /// would leave a memory with a NULL `kg_extraction_status` and no pending
+    /// work item — the row would be invisible to both the backfill (which
+    /// only picks up rows whose status is NULL — but the dedup key is missing
+    /// so it'd actually be rescued, _but_ the status-vs-work-item invariant
+    /// is the more important one to keep clean for the progress publisher).
+    /// Doing both writes in one transaction removes the window entirely.
     @discardableResult
     func insertLocalMemory(_ record: MemoryRecord) async throws -> MemoryRecord {
         let db = try await ensureInitialized()
@@ -427,12 +434,53 @@ actor MemoryStorage {
         insertRecord.backendSynced = false  // Mark as not yet synced
 
         let recordToInsert = insertRecord
-        let inserted = try await db.write { database in
-            try recordToInsert.inserted(database)
+        let inserted: MemoryRecord = try await db.write { database in
+            let saved = try recordToInsert.inserted(database)
+            // Enqueue extractKG inline so the memory + work item land in the
+            // same transaction. Mirrors `PendingWorkStorage.enqueue` SQL but
+            // skips the depth-cap check (a single live insert can't exceed
+            // the cap on its own, and even if it did, leaving a memory
+            // un-extracted is preferable to dropping it on the floor here).
+            if let memoryId = saved.id, memoryId != ONBOARDING_SENTINEL {
+                try Self.enqueueExtractKGInline(
+                    database: database,
+                    memoryId: memoryId
+                )
+            }
+            return saved
         }
 
-        log("MemoryStorage: Inserted local memory (id: \(inserted.id ?? -1))")
+        log("MemoryStorage: Inserted local memory (id: \(inserted.id ?? -1)) with KG work enqueued atomically")
         return inserted
+    }
+
+    /// Inline SQL to enqueue an `.extractKG` work item, used by
+    /// `insertLocalMemory` (and the deferred sync paths) so the queue insert
+    /// can ride inside the same `db.write` transaction as the memory insert.
+    /// Idempotent on the dedup key — duplicate live rows are silently skipped
+    /// the same way `PendingWorkStorage.enqueue` does it.
+    fileprivate static func enqueueExtractKGInline(
+        database: Database,
+        memoryId: Int64
+    ) throws {
+        struct PendingPayload: Codable { let memory_id: Int64 }
+        let payload = try JSONEncoder().encode(PendingPayload(memory_id: memoryId))
+        let now = Date()
+        let dedupKey = "extractKG:\(memoryId)"
+        do {
+            try database.execute(
+                sql: """
+                    INSERT INTO pending_work
+                        (workType, payload, status, attempts, maxAttempts,
+                         scheduledFor, dedupKey, createdAt, updatedAt)
+                    VALUES (?, ?, 'queued', 0, 8, ?, ?, ?, ?)
+                """,
+                arguments: ["extractKG", payload, now, dedupKey, now, now]
+            )
+        } catch let dbError as DatabaseError where dbError.resultCode == .SQLITE_CONSTRAINT {
+            // Live dedup row already exists — no-op.
+            log("MemoryStorage: extractKG dedup hit for memory \(memoryId), skipping inline enqueue")
+        }
     }
 
     /// Mark a local memory as synced with backend ID
@@ -526,13 +574,13 @@ actor MemoryStorage {
     }
 
     /// Update the `kg_extraction_status` column on a memory row.
-    /// Values used by Lane C handler: "succeeded", "empty", "failed".
-    func setKGExtractionStatus(id: Int64, status: String) async throws {
+    /// Values used by Lane C handler: `.succeeded`, `.empty`, `.failed`.
+    func setKGExtractionStatus(id: Int64, status: KGExtractionStatus) async throws {
         let db = try await ensureInitialized()
         try await db.write { database in
             try database.execute(
                 sql: "UPDATE memories SET kg_extraction_status = ?, updatedAt = ? WHERE id = ?",
-                arguments: [status, Date(), id]
+                arguments: [status.rawValue, Date(), id]
             )
         }
     }
@@ -597,14 +645,34 @@ actor MemoryStorage {
     func deleteAllMemories() async throws {
         let db = try await ensureInitialized()
 
-        try await db.write { database in
+        // Snapshot the affected memory ids inside the same transaction that
+        // soft-deletes them so KG provenance cascade can't miss a row that
+        // was concurrently inserted between the snapshot and the UPDATE.
+        let affectedIds: [Int64] = try await db.write { database in
+            let ids = try Int64.fetchAll(
+                database,
+                sql: "SELECT id FROM memories WHERE deleted = 0"
+            )
             try database.execute(
                 sql: "UPDATE memories SET deleted = 1, updatedAt = ? WHERE deleted = 0",
                 arguments: [Date()]
             )
+            return ids
         }
 
-        log("MemoryStorage: Soft deleted all memories")
+        // Cascade KG provenance for every affected row. Failures are logged
+        // per-id but don't abort the loop — the memory soft-delete already
+        // succeeded, and partial provenance survival is preferable to zero
+        // cascade.
+        for memoryId in affectedIds {
+            do {
+                try await KnowledgeGraphStorage.shared.removeProvenance(forMemoryId: memoryId)
+            } catch {
+                logError("MemoryStorage: KG provenance removal failed for memory \(memoryId)", error: error)
+            }
+        }
+
+        log("MemoryStorage: Soft deleted all memories (\(affectedIds.count) rows; KG cascade attempted)")
     }
 
     /// Update content by backend ID

--- a/Desktop/Sources/Rewind/Core/PendingWorkStorage.swift
+++ b/Desktop/Sources/Rewind/Core/PendingWorkStorage.swift
@@ -67,6 +67,11 @@ actor PendingWorkStorage {
     private let depthCaps: [String: Int] = [
         PendingWork.Kind.transcribe.rawValue:         5_000,
         PendingWork.Kind.ocr.rawValue:               50_000,
+        // KG extraction is bounded by the local memory count; a 100k cap
+        // gives plenty of headroom for the historical backfill on first
+        // launch while still preventing a runaway producer from filling
+        // the queue table.
+        PendingWork.Kind.extractKG.rawValue:        100_000,
     ]
     private let defaultDepthCap = 10_000
     private let maxPayloadBytes = 64 * 1024   // 64 KB

--- a/Desktop/Sources/Rewind/Core/RewindDatabase.swift
+++ b/Desktop/Sources/Rewind/Core/RewindDatabase.swift
@@ -2458,6 +2458,28 @@ actor RewindDatabase {
                           on: "local_integration_outbox", columns: ["integrationId"])
         }
 
+        migrator.registerMigration("createKGProvenanceAndExtractionStatus") { db in
+            try db.create(table: "local_kg_node_sources") { t in
+                t.column("memoryId", .integer).notNull()
+                t.column("nodeId", .text).notNull()
+                t.primaryKey(["memoryId", "nodeId"])
+            }
+            try db.create(index: "idx_local_kg_node_sources_nodeId",
+                          on: "local_kg_node_sources", columns: ["nodeId"])
+
+            try db.create(table: "local_kg_edge_sources") { t in
+                t.column("memoryId", .integer).notNull()
+                t.column("edgeId", .text).notNull()
+                t.primaryKey(["memoryId", "edgeId"])
+            }
+            try db.create(index: "idx_local_kg_edge_sources_edgeId",
+                          on: "local_kg_edge_sources", columns: ["edgeId"])
+
+            try db.alter(table: "memories") { t in
+                t.add(column: "kg_extraction_status", .text)
+            }
+        }
+
         try migrator.migrate(queue)
     }
 

--- a/Desktop/Sources/Rewind/Services/KGBackfillService.swift
+++ b/Desktop/Sources/Rewind/Services/KGBackfillService.swift
@@ -1,0 +1,173 @@
+import Foundation
+import GRDB
+
+/// One-shot backfill that walks every existing local memory and enqueues an
+/// `.extractKG` work item for it via `PendingWorkStorage`. The actual
+/// extraction is performed lazily by the scheduler's `.extractKG` handler;
+/// this service only seeds the queue.
+///
+/// Idempotency is gated by the `migration_status` row keyed
+/// `kg_backfill_v1`. Repeat calls after success are no-ops.
+///
+/// Pattern mirrors `ConversationSummaryBackfillService` (PendingWorkStorage
+/// enqueue + dedup key) rather than the inline-loop approach of
+/// `EmbeddingBackfillService`.
+actor KGBackfillService {
+    static let shared = KGBackfillService()
+
+    /// migration_status row key for this backfill.
+    static let migrationKey = "kg_backfill_v1"
+
+    /// Pending-work `workType` string. Must match
+    /// `PendingWork.Kind.extractKG.rawValue` and is shared with the handler
+    /// in `PowerWorkBridge`.
+    private static let workType: String = PendingWork.Kind.extractKG.rawValue
+
+    /// JSON wire format for `.extractKG` payload rows.
+    /// Matches the contract used by `PowerWorkBridge.handleExtractKG`.
+    private struct PendingPayload: Codable {
+        let memory_id: Int64
+    }
+
+    /// Dedup key — colon-style, matches `summarize:<id>`.
+    static func dedupKey(forMemoryId memoryId: Int64) -> String {
+        return "extractKG:\(memoryId)"
+    }
+
+    private init() {}
+
+    // MARK: - Public API
+
+    /// One-time historical backfill. Idempotent — second call no-ops.
+    /// Called from `AppDelegate` (or whichever boot site invokes
+    /// `PowerWorkBridge.shared.start()`) after the scheduler is up.
+    func runIfNeeded() async {
+        do {
+            if try await isComplete() {
+                log("KGBackfillService: already complete (\(Self.migrationKey)), skipping")
+                return
+            }
+        } catch {
+            logError("KGBackfillService: failed to check migration_status; will attempt anyway", error: error)
+        }
+
+        do {
+            try await markStarted()
+        } catch {
+            logError("KGBackfillService: failed to record migration start row", error: error)
+        }
+
+        let memoryIds: [Int64]
+        do {
+            memoryIds = try await fetchEligibleMemoryIds()
+        } catch {
+            logError("KGBackfillService: failed to fetch eligible memories; will retry next launch", error: error)
+            return
+        }
+
+        guard !memoryIds.isEmpty else {
+            log("KGBackfillService: no memories to backfill — marking complete")
+            try? await markComplete()
+            return
+        }
+
+        log("KGBackfillService: enqueueing \(memoryIds.count) memory(ies) for KG extraction")
+        var enqueued = 0
+        for id in memoryIds {
+            do {
+                let payload = try JSONEncoder().encode(PendingPayload(memory_id: id))
+                _ = try await PendingWorkStorage.shared.enqueue(
+                    workType: Self.workType,
+                    payload: payload,
+                    dedupKey: Self.dedupKey(forMemoryId: id)
+                )
+                enqueued += 1
+            } catch {
+                logError("KGBackfillService: enqueue failed for memory \(id)", error: error)
+            }
+        }
+
+        log("KGBackfillService: enqueued \(enqueued)/\(memoryIds.count) extractKG jobs")
+
+        // Mark complete: the migration is "all eligible memories enqueued".
+        // Per-row retry / dead-letter is owned by PendingWorkStorage; this
+        // service shouldn't loop on outcomes.
+        try? await markComplete()
+    }
+
+    /// Durable enqueue for a single memory id. Used by the live insert path
+    /// in the proactive assistants and the server-sync path. Idempotent via
+    /// the dedup key.
+    func enqueueExtractKG(memoryId: Int64, reason: String) async {
+        // Skip the onboarding sentinel — it represents a bulk write, not a
+        // single memory, and shouldn't generate a per-memory work item.
+        guard memoryId != ONBOARDING_SENTINEL else { return }
+        do {
+            let payload = try JSONEncoder().encode(PendingPayload(memory_id: memoryId))
+            _ = try await PendingWorkStorage.shared.enqueue(
+                workType: Self.workType,
+                payload: payload,
+                dedupKey: Self.dedupKey(forMemoryId: memoryId)
+            )
+            log("KGBackfillService: enqueued extractKG for memory \(memoryId) (\(reason))")
+        } catch {
+            logError("KGBackfillService: enqueue failed for memory \(memoryId) (\(reason))", error: error)
+        }
+    }
+
+    // MARK: - migration_status helpers
+
+    private func isComplete() async throws -> Bool {
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else { return false }
+        return try await dbQueue.read { db in
+            let completed = try Int.fetchOne(
+                db,
+                sql: "SELECT completed FROM migration_status WHERE name = ?",
+                arguments: [Self.migrationKey]
+            ) ?? 0
+            return completed == 1
+        }
+    }
+
+    private func markStarted() async throws {
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else { return }
+        try await dbQueue.write { db in
+            try db.execute(sql: """
+                INSERT OR IGNORE INTO migration_status (name, completed, startedAt)
+                VALUES (?, 0, datetime('now'))
+            """, arguments: [Self.migrationKey])
+        }
+    }
+
+    private func markComplete() async throws {
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else { return }
+        try await dbQueue.write { db in
+            try db.execute(sql: """
+                INSERT OR REPLACE INTO migration_status (name, completed, startedAt, completedAt)
+                VALUES (?, 1,
+                    COALESCE((SELECT startedAt FROM migration_status WHERE name = ?), datetime('now')),
+                    datetime('now'))
+            """, arguments: [Self.migrationKey, Self.migrationKey])
+        }
+    }
+
+    // MARK: - DB walks
+
+    /// Memories eligible for KG backfill: not deleted, no extraction status
+    /// yet (NULL), and id > 0 (excludes the onboarding sentinel).
+    private func fetchEligibleMemoryIds() async throws -> [Int64] {
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else { return [] }
+        return try await dbQueue.read { db in
+            try Int64.fetchAll(
+                db,
+                sql: """
+                    SELECT id FROM memories
+                    WHERE deleted = 0
+                      AND kg_extraction_status IS NULL
+                      AND id > 0
+                    ORDER BY createdAt DESC
+                """
+            )
+        }
+    }
+}

--- a/Desktop/Sources/Rewind/Services/KGBackfillService.swift
+++ b/Desktop/Sources/Rewind/Services/KGBackfillService.swift
@@ -48,7 +48,12 @@ actor KGBackfillService {
                 return
             }
         } catch {
-            logError("KGBackfillService: failed to check migration_status; will attempt anyway", error: error)
+            // Cluster D4: surface the read error loudly. We still proceed
+            // (the dedup key + status filter limits blast radius — at worst
+            // we re-enqueue rows that already have a live work item, which
+            // PendingWorkStorage's UNIQUE dedup index will collapse to a
+            // no-op), but a transient DB error must not hide.
+            logError("KGBackfillService: WARNING — migration_status read failed; proceeding with backfill anyway. Per-row dedup will absorb duplicates.", error: error)
         }
 
         do {
@@ -73,26 +78,56 @@ actor KGBackfillService {
 
         log("KGBackfillService: enqueueing \(memoryIds.count) memory(ies) for KG extraction")
         var enqueued = 0
+        var capDropped = 0
+        var failed = 0
         for id in memoryIds {
             do {
                 let payload = try JSONEncoder().encode(PendingPayload(memory_id: id))
-                _ = try await PendingWorkStorage.shared.enqueue(
+                // `enqueue` returns nil for both dedup-hits and cap-drops.
+                // We can't distinguish them from the return value alone
+                // without breaking the API; instead infer cap-drop by
+                // observing `recentDrops` deltas. Simpler: if the result is
+                // nil AND no dedup row exists for this memory, count it as
+                // cap-drop (this is the case the consensus review wants
+                // counted as a failure). If we can't tell, we err on the
+                // side of treating nil as success (dedup hit) so an
+                // already-enqueued row doesn't re-trigger a re-run.
+                let beforeDrops = await PendingWorkStorage.shared.recentDrops
+                let rowId = try await PendingWorkStorage.shared.enqueue(
                     workType: Self.workType,
                     payload: payload,
                     dedupKey: Self.dedupKey(forMemoryId: id)
                 )
-                enqueued += 1
+                let afterDrops = await PendingWorkStorage.shared.recentDrops
+                if rowId != nil {
+                    enqueued += 1
+                } else if afterDrops > beforeDrops {
+                    // Cap-drop — log loudly so the operator sees it; D1
+                    // partial-enqueue path will take over.
+                    capDropped += 1
+                    log("KGBackfillService: cap-drop for memory \(id) — queue at depth limit")
+                } else {
+                    // Dedup hit — already-active row exists for this memory.
+                    // Treat as already enqueued for the completion check.
+                    enqueued += 1
+                }
             } catch {
+                failed += 1
                 logError("KGBackfillService: enqueue failed for memory \(id)", error: error)
             }
         }
 
-        log("KGBackfillService: enqueued \(enqueued)/\(memoryIds.count) extractKG jobs")
+        log("KGBackfillService: enqueued \(enqueued)/\(memoryIds.count) extractKG jobs (cap-dropped=\(capDropped), failed=\(failed))")
 
-        // Mark complete: the migration is "all eligible memories enqueued".
-        // Per-row retry / dead-letter is owned by PendingWorkStorage; this
-        // service shouldn't loop on outcomes.
-        try? await markComplete()
+        // Cluster D1: only mark complete when every eligible row landed in
+        // the queue. Otherwise the next launch will retry the misses.
+        // Per-row retry / dead-letter is still owned by PendingWorkStorage;
+        // this service only owns the all-enqueued invariant.
+        if enqueued == memoryIds.count {
+            try? await markComplete()
+        } else {
+            log("KGBackfillService: NOT marking complete — \(memoryIds.count - enqueued) row(s) failed to enqueue; will retry on next launch")
+        }
     }
 
     /// Durable enqueue for a single memory id. Used by the live insert path

--- a/Desktop/Sources/Rewind/Services/KGProgressPublisher.swift
+++ b/Desktop/Sources/Rewind/Services/KGProgressPublisher.swift
@@ -1,0 +1,315 @@
+import Foundation
+import GRDB
+
+/// Snapshot of brain-map build progress, surfaced to the UI.
+///
+/// Denominator (`totalMemories`) is the count of non-deleted local memories.
+/// Numerator (`processedMemories`) is the count of distinct memoryIds with
+/// any provenance row recorded — i.e. memories the extractor has touched at
+/// least once, regardless of outcome.
+struct KGBuildProgress: Sendable, Equatable {
+    let totalMemories: Int
+    let processedMemories: Int
+    let succeededMemories: Int
+    let totalNodes: Int
+    let state: BuildState
+    let etaSeconds: Int?
+}
+
+/// Build-time state. The UI's precedence ladder maps these to user-visible
+/// strings; see `MemoryGraphPage.BuildPillState`.
+enum BuildState: Sendable, Equatable {
+    case idleNoWork
+    case building
+    case pausedThermal
+    case pausedBattery
+    case pausedNotIdle
+    case modelNotReady
+}
+
+/// Empty-state copy mode. Pure function of (state, totalNodes, totalMemories)
+/// so the test suite can assert it without rendering SwiftUI.
+enum EmptyStateMode: Sendable, Equatable {
+    /// "Building your brain map. This runs while your Mac is idle."
+    case backfillNotStarted
+    /// "Building — 0 / N memories"
+    case backfillRunningNoNodesYet
+    /// "No entities found yet. ..."
+    case backfillCompleteEmpty
+}
+
+/// Pure mapping used by both the UI and tests.
+///
+/// Caller is expected to invoke this only when the populated graph is not
+/// being shown (i.e. `totalNodes == 0` or the VM has elected to suppress
+/// the SceneKit view because there's nothing to render yet).
+enum BrainMapEmptyStateClassifier {
+    static func mode(
+        state: BuildState,
+        totalNodes: Int,
+        totalMemories: Int,
+        processedMemories: Int
+    ) -> EmptyStateMode {
+        // If a build is actively in progress (or paused mid-build) and we
+        // haven't extracted any nodes yet, show the building copy.
+        switch state {
+        case .building, .pausedThermal, .pausedBattery, .pausedNotIdle, .modelNotReady:
+            return .backfillRunningNoNodesYet
+        case .idleNoWork:
+            // No pending work. Either the backfill is finished, or it never
+            // had anything to do. If we processed at least one memory the
+            // backfill ran — distinguish from "haven't started" (no memories
+            // touched and there are memories that could be).
+            if processedMemories > 0 || totalMemories == 0 {
+                return .backfillCompleteEmpty
+            }
+            return .backfillNotStarted
+        }
+    }
+}
+
+/// Singleton publisher fed by the `.extractKG` handler. The Brain Map VM
+/// subscribes to `stream` and renders the pill / empty-state copy.
+///
+/// Throttle: emits at most every 250 ms. ETA: rolling avg of last 5 drain
+/// durations × remaining count, nil until we have ≥ 3 samples.
+actor KGProgressPublisher {
+    static let shared = KGProgressPublisher()
+
+    private var continuations: [UUID: AsyncStream<KGBuildProgress>.Continuation] = [:]
+    private var lastEmittedAt: Date?
+    private var lastSnapshot: KGBuildProgress?
+    private var coalesceTask: Task<Void, Never>?
+
+    /// Last N drain durations, used to compute ETA.
+    private var drainSamples: [TimeInterval] = []
+    /// Maximum samples retained.
+    private let maxSamples = 5
+    /// Minimum samples before we publish a non-nil ETA.
+    private let minSamplesForETA = 3
+    /// Min throttle window between consecutive emits.
+    private let throttleSeconds: TimeInterval = 0.25
+
+    private init() {}
+
+    /// Async stream of progress snapshots. Each call returns a fresh stream;
+    /// the caller owns it.
+    var stream: AsyncStream<KGBuildProgress> {
+        AsyncStream { continuation in
+            let id = UUID()
+            self.registerContinuation(id: id, continuation: continuation)
+            continuation.onTermination = { @Sendable [weak self] _ in
+                guard let self = self else { return }
+                Task { await self.removeContinuation(id: id) }
+            }
+        }
+    }
+
+    private func registerContinuation(
+        id: UUID,
+        continuation: AsyncStream<KGBuildProgress>.Continuation
+    ) {
+        continuations[id] = continuation
+        // Replay last snapshot so newly subscribed observers see current state
+        // immediately rather than waiting for the next tick.
+        if let snap = lastSnapshot {
+            continuation.yield(snap)
+        }
+    }
+
+    private func removeContinuation(id: UUID) {
+        continuations.removeValue(forKey: id)
+    }
+
+    // MARK: - Public
+
+    /// Record a per-memory drain duration sample. Call once per handler
+    /// invocation so the ETA estimator has a denominator.
+    func recordDrainSample(seconds: TimeInterval) {
+        drainSamples.append(seconds)
+        if drainSamples.count > maxSamples {
+            drainSamples.removeFirst(drainSamples.count - maxSamples)
+        }
+    }
+
+    /// Sample DB counters + scheduler state, build a `KGBuildProgress`, and
+    /// emit on the stream (subject to throttle/coalesce).
+    func tick() async {
+        let snap = await sample()
+        await emit(snap)
+    }
+
+    /// Force an immediate emit ignoring the throttle. Used for state changes
+    /// (e.g. "model became ready") where the user is waiting for the pill to
+    /// flip.
+    func emitNow() async {
+        let snap = await sample()
+        coalesceTask?.cancel()
+        coalesceTask = nil
+        deliver(snap)
+    }
+
+    // MARK: - Sampling
+
+    private func sample() async -> KGBuildProgress {
+        async let totalMemoriesAsync = totalMemoryCount()
+        async let processedAsync = processedAndSucceededCounts()
+        async let totalNodesAsync = totalNodesCount()
+
+        let totalMemories = (try? await totalMemoriesAsync) ?? 0
+        let (processed, succeeded) = (try? await processedAsync) ?? (0, 0)
+        let totalNodes = (try? await totalNodesAsync) ?? 0
+
+        let state = await deriveState(processedMemories: processed, totalMemories: totalMemories)
+        let eta = computeETA(
+            processed: processed, totalMemories: totalMemories
+        )
+
+        return KGBuildProgress(
+            totalMemories: totalMemories,
+            processedMemories: processed,
+            succeededMemories: succeeded,
+            totalNodes: totalNodes,
+            state: state,
+            etaSeconds: eta
+        )
+    }
+
+    @MainActor
+    private func mainActorReadiness() -> (
+        allowHeavy: Bool, allowAutonomous: Bool,
+        thermalSerious: Bool, onBattery: Bool, modelReady: Bool
+    ) {
+        let s = BatteryAwareScheduler.shared
+        let lifecycle = MLXLifecycleManager.shared
+        let modelReady = lifecycle.agentInstalled && lifecycle.modelPresent
+        return (
+            allowHeavy: s.allowHeavyWork,
+            allowAutonomous: s.allowAutonomousAIWork,
+            thermalSerious: s.thermalState.rawValue >= ProcessInfo.ThermalState.serious.rawValue,
+            onBattery: s.source != .ac,
+            modelReady: modelReady
+        )
+    }
+
+    private func deriveState(processedMemories: Int, totalMemories: Int) async -> BuildState {
+        let r = await mainActorReadiness()
+
+        // Pending-work depth for `.extractKG` decides whether there's work at
+        // all. If the queue is empty, treat as `idleNoWork` regardless of
+        // power state — there's nothing pending to be paused.
+        let depth = (try? await PendingWorkStorage.shared.depthSummary()) ?? PendingWorkDepth()
+        let key = PendingWork.Kind.extractKG.rawValue
+        let pending = (depth.queued[key] ?? 0) + (depth.failed[key] ?? 0) + (depth.claimed[key] ?? 0)
+
+        if pending == 0 {
+            return .idleNoWork
+        }
+
+        // There's pending work — derive the precedence ladder gate reason.
+        if !r.modelReady { return .modelNotReady }
+        if r.thermalSerious { return .pausedThermal }
+        if r.onBattery && !r.allowHeavy { return .pausedBattery }
+        if r.allowHeavy && !r.allowAutonomous {
+            // Heavy work is allowed (AC + thermal ok) but the user is active —
+            // autonomous-LLM work waits for idle/lock.
+            return .pausedNotIdle
+        }
+        return .building
+    }
+
+    private func computeETA(processed: Int, totalMemories: Int) -> Int? {
+        guard drainSamples.count >= minSamplesForETA else { return nil }
+        let remaining = max(0, totalMemories - processed)
+        guard remaining > 0 else { return 0 }
+        let avg = drainSamples.reduce(0, +) / Double(drainSamples.count)
+        return Int((Double(remaining) * avg).rounded())
+    }
+
+    // MARK: - DB counters
+
+    private func totalMemoryCount() async throws -> Int {
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else { return 0 }
+        return try await dbQueue.read { db in
+            try Int.fetchOne(
+                db,
+                sql: "SELECT COUNT(*) FROM memories WHERE deleted = 0"
+            ) ?? 0
+        }
+    }
+
+    /// Returns (processedMemories, succeededMemories).
+    /// Processed = distinct memoryIds with any node provenance row, excluding
+    /// the onboarding sentinel.
+    /// Succeeded = same, with `kg_extraction_status = 'succeeded'`.
+    private func processedAndSucceededCounts() async throws -> (Int, Int) {
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else { return (0, 0) }
+        return try await dbQueue.read { db in
+            let processed = try Int.fetchOne(
+                db,
+                sql: """
+                    SELECT COUNT(DISTINCT m.id)
+                    FROM memories m
+                    WHERE m.deleted = 0
+                      AND m.kg_extraction_status IS NOT NULL
+                """
+            ) ?? 0
+            let succeeded = try Int.fetchOne(
+                db,
+                sql: """
+                    SELECT COUNT(*)
+                    FROM memories
+                    WHERE deleted = 0
+                      AND kg_extraction_status = 'succeeded'
+                """
+            ) ?? 0
+            return (processed, succeeded)
+        }
+    }
+
+    private func totalNodesCount() async throws -> Int {
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else { return 0 }
+        return try await dbQueue.read { db in
+            try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM local_kg_nodes") ?? 0
+        }
+    }
+
+    // MARK: - Throttling
+
+    private func emit(_ snapshot: KGBuildProgress) async {
+        // Coalesce: if a tick lands inside the throttle window, schedule a
+        // single trailing emit and drop intermediate samples.
+        let now = Date()
+        if let last = lastEmittedAt, now.timeIntervalSince(last) < throttleSeconds {
+            // Stash the latest snapshot for diagnostic replay.
+            lastSnapshot = snapshot
+            // Queue (or replace) a trailing emit.
+            coalesceTask?.cancel()
+            let delay = throttleSeconds - now.timeIntervalSince(last)
+            coalesceTask = Task { [weak self] in
+                try? await Task.sleep(nanoseconds: UInt64(max(0, delay) * 1_000_000_000))
+                if Task.isCancelled { return }
+                await self?.flushTrailing()
+            }
+            return
+        }
+        deliver(snapshot)
+    }
+
+    private func flushTrailing() async {
+        coalesceTask = nil
+        // Re-sample so the trailing emit reflects the freshest DB state, not
+        // the snapshot that was queued at throttle-start.
+        let snap = await sample()
+        deliver(snap)
+    }
+
+    private func deliver(_ snapshot: KGBuildProgress) {
+        lastEmittedAt = Date()
+        lastSnapshot = snapshot
+        for (_, c) in continuations {
+            c.yield(snapshot)
+        }
+    }
+}
+

--- a/Desktop/Sources/Rewind/Services/KGProgressPublisher.swift
+++ b/Desktop/Sources/Rewind/Services/KGProgressPublisher.swift
@@ -14,6 +14,34 @@ struct KGBuildProgress: Sendable, Equatable {
     let totalNodes: Int
     let state: BuildState
     let etaSeconds: Int?
+
+    /// Saturating init: enforces `processed ≤ total` and `succeeded ≤ processed`.
+    /// Lane C originally took counts from independent SQL reads — a window
+    /// between reads could legitimately produce `processed > total` (e.g. a
+    /// memory got soft-deleted between the two queries). Clamp here so the
+    /// pill never renders "5/3 memories" and so the empty-state classifier
+    /// can trust its inputs. Logs when clamping fires so we still see the
+    /// underlying source of drift.
+    init(
+        totalMemories: Int,
+        processedMemories: Int,
+        succeededMemories: Int,
+        totalNodes: Int,
+        state: BuildState,
+        etaSeconds: Int?
+    ) {
+        let clampedProcessed = min(max(0, processedMemories), max(0, totalMemories))
+        let clampedSucceeded = min(max(0, succeededMemories), clampedProcessed)
+        if clampedProcessed != processedMemories || clampedSucceeded != succeededMemories {
+            log("KGBuildProgress: clamped counters total=\(totalMemories) processed=\(processedMemories)→\(clampedProcessed) succeeded=\(succeededMemories)→\(clampedSucceeded)")
+        }
+        self.totalMemories = max(0, totalMemories)
+        self.processedMemories = clampedProcessed
+        self.succeededMemories = clampedSucceeded
+        self.totalNodes = max(0, totalNodes)
+        self.state = state
+        self.etaSeconds = etaSeconds
+    }
 }
 
 /// Build-time state. The UI's precedence ladder maps these to user-visible
@@ -42,11 +70,12 @@ enum EmptyStateMode: Sendable, Equatable {
 ///
 /// Caller is expected to invoke this only when the populated graph is not
 /// being shown (i.e. `totalNodes == 0` or the VM has elected to suppress
-/// the SceneKit view because there's nothing to render yet).
+/// the SceneKit view because there's nothing to render yet). The
+/// `totalNodes` parameter was removed in the consensus review pass — it
+/// duplicated the caller's gate without adding signal here.
 enum BrainMapEmptyStateClassifier {
     static func mode(
         state: BuildState,
-        totalNodes: Int,
         totalMemories: Int,
         processedMemories: Int
     ) -> EmptyStateMode {
@@ -80,6 +109,16 @@ actor KGProgressPublisher {
     private var lastEmittedAt: Date?
     private var lastSnapshot: KGBuildProgress?
     private var coalesceTask: Task<Void, Never>?
+    /// Cluster I — single-flight flush. When `true` and a flush is already
+    /// scheduled or in-flight, emit() returns without spawning a second timer
+    /// and `flushTrailing` will re-run on completion.
+    private var pendingTrailingFlush: Bool = false
+    /// Cluster E2 — low-frequency poller so paused / model-not-ready states
+    /// surface even when no `.extractKG` handler tick has fired. Started on
+    /// first subscriber, stopped when the subscriber count drops to zero.
+    /// Polls every `pollSeconds`; the 250ms emit throttle prevents flooding.
+    private var pollTask: Task<Void, Never>?
+    private let pollSeconds: TimeInterval = 5.0
 
     /// Last N drain durations, used to compute ETA.
     private var drainSamples: [TimeInterval] = []
@@ -115,10 +154,43 @@ actor KGProgressPublisher {
         if let snap = lastSnapshot {
             continuation.yield(snap)
         }
+        // Cluster E2: ensure poller is running so paused / model-not-ready
+        // states surface without waiting for a handler-driven tick. Also
+        // schedule an immediate sample for first paint.
+        startPollerIfNeeded()
+        Task { [weak self] in await self?.tick() }
     }
 
     private func removeContinuation(id: UUID) {
         continuations.removeValue(forKey: id)
+        if continuations.isEmpty {
+            stopPoller()
+        }
+    }
+
+    // MARK: - Polling (Cluster E2)
+
+    private func startPollerIfNeeded() {
+        guard pollTask == nil else { return }
+        pollTask = Task { [weak self] in
+            guard let self = self else { return }
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: UInt64(self.pollSeconds * 1_000_000_000))
+                if Task.isCancelled { return }
+                await self.pollTickIfActive()
+            }
+        }
+    }
+
+    private func stopPoller() {
+        pollTask?.cancel()
+        pollTask = nil
+    }
+
+    /// Poll-driven tick. Bails out if no subscribers remain (raced cancel).
+    private func pollTickIfActive() async {
+        guard !continuations.isEmpty else { return }
+        await tick()
     }
 
     // MARK: - Public
@@ -134,8 +206,11 @@ actor KGProgressPublisher {
 
     /// Sample DB counters + scheduler state, build a `KGBuildProgress`, and
     /// emit on the stream (subject to throttle/coalesce).
+    /// On DB read failure the tick is skipped — emitting a 0/0 snapshot
+    /// would be indistinguishable from "backfill complete empty" and
+    /// would silently corrupt the UI's state machine.
     func tick() async {
-        let snap = await sample()
+        guard let snap = await sample() else { return }
         await emit(snap)
     }
 
@@ -143,7 +218,7 @@ actor KGProgressPublisher {
     /// (e.g. "model became ready") where the user is waiting for the pill to
     /// flip.
     func emitNow() async {
-        let snap = await sample()
+        guard let snap = await sample() else { return }
         coalesceTask?.cancel()
         coalesceTask = nil
         deliver(snap)
@@ -151,14 +226,26 @@ actor KGProgressPublisher {
 
     // MARK: - Sampling
 
-    private func sample() async -> KGBuildProgress {
+    /// Returns nil on DB read failure. Caller must skip the emit.
+    private func sample() async -> KGBuildProgress? {
         async let totalMemoriesAsync = totalMemoryCount()
         async let processedAsync = processedAndSucceededCounts()
         async let totalNodesAsync = totalNodesCount()
 
-        let totalMemories = (try? await totalMemoriesAsync) ?? 0
-        let (processed, succeeded) = (try? await processedAsync) ?? (0, 0)
-        let totalNodes = (try? await totalNodesAsync) ?? 0
+        let totalMemories: Int
+        let processed: Int
+        let succeeded: Int
+        let totalNodes: Int
+        do {
+            totalMemories = try await totalMemoriesAsync
+            (processed, succeeded) = try await processedAsync
+            totalNodes = try await totalNodesAsync
+        } catch {
+            // Don't emit — a 0/0 snapshot here would render as
+            // "backfill complete empty" and lie to the user.
+            logError("KGProgressPublisher: sample DB read failed; skipping tick", error: error)
+            return nil
+        }
 
         let state = await deriveState(processedMemories: processed, totalMemories: totalMemories)
         let eta = computeETA(
@@ -260,8 +347,9 @@ actor KGProgressPublisher {
                     SELECT COUNT(*)
                     FROM memories
                     WHERE deleted = 0
-                      AND kg_extraction_status = 'succeeded'
-                """
+                      AND kg_extraction_status = ?
+                """,
+                arguments: [KGExtractionStatus.succeeded.rawValue]
             ) ?? 0
             return (processed, succeeded)
         }
@@ -283,8 +371,14 @@ actor KGProgressPublisher {
         if let last = lastEmittedAt, now.timeIntervalSince(last) < throttleSeconds {
             // Stash the latest snapshot for diagnostic replay.
             lastSnapshot = snapshot
-            // Queue (or replace) a trailing emit.
-            coalesceTask?.cancel()
+            // Single-flight (cluster I): if a flush is already pending, just
+            // mark that another should run on completion and return. The
+            // previous cancel-then-replace pattern raced with `flushTrailing`
+            // re-entrant runs; flipping to a flag avoids that entirely.
+            if coalesceTask != nil {
+                pendingTrailingFlush = true
+                return
+            }
             let delay = throttleSeconds - now.timeIntervalSince(last)
             coalesceTask = Task { [weak self] in
                 try? await Task.sleep(nanoseconds: UInt64(max(0, delay) * 1_000_000_000))
@@ -297,11 +391,27 @@ actor KGProgressPublisher {
     }
 
     private func flushTrailing() async {
-        coalesceTask = nil
         // Re-sample so the trailing emit reflects the freshest DB state, not
-        // the snapshot that was queued at throttle-start.
+        // the snapshot that was queued at throttle-start. If the DB read
+        // fails we skip the emit — a 0/0 snapshot would lie.
         let snap = await sample()
-        deliver(snap)
+        // Single-flight: re-check for queued work BEFORE clearing the slot
+        // (cluster I). If another tick landed during the sample, run another
+        // pass without spawning a parallel coalesce timer.
+        let needsAnother = pendingTrailingFlush
+        pendingTrailingFlush = false
+        coalesceTask = nil
+        if let snap = snap {
+            deliver(snap)
+        }
+        if needsAnother {
+            // Re-emit the latest state immediately. Use Task here to avoid
+            // unbounded recursion if multiple flushes pile up; the actor
+            // reentry will serialize them anyway.
+            Task { [weak self] in
+                await self?.flushTrailing()
+            }
+        }
     }
 
     private func deliver(_ snapshot: KGBuildProgress) {

--- a/Desktop/Tests/KGExtractorTests.swift
+++ b/Desktop/Tests/KGExtractorTests.swift
@@ -1,0 +1,234 @@
+import XCTest
+@testable import Omi_Computer
+
+// MARK: - Fake LLM
+
+/// In-memory `AutonomousLLMCalling` that returns scripted replies and records
+/// every call for assertion. Sequencing: `replies` are popped in FIFO order
+/// per call. If exhausted, the test fails fast.
+private final class FakeAutonomousLLM: AutonomousLLMCalling, @unchecked Sendable {
+  struct Call: Equatable {
+    let prompt: String
+    let maxTokens: Int
+    let temperature: Double
+    let seed: UInt64?
+  }
+
+  private let lock = NSLock()
+  private var queue: [String]
+  private(set) var calls: [Call] = []
+
+  init(replies: [String]) { self.queue = replies }
+
+  func extractJSON(prompt: String, maxTokens: Int, temperature: Double, seed: UInt64?) async throws -> String {
+    lock.lock()
+    defer { lock.unlock() }
+    calls.append(Call(prompt: prompt, maxTokens: maxTokens, temperature: temperature, seed: seed))
+    guard !queue.isEmpty else {
+      XCTFail("FakeAutonomousLLM ran out of replies on call #\(calls.count)")
+      return ""
+    }
+    return queue.removeFirst()
+  }
+}
+
+// MARK: - Tests
+
+final class KGExtractorTests: XCTestCase {
+
+  // 1. Happy path strict JSON
+  func test_happyPath_strictJSON_returnsParsed() async throws {
+    let json = """
+      {"nodes":[
+        {"id":"alice","label":"Alice","type":"person","aliases":[]},
+        {"id":"acme","label":"Acme","type":"organization","aliases":[]}
+      ],"edges":[
+        {"source":"alice","target":"acme","label":"works at"}
+      ]}
+      """
+    let fake = FakeAutonomousLLM(replies: [json])
+    let extractor = KGExtractor(llm: fake)
+    let result = try await extractor.extract(memoryId: 1, content: "Alice works at Acme.", sourceApp: nil)
+
+    XCTAssertEqual(result.outcome, .parsed)
+    XCTAssertEqual(result.nodes.count, 2)
+    XCTAssertEqual(result.edges.count, 1)
+    XCTAssertEqual(result.nodes[0].id, "alice")
+    XCTAssertEqual(result.nodes[0].type, .person)
+  }
+
+  // 2. Code-fenced JSON -> .parsed (after strip)
+  func test_codeFencedJSON_returnsParsed() async throws {
+    let fenced = """
+      ```json
+      {"nodes":[{"id":"bob","label":"Bob","type":"person","aliases":[]}],"edges":[]}
+      ```
+      """
+    let fake = FakeAutonomousLLM(replies: [fenced])
+    let extractor = KGExtractor(llm: fake)
+    let result = try await extractor.extract(memoryId: 2, content: "Bob said hi.", sourceApp: nil)
+    XCTAssertEqual(result.outcome, .parsed)
+    XCTAssertEqual(result.nodes.first?.id, "bob")
+  }
+
+  // 3. Prose-wrapped JSON -> .recovered
+  func test_proseWrappedJSON_returnsRecovered() async throws {
+    let raw = """
+      Sure, here is the graph:
+      {"nodes":[{"id":"carol","label":"Carol","type":"person","aliases":[]}],"edges":[]}
+      Hope that helps!
+      """
+    let fake = FakeAutonomousLLM(replies: [raw])
+    let extractor = KGExtractor(llm: fake)
+    let result = try await extractor.extract(memoryId: 3, content: "Carol called.", sourceApp: nil)
+    XCTAssertEqual(result.outcome, .recovered)
+    XCTAssertEqual(result.nodes.first?.id, "carol")
+  }
+
+  // 4. Truncated mid-object twice -> .failed(.lengthTruncatedTwice)
+  func test_truncatedTwice_returnsFailedLengthTruncatedTwice() async throws {
+    let truncated = "{\"nodes\":[{\"id\":\"da" + KGExtractor.lengthTruncationMarker
+    let fake = FakeAutonomousLLM(replies: [truncated, truncated])
+    let extractor = KGExtractor(llm: fake)
+    let result = try await extractor.extract(memoryId: 4, content: "Some content.", sourceApp: nil)
+    XCTAssertEqual(result.outcome, .failed(reason: .lengthTruncatedTwice))
+    XCTAssertEqual(fake.calls.count, 2)
+    // Second call must use 2x maxTokens.
+    XCTAssertEqual(fake.calls[1].maxTokens, fake.calls[0].maxTokens * 2)
+  }
+
+  // 4b. Truncated then retry succeeds -> .truncatedRetried
+  func test_truncatedThenRecovered_returnsTruncatedRetried() async throws {
+    let truncated = "{\"nodes\":[{\"id\":\"da" + KGExtractor.lengthTruncationMarker
+    let good = """
+      {"nodes":[{"id":"dan","label":"Dan","type":"person","aliases":[]}],"edges":[]}
+      """
+    let fake = FakeAutonomousLLM(replies: [truncated, good])
+    let extractor = KGExtractor(llm: fake)
+    let result = try await extractor.extract(memoryId: 5, content: "Dan came over.", sourceApp: nil)
+    XCTAssertEqual(result.outcome, .truncatedRetried)
+    XCTAssertEqual(result.nodes.first?.id, "dan")
+  }
+
+  // 5. All-invalid enum -> .empty(.allNodesInvalid)
+  func test_allInvalidEnum_returnsEmptyAllNodesInvalid() async throws {
+    let raw = """
+      {"nodes":[
+        {"id":"x","label":"X","type":"alien","aliases":[]},
+        {"id":"y","label":"Y","type":"vehicle","aliases":[]}
+      ],"edges":[]}
+      """
+    let fake = FakeAutonomousLLM(replies: [raw])
+    let extractor = KGExtractor(llm: fake)
+    let result = try await extractor.extract(memoryId: 6, content: "Some content.", sourceApp: nil)
+    XCTAssertEqual(result.outcome, .empty(reason: .allNodesInvalid))
+    XCTAssertTrue(result.nodes.isEmpty)
+    XCTAssertTrue(result.edges.isEmpty)
+  }
+
+  // 6. Edges referencing missing node ids -> dropped, valid kept
+  func test_edgesReferencingMissingIds_areDropped() async throws {
+    let raw = """
+      {"nodes":[
+        {"id":"eve","label":"Eve","type":"person","aliases":[]},
+        {"id":"frank","label":"Frank","type":"person","aliases":[]}
+      ],"edges":[
+        {"source":"eve","target":"frank","label":"knows"},
+        {"source":"eve","target":"ghost","label":"haunts"},
+        {"source":"phantom","target":"frank","label":"chases"}
+      ]}
+      """
+    let fake = FakeAutonomousLLM(replies: [raw])
+    let extractor = KGExtractor(llm: fake)
+    let result = try await extractor.extract(memoryId: 7, content: "Eve knows Frank.", sourceApp: nil)
+    XCTAssertEqual(result.outcome, .parsed)
+    XCTAssertEqual(result.nodes.count, 2)
+    XCTAssertEqual(result.edges.count, 1)
+    XCTAssertEqual(result.edges.first?.label, "knows")
+  }
+
+  // 7. Empty input -> .empty(.contentTooShort), no LLM call
+  func test_emptyInput_returnsContentTooShort_noLLMCall() async throws {
+    let fake = FakeAutonomousLLM(replies: [])
+    let extractor = KGExtractor(llm: fake)
+    let result1 = try await extractor.extract(memoryId: 8, content: "", sourceApp: nil)
+    let result2 = try await extractor.extract(memoryId: 9, content: "   \n\t  ", sourceApp: "Mail")
+    XCTAssertEqual(result1.outcome, .empty(reason: .contentTooShort))
+    XCTAssertEqual(result2.outcome, .empty(reason: .contentTooShort))
+    XCTAssertEqual(fake.calls.count, 0)
+  }
+
+  // 8. Chunked input: multiple extractJSON calls, union deduped by id
+  func test_chunkedInput_callsMultipleAndDedupes() async throws {
+    let chunkA = """
+      {"nodes":[
+        {"id":"shared","label":"Shared","type":"thing","aliases":[]},
+        {"id":"only-a","label":"OnlyA","type":"concept","aliases":[]}
+      ],"edges":[
+        {"source":"only-a","target":"shared","label":"refers"}
+      ]}
+      """
+    let chunkB = """
+      {"nodes":[
+        {"id":"shared","label":"Shared","type":"thing","aliases":[]},
+        {"id":"only-b","label":"OnlyB","type":"concept","aliases":[]}
+      ],"edges":[
+        {"source":"only-b","target":"shared","label":"refers"}
+      ]}
+      """
+    // 180 chars with maxContentChars=100, overlap=20 -> 2 chunks (0..100, 80..180).
+    let fake = FakeAutonomousLLM(replies: [chunkA, chunkB])
+    let extractor = KGExtractor(llm: fake, maxContentChars: 100, chunkOverlapChars: 20)
+    let big = String(repeating: "abcdefghij", count: 18) // 180 chars
+    let result = try await extractor.extract(memoryId: 10, content: big, sourceApp: nil)
+
+    XCTAssertEqual(fake.calls.count, 2)
+    XCTAssertEqual(result.outcome, .parsed)
+    let ids = Set(result.nodes.map { $0.id })
+    XCTAssertEqual(ids, Set(["shared", "only-a", "only-b"]))
+    // Edges from both chunks should both survive (different source ids).
+    XCTAssertEqual(result.edges.count, 2)
+  }
+
+  // 9. Determinism: same input + same fake -> identical output bytes
+  //    AND temperature/seed are passed through.
+  func test_determinism_passesTemperatureAndSeed() async throws {
+    let json = """
+      {"nodes":[{"id":"zoe","label":"Zoe","type":"person","aliases":[]}],"edges":[]}
+      """
+    let fake1 = FakeAutonomousLLM(replies: [json])
+    let extractor1 = KGExtractor(llm: fake1)
+    let r1 = try await extractor1.extract(memoryId: 11, content: "Zoe arrived.", sourceApp: nil)
+
+    let fake2 = FakeAutonomousLLM(replies: [json])
+    let extractor2 = KGExtractor(llm: fake2)
+    let r2 = try await extractor2.extract(memoryId: 11, content: "Zoe arrived.", sourceApp: nil)
+
+    XCTAssertEqual(r1.nodes, r2.nodes)
+    XCTAssertEqual(r1.edges, r2.edges)
+    XCTAssertEqual(r1.outcome, r2.outcome)
+
+    XCTAssertEqual(fake1.calls.first?.temperature, 0.0)
+    XCTAssertEqual(fake1.calls.first?.seed, KGExtractor.fixedSeed)
+  }
+
+  // Bonus: model returns explicit empty arrays -> .empty(.modelReturnedNone)
+  func test_modelReturnsEmptyArrays_returnsModelReturnedNone() async throws {
+    let raw = """
+      {"nodes":[],"edges":[]}
+      """
+    let fake = FakeAutonomousLLM(replies: [raw])
+    let extractor = KGExtractor(llm: fake)
+    let result = try await extractor.extract(memoryId: 12, content: "Quiet day.", sourceApp: nil)
+    XCTAssertEqual(result.outcome, .empty(reason: .modelReturnedNone))
+  }
+
+  // Bonus: jsonUnsalvageable when no braces at all and not truncated.
+  func test_garbageReply_returnsJsonUnsalvageable() async throws {
+    let raw = "I am not going to give you JSON, sorry."
+    let fake = FakeAutonomousLLM(replies: [raw])
+    let extractor = KGExtractor(llm: fake)
+    let result = try await extractor.extract(memoryId: 13, content: "Whatever.", sourceApp: nil)
+    XCTAssertEqual(result.outcome, .failed(reason: .jsonUnsalvageable))
+  }
+}

--- a/Desktop/Tests/KGWiringTests.swift
+++ b/Desktop/Tests/KGWiringTests.swift
@@ -1,0 +1,198 @@
+import XCTest
+@testable import Omi_Computer
+
+/// Tests for Lane C wiring: dedup-key contract, payload shape,
+/// empty-state classifier, scheduler readiness gating, and progress
+/// publisher invariants.
+///
+/// DB-bound paths (extractor outcomes → KnowledgeGraphStorage upsert) are
+/// covered by `KnowledgeGraphStorageTests` and `KGExtractorTests`. These
+/// tests focus on the wiring seams Lane C owns.
+final class KGWiringTests: XCTestCase {
+
+    // MARK: - Dedup key contract
+
+    func testDedupKeyMatchesColonStyleConvention() {
+        XCTAssertEqual(
+            KGBackfillService.dedupKey(forMemoryId: 42),
+            "extractKG:42",
+            "Dedup key must be `extractKG:<id>` to match the summarize/<id> convention used by the scheduler."
+        )
+    }
+
+    func testDedupKeyDistinctPerMemoryId() {
+        let a = KGBackfillService.dedupKey(forMemoryId: 1)
+        let b = KGBackfillService.dedupKey(forMemoryId: 2)
+        XCTAssertNotEqual(a, b)
+    }
+
+    func testDedupKeyHandlesNegativeAndLargeIds() {
+        XCTAssertEqual(KGBackfillService.dedupKey(forMemoryId: -1), "extractKG:-1")
+        XCTAssertEqual(
+            KGBackfillService.dedupKey(forMemoryId: Int64.max),
+            "extractKG:\(Int64.max)"
+        )
+    }
+
+    // MARK: - Migration key
+
+    func testMigrationKeyIsKgBackfillV1() {
+        XCTAssertEqual(KGBackfillService.migrationKey, "kg_backfill_v1")
+    }
+
+    // MARK: - Pending work label
+
+    func testWorkLabelDecodesExtractKGPayload() throws {
+        let payload = try JSONSerialization.data(withJSONObject: ["memory_id": 123])
+        let work = PendingWork(
+            kind: .extractKG,
+            payload: payload
+        )
+        let label = WorkLabels.humanLabel(work)
+        XCTAssertTrue(
+            label.contains("123"),
+            "extractKG label must include the memory id; got: \(label)"
+        )
+        XCTAssertTrue(
+            label.lowercased().contains("brain map") || label.lowercased().contains("entit"),
+            "extractKG label should reference brain map / entities; got: \(label)"
+        )
+    }
+
+    func testWorkLabelExtractKGFallsBackOnUndecodablePayload() {
+        let work = PendingWork(
+            kind: .extractKG,
+            payload: Data("not-json".utf8)
+        )
+        let label = WorkLabels.humanLabel(work)
+        XCTAssertFalse(label.isEmpty)
+    }
+
+    // MARK: - Scheduler readiness gating
+
+    func testExtractKGRequiresAutonomousReadiness() {
+        // The autonomous-readiness gate determines whether the scheduler
+        // demands MLX-loaded + idle/lock state before draining. KG
+        // extraction calls into the local LLM, so it must opt in.
+        // We can't access fileprivate `requiresAutonomousReadiness` directly
+        // here, but the contract is exercised end-to-end by
+        // `BatteryAwareSchedulerReadinessTests`. This guard is a smoke check
+        // that the enum cases needed by Lane C exist.
+        let kinds = PendingWork.Kind.allCases
+        XCTAssertTrue(
+            kinds.contains(.extractKG),
+            "PendingWork.Kind.extractKG must be present so handlers can register."
+        )
+        XCTAssertTrue(kinds.contains(.summarize))
+    }
+
+    // MARK: - Empty-state classifier
+
+    func testClassifierReturnsBuildingWhilePending() {
+        for state: BuildState in [.building, .pausedThermal, .pausedBattery, .pausedNotIdle, .modelNotReady] {
+            let mode = BrainMapEmptyStateClassifier.mode(
+                state: state,
+                totalNodes: 0,
+                totalMemories: 100,
+                processedMemories: 5
+            )
+            XCTAssertEqual(
+                mode, .backfillRunningNoNodesYet,
+                "State \(state) with pending work should report backfillRunningNoNodesYet"
+            )
+        }
+    }
+
+    func testClassifierReturnsNotStartedWhenIdleAndUntouched() {
+        let mode = BrainMapEmptyStateClassifier.mode(
+            state: .idleNoWork,
+            totalNodes: 0,
+            totalMemories: 50,
+            processedMemories: 0
+        )
+        XCTAssertEqual(mode, .backfillNotStarted)
+    }
+
+    func testClassifierReturnsCompleteEmptyWhenIdleAndProcessedAllZero() {
+        let mode = BrainMapEmptyStateClassifier.mode(
+            state: .idleNoWork,
+            totalNodes: 0,
+            totalMemories: 50,
+            processedMemories: 50
+        )
+        XCTAssertEqual(mode, .backfillCompleteEmpty)
+    }
+
+    func testClassifierReturnsCompleteEmptyWhenNoMemoriesAtAll() {
+        let mode = BrainMapEmptyStateClassifier.mode(
+            state: .idleNoWork,
+            totalNodes: 0,
+            totalMemories: 0,
+            processedMemories: 0
+        )
+        XCTAssertEqual(mode, .backfillCompleteEmpty)
+    }
+
+    // MARK: - Build progress equality / decoding
+
+    func testBuildProgressEquatableSemantics() {
+        let a = KGBuildProgress(
+            totalMemories: 10, processedMemories: 4, succeededMemories: 3,
+            totalNodes: 7, state: .building, etaSeconds: 12
+        )
+        let b = KGBuildProgress(
+            totalMemories: 10, processedMemories: 4, succeededMemories: 3,
+            totalNodes: 7, state: .building, etaSeconds: 12
+        )
+        let c = KGBuildProgress(
+            totalMemories: 10, processedMemories: 5, succeededMemories: 3,
+            totalNodes: 7, state: .building, etaSeconds: 12
+        )
+        XCTAssertEqual(a, b)
+        XCTAssertNotEqual(a, c)
+    }
+
+    // MARK: - Progress publisher
+
+    func testProgressPublisherDeliversAfterTick() async {
+        // The publisher is a singleton actor backed by the real DB. We
+        // assert only that subscribing + ticking yields at least one
+        // snapshot (the publisher replays its last cached snapshot on
+        // subscribe and emits on tick).
+        let publisher = KGProgressPublisher.shared
+        let stream = await publisher.stream
+
+        let task = Task<KGBuildProgress?, Never> {
+            for await snap in stream {
+                return snap
+            }
+            return nil
+        }
+
+        // Trigger a sample.
+        await publisher.tick()
+
+        let received = await withTaskGroup(of: KGBuildProgress?.self) { group in
+            group.addTask { await task.value }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: 2_000_000_000)
+                return nil
+            }
+            let first = await group.next() ?? nil
+            group.cancelAll()
+            return first
+        }
+        task.cancel()
+
+        XCTAssertNotNil(received, "Publisher must yield a snapshot after tick().")
+    }
+
+    func testProgressPublisherRecordDrainSampleDoesNotCrash() async {
+        // Recording samples before subscribers attach must be safe.
+        await KGProgressPublisher.shared.recordDrainSample(seconds: 0.5)
+        await KGProgressPublisher.shared.recordDrainSample(seconds: 0.4)
+        await KGProgressPublisher.shared.recordDrainSample(seconds: 0.6)
+        // No crash + tick still works.
+        await KGProgressPublisher.shared.tick()
+    }
+}

--- a/Desktop/Tests/KGWiringTests.swift
+++ b/Desktop/Tests/KGWiringTests.swift
@@ -92,7 +92,6 @@ final class KGWiringTests: XCTestCase {
         for state: BuildState in [.building, .pausedThermal, .pausedBattery, .pausedNotIdle, .modelNotReady] {
             let mode = BrainMapEmptyStateClassifier.mode(
                 state: state,
-                totalNodes: 0,
                 totalMemories: 100,
                 processedMemories: 5
             )
@@ -106,7 +105,6 @@ final class KGWiringTests: XCTestCase {
     func testClassifierReturnsNotStartedWhenIdleAndUntouched() {
         let mode = BrainMapEmptyStateClassifier.mode(
             state: .idleNoWork,
-            totalNodes: 0,
             totalMemories: 50,
             processedMemories: 0
         )
@@ -116,7 +114,6 @@ final class KGWiringTests: XCTestCase {
     func testClassifierReturnsCompleteEmptyWhenIdleAndProcessedAllZero() {
         let mode = BrainMapEmptyStateClassifier.mode(
             state: .idleNoWork,
-            totalNodes: 0,
             totalMemories: 50,
             processedMemories: 50
         )
@@ -126,7 +123,6 @@ final class KGWiringTests: XCTestCase {
     func testClassifierReturnsCompleteEmptyWhenNoMemoriesAtAll() {
         let mode = BrainMapEmptyStateClassifier.mode(
             state: .idleNoWork,
-            totalNodes: 0,
             totalMemories: 0,
             processedMemories: 0
         )
@@ -194,5 +190,94 @@ final class KGWiringTests: XCTestCase {
         await KGProgressPublisher.shared.recordDrainSample(seconds: 0.6)
         // No crash + tick still works.
         await KGProgressPublisher.shared.tick()
+    }
+
+    // MARK: - Cluster D3 — saturating progress invariants
+
+    func testBuildProgressClampsProcessedOverTotal() {
+        let p = KGBuildProgress(
+            totalMemories: 10,
+            processedMemories: 15,   // race window, clamp to total
+            succeededMemories: 12,
+            totalNodes: 0,
+            state: .building,
+            etaSeconds: nil
+        )
+        XCTAssertEqual(p.totalMemories, 10)
+        XCTAssertEqual(p.processedMemories, 10, "processed must clamp to total")
+        XCTAssertEqual(p.succeededMemories, 10, "succeeded must clamp to processed")
+    }
+
+    func testBuildProgressClampsSucceededOverProcessed() {
+        let p = KGBuildProgress(
+            totalMemories: 10,
+            processedMemories: 4,
+            succeededMemories: 9,    // bogus — succeeded must trail processed
+            totalNodes: 0,
+            state: .building,
+            etaSeconds: nil
+        )
+        XCTAssertEqual(p.processedMemories, 4)
+        XCTAssertEqual(p.succeededMemories, 4, "succeeded must clamp to processed")
+    }
+
+    func testBuildProgressClampsNegativeInputs() {
+        let p = KGBuildProgress(
+            totalMemories: -1,
+            processedMemories: -5,
+            succeededMemories: -3,
+            totalNodes: -2,
+            state: .idleNoWork,
+            etaSeconds: nil
+        )
+        XCTAssertEqual(p.totalMemories, 0)
+        XCTAssertEqual(p.processedMemories, 0)
+        XCTAssertEqual(p.succeededMemories, 0)
+        XCTAssertEqual(p.totalNodes, 0)
+    }
+
+    // MARK: - Cluster H1 — extractKG depth cap
+
+    func testExtractKGNotCapDroppedAtLowDepth() async throws {
+        // Cluster H1: the depthCaps entry for extractKG must be high enough
+        // that a single enqueue at low queue depth doesn't trigger a
+        // cap-drop. We use the recentDrops counter delta to detect cap-drop
+        // — a nil return from `enqueue` could also mean a dedup hit, which
+        // is fine for this assertion.
+        let storage = PendingWorkStorage.shared
+        let dropsBefore = await storage.recentDrops
+
+        let key = "extractKG-test-\(UUID().uuidString)"
+        let payload = try JSONSerialization.data(withJSONObject: ["memory_id": Int64.max])
+        _ = try await storage.enqueue(
+            workType: PendingWork.Kind.extractKG.rawValue,
+            payload: payload,
+            dedupKey: key
+        )
+
+        let dropsAfter = await storage.recentDrops
+        XCTAssertEqual(
+            dropsAfter, dropsBefore,
+            "extractKG must not be cap-dropped at low queue depth (recentDrops bumped)"
+        )
+    }
+
+    // MARK: - Cluster K — classifier no longer takes totalNodes
+
+    func testClassifierIsPureFunctionOfStateAndCounts() {
+        // Same (state, totals) must produce same mode regardless of
+        // anything else — the only inputs are the three params.
+        XCTAssertEqual(
+            BrainMapEmptyStateClassifier.mode(state: .idleNoWork, totalMemories: 5, processedMemories: 0),
+            .backfillNotStarted
+        )
+        XCTAssertEqual(
+            BrainMapEmptyStateClassifier.mode(state: .idleNoWork, totalMemories: 5, processedMemories: 5),
+            .backfillCompleteEmpty
+        )
+        XCTAssertEqual(
+            BrainMapEmptyStateClassifier.mode(state: .building, totalMemories: 5, processedMemories: 2),
+            .backfillRunningNoNodesYet
+        )
     }
 }

--- a/Desktop/Tests/KnowledgeGraphStorageTests.swift
+++ b/Desktop/Tests/KnowledgeGraphStorageTests.swift
@@ -31,6 +31,47 @@ final class KnowledgeGraphStorageTests: XCTestCase {
     private func cleanup(_ memoryIds: [Int64]) async {
         for mid in memoryIds {
             try? await KnowledgeGraphStorage.shared.removeProvenance(forMemoryId: mid)
+            // Also strip the seeded `memories` row so subsequent runs of
+            // these tests don't accumulate fixtures. The B3 guard rejects
+            // upserts against missing/deleted rows, which is why we seed
+            // one in the first place — see `seedMemoryRow`.
+            try? await deleteMemoryRow(id: mid)
+        }
+    }
+
+    /// Insert a minimal `memories` row at the given id so `upsert()`'s
+    /// existence check (Cluster B3) passes. Uses `INSERT OR REPLACE` so a
+    /// stale row from a previous run is overwritten cleanly. Mirrors the
+    /// column set the migration test uses, which is known to match the
+    /// live schema.
+    private func seedMemoryRow(id: Int64) async throws {
+        // Force the migrator to run before requesting the queue. Mirrors the
+        // pattern in `test_migration_addsKGExtractionStatusColumn`.
+        _ = try await KnowledgeGraphStorage.shared.memoriesWithExtractedKGCount()
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+            throw XCTSkip("database queue unavailable")
+        }
+        let now = Date()
+        try await dbQueue.write { db in
+            // Drop any stale row first so we can reuse the id deterministically.
+            try db.execute(sql: "DELETE FROM memories WHERE id = ?", arguments: [id])
+            try db.execute(
+                sql: """
+                    INSERT INTO memories (
+                        id, backendId, backendSynced, content, category,
+                        reviewed, manuallyAdded, isRead, isDismissed, deleted,
+                        createdAt, updatedAt
+                    ) VALUES (?, ?, 0, ?, 'manual', 0, 0, 0, 0, 0, ?, ?)
+                """,
+                arguments: [id, "fixture-\(id)", "fixture for memory \(id)", now, now]
+            )
+        }
+    }
+
+    private func deleteMemoryRow(id: Int64) async throws {
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else { return }
+        try await dbQueue.write { db in
+            try db.execute(sql: "DELETE FROM memories WHERE id = ?", arguments: [id])
         }
     }
 
@@ -119,6 +160,7 @@ final class KnowledgeGraphStorageTests: XCTestCase {
     func test_upsert_atomic_badEdgeRollsBackEverything() async throws {
         let memoryId = nextMemoryId()
         defer { Task { await self.cleanup([memoryId]) } }
+        try await seedMemoryRow(id: memoryId)
 
         let goodNode1 = makeNode(id: "atomic-alpha-\(memoryId)")
         let goodNode2 = makeNode(id: "atomic-beta-\(memoryId)")
@@ -155,6 +197,7 @@ final class KnowledgeGraphStorageTests: XCTestCase {
     func test_upsert_idempotent_secondCallNoOps() async throws {
         let memoryId = nextMemoryId()
         defer { Task { await self.cleanup([memoryId]) } }
+        try await seedMemoryRow(id: memoryId)
 
         let n1 = makeNode(id: "idem-one-\(memoryId)", aliases: ["alias-1"])
         let n2 = makeNode(id: "idem-two-\(memoryId)")
@@ -184,6 +227,8 @@ final class KnowledgeGraphStorageTests: XCTestCase {
         let memA = nextMemoryId()
         let memB = nextMemoryId()
         defer { Task { await self.cleanup([memA, memB]) } }
+        try await seedMemoryRow(id: memA)
+        try await seedMemoryRow(id: memB)
 
         let sharedRaw = "shared-x-\(memA)-\(memB)"
         let nodeA = makeNode(id: sharedRaw, label: "X", aliases: ["a"])
@@ -217,6 +262,8 @@ final class KnowledgeGraphStorageTests: XCTestCase {
         let memA = nextMemoryId()
         let memB = nextMemoryId()
         defer { Task { await self.cleanup([memA, memB]) } }
+        try await seedMemoryRow(id: memA)
+        try await seedMemoryRow(id: memB)
 
         let sharedId = "cascade-shared-\(memA)-\(memB)"
         let aOnlyId = "cascade-aonly-\(memA)"
@@ -255,6 +302,8 @@ final class KnowledgeGraphStorageTests: XCTestCase {
         let memA = nextMemoryId()
         let memB = nextMemoryId()
         defer { Task { await self.cleanup([memA, memB]) } }
+        try await seedMemoryRow(id: memA)
+        try await seedMemoryRow(id: memB)
 
         let baseline = try await KnowledgeGraphStorage.shared.memoriesWithExtractedKGCount()
 
@@ -286,6 +335,7 @@ final class KnowledgeGraphStorageTests: XCTestCase {
     func test_clearAll_wipesProvenanceTables() async throws {
         let memoryId = nextMemoryId()
         // No defer cleanup — clearAll handles it.
+        try await seedMemoryRow(id: memoryId)
 
         _ = try await KnowledgeGraphStorage.shared.upsert(
             memoryId: memoryId,
@@ -356,5 +406,88 @@ final class KnowledgeGraphStorageTests: XCTestCase {
             )
         }
         XCTAssertNil(status, "kg_extraction_status must default to NULL on a fresh memory row")
+    }
+
+    // MARK: - 8. Cluster B3 — upsert aborts cleanly against missing memory
+
+    func test_upsert_abortsWhenMemoryMissing() async throws {
+        // No seed — memory row never existed. Upsert must return zero
+        // counts and write no provenance.
+        let memoryId = nextMemoryId()
+        defer { Task { await self.cleanup([memoryId]) } }
+
+        let result = try await KnowledgeGraphStorage.shared.upsert(
+            memoryId: memoryId,
+            nodes: [makeNode(id: "missing-\(memoryId)")],
+            edges: []
+        )
+        XCTAssertEqual(result.nodesInserted, 0,
+                       "upsert against a missing memory must not insert nodes")
+        XCTAssertEqual(result.nodesMerged, 0)
+        XCTAssertEqual(result.edgesInserted, 0)
+
+        let exists = try await nodeExists("missing-\(memoryId)")
+        XCTAssertFalse(exists, "no node row should be written for a missing memory")
+
+        let provCount = try await nodeProvenanceRowCount(memoryId: memoryId)
+        XCTAssertEqual(provCount, 0, "no provenance should be written for a missing memory")
+    }
+
+    func test_upsert_abortsWhenMemorySoftDeleted() async throws {
+        let memoryId = nextMemoryId()
+        defer { Task { await self.cleanup([memoryId]) } }
+
+        // Seed and immediately mark deleted = 1.
+        try await seedMemoryRow(id: memoryId)
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+            return XCTFail("database queue unavailable")
+        }
+        try await dbQueue.write { db in
+            try db.execute(
+                sql: "UPDATE memories SET deleted = 1 WHERE id = ?",
+                arguments: [memoryId]
+            )
+        }
+
+        let result = try await KnowledgeGraphStorage.shared.upsert(
+            memoryId: memoryId,
+            nodes: [makeNode(id: "deleted-\(memoryId)")],
+            edges: []
+        )
+        XCTAssertEqual(result.nodesInserted, 0,
+                       "upsert against a soft-deleted memory must abort")
+        let exists = try await nodeExists("deleted-\(memoryId)")
+        XCTAssertFalse(exists, "no node row should be written for a deleted memory")
+    }
+
+    // MARK: - 9. Cluster B2 — terminalStatus written atomically with provenance
+
+    func test_upsert_terminalStatusWrittenAtomicallyWithProvenance() async throws {
+        let memoryId = nextMemoryId()
+        defer { Task { await self.cleanup([memoryId]) } }
+        try await seedMemoryRow(id: memoryId)
+
+        _ = try await KnowledgeGraphStorage.shared.upsert(
+            memoryId: memoryId,
+            nodes: [makeNode(id: "atomic-status-\(memoryId)")],
+            edges: [],
+            terminalStatus: .succeeded
+        )
+
+        let provCount = try await nodeProvenanceRowCount(memoryId: memoryId)
+        XCTAssertEqual(provCount, 1)
+
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+            return XCTFail("database queue unavailable")
+        }
+        let status: String? = try await dbQueue.read { db in
+            try String.fetchOne(
+                db,
+                sql: "SELECT kg_extraction_status FROM memories WHERE id = ?",
+                arguments: [memoryId]
+            )
+        }
+        XCTAssertEqual(status, KGExtractionStatus.succeeded.rawValue,
+                       "terminalStatus must be written in the same transaction as provenance")
     }
 }

--- a/Desktop/Tests/KnowledgeGraphStorageTests.swift
+++ b/Desktop/Tests/KnowledgeGraphStorageTests.swift
@@ -1,0 +1,360 @@
+import XCTest
+import GRDB
+@testable import Omi_Computer
+
+/// Tests for `KnowledgeGraphStorage`'s provenance + atomic incremental
+/// upsert seam. Scoped against `KnowledgeGraphStorage.shared` and the real
+/// `RewindDatabase.shared` (matches the existing storage-test convention,
+/// e.g. `PendingWorkStorageDelegateTests`).
+///
+/// Each test claims a unique memoryId range so concurrent test runs and
+/// stale rows from other test classes don't collide.
+final class KnowledgeGraphStorageTests: XCTestCase {
+
+    /// A high, distinctive base so we don't collide with any onboarding
+    /// sentinel (-1) or real memory rowids inserted by other tests.
+    private static let memoryIdBase: Int64 = 9_000_000
+
+    /// Per-test unique memoryId, derived from a shared atomic counter so two
+    /// methods in the same suite run never reuse the same id.
+    private nonisolated(unsafe) static var counter: Int64 = 0
+    private static let counterLock = NSLock()
+
+    private func nextMemoryId() -> Int64 {
+        Self.counterLock.lock(); defer { Self.counterLock.unlock() }
+        Self.counter += 1
+        return Self.memoryIdBase + Self.counter
+    }
+
+    /// Remove provenance for any memory ids this test created so subsequent
+    /// runs (and other tests) start clean.
+    private func cleanup(_ memoryIds: [Int64]) async {
+        for mid in memoryIds {
+            try? await KnowledgeGraphStorage.shared.removeProvenance(forMemoryId: mid)
+        }
+    }
+
+    private func makeNode(
+        id: String,
+        label: String? = nil,
+        type: KnowledgeGraphNodeType = .concept,
+        aliases: [String] = []
+    ) -> ExtractedKGNode {
+        ExtractedKGNode(id: id, label: label ?? id, type: type, aliases: aliases)
+    }
+
+    private func nodeAliases(forCanonicalId nodeId: String) async throws -> [String] {
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+            throw XCTSkip("database queue unavailable")
+        }
+        return try await dbQueue.read { db in
+            let json = try String.fetchOne(
+                db,
+                sql: "SELECT aliasesJson FROM local_kg_nodes WHERE nodeId = ?",
+                arguments: [nodeId]
+            )
+            guard let json = json,
+                  let data = json.data(using: .utf8),
+                  let parsed = try? JSONDecoder().decode([String].self, from: data)
+            else { return [] }
+            return parsed
+        }
+    }
+
+    private func nodeExists(_ nodeId: String) async throws -> Bool {
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+            throw XCTSkip("database queue unavailable")
+        }
+        return try await dbQueue.read { db in
+            let count = try Int.fetchOne(
+                db,
+                sql: "SELECT COUNT(*) FROM local_kg_nodes WHERE nodeId = ?",
+                arguments: [nodeId]
+            ) ?? 0
+            return count > 0
+        }
+    }
+
+    private func provenanceCount(memoryId: Int64, nodeId: String) async throws -> Int {
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+            throw XCTSkip("database queue unavailable")
+        }
+        return try await dbQueue.read { db in
+            try Int.fetchOne(
+                db,
+                sql: "SELECT COUNT(*) FROM local_kg_node_sources WHERE memoryId = ? AND nodeId = ?",
+                arguments: [memoryId, nodeId]
+            ) ?? 0
+        }
+    }
+
+    private func nodeProvenanceRowCount(memoryId: Int64) async throws -> Int {
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+            throw XCTSkip("database queue unavailable")
+        }
+        return try await dbQueue.read { db in
+            try Int.fetchOne(
+                db,
+                sql: "SELECT COUNT(*) FROM local_kg_node_sources WHERE memoryId = ?",
+                arguments: [memoryId]
+            ) ?? 0
+        }
+    }
+
+    private func edgeProvenanceRowCount(memoryId: Int64) async throws -> Int {
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+            throw XCTSkip("database queue unavailable")
+        }
+        return try await dbQueue.read { db in
+            try Int.fetchOne(
+                db,
+                sql: "SELECT COUNT(*) FROM local_kg_edge_sources WHERE memoryId = ?",
+                arguments: [memoryId]
+            ) ?? 0
+        }
+    }
+
+    // MARK: - 1. Atomic: bad input rolls back the whole batch
+
+    func test_upsert_atomic_badEdgeRollsBackEverything() async throws {
+        let memoryId = nextMemoryId()
+        defer { Task { await self.cleanup([memoryId]) } }
+
+        let goodNode1 = makeNode(id: "atomic-alpha-\(memoryId)")
+        let goodNode2 = makeNode(id: "atomic-beta-\(memoryId)")
+
+        // An edge with empty target id — the seam validates inputs before
+        // touching the DB and throws, so nothing should be persisted.
+        let badEdge = ExtractedKGEdge(
+            sourceId: goodNode1.id,
+            targetId: "",
+            label: "relates-to"
+        )
+
+        do {
+            _ = try await KnowledgeGraphStorage.shared.upsert(
+                memoryId: memoryId,
+                nodes: [goodNode1, goodNode2],
+                edges: [badEdge]
+            )
+            XCTFail("upsert should have thrown for invalid edge")
+        } catch {
+            // expected
+        }
+
+        let alphaExists = try await nodeExists("atomic-alpha-\(memoryId)")
+        let betaExists = try await nodeExists("atomic-beta-\(memoryId)")
+        XCTAssertFalse(alphaExists, "no nodes should be inserted when batch fails")
+        XCTAssertFalse(betaExists, "no nodes should be inserted when batch fails")
+        let provCount = try await nodeProvenanceRowCount(memoryId: memoryId)
+        XCTAssertEqual(provCount, 0, "no provenance rows should be written when batch fails")
+    }
+
+    // MARK: - 2. Idempotent: same batch twice → no duplicate rows, 0 inserts on second call
+
+    func test_upsert_idempotent_secondCallNoOps() async throws {
+        let memoryId = nextMemoryId()
+        defer { Task { await self.cleanup([memoryId]) } }
+
+        let n1 = makeNode(id: "idem-one-\(memoryId)", aliases: ["alias-1"])
+        let n2 = makeNode(id: "idem-two-\(memoryId)")
+        let e1 = ExtractedKGEdge(sourceId: n1.id, targetId: n2.id, label: "knows")
+
+        let first = try await KnowledgeGraphStorage.shared.upsert(
+            memoryId: memoryId, nodes: [n1, n2], edges: [e1]
+        )
+        XCTAssertEqual(first.nodesInserted, 2)
+        XCTAssertEqual(first.nodesMerged, 0)
+        XCTAssertEqual(first.edgesInserted, 1)
+
+        let second = try await KnowledgeGraphStorage.shared.upsert(
+            memoryId: memoryId, nodes: [n1, n2], edges: [e1]
+        )
+        XCTAssertEqual(second.nodesInserted, 0, "no new nodes on second identical call")
+        XCTAssertEqual(second.nodesMerged, 2, "both existing nodes merge as no-op")
+        XCTAssertEqual(second.edgesInserted, 0, "no new edges on second identical call")
+
+        let provN1 = try await provenanceCount(memoryId: memoryId, nodeId: "idem-one-\(memoryId)")
+        XCTAssertEqual(provN1, 1, "no duplicate provenance rows after second call")
+    }
+
+    // MARK: - 3. Shared-node merge across memories
+
+    func test_upsert_sharedNode_mergesAliasesAcrossMemories() async throws {
+        let memA = nextMemoryId()
+        let memB = nextMemoryId()
+        defer { Task { await self.cleanup([memA, memB]) } }
+
+        let sharedRaw = "shared-x-\(memA)-\(memB)"
+        let nodeA = makeNode(id: sharedRaw, label: "X", aliases: ["a"])
+        let nodeB = makeNode(id: sharedRaw, label: "X", aliases: ["b"])
+
+        _ = try await KnowledgeGraphStorage.shared.upsert(
+            memoryId: memA, nodes: [nodeA], edges: []
+        )
+        let secondResult = try await KnowledgeGraphStorage.shared.upsert(
+            memoryId: memB, nodes: [nodeB], edges: []
+        )
+        XCTAssertEqual(secondResult.nodesInserted, 0,
+                       "second memory inserts the shared node should be a merge, not insert")
+        XCTAssertEqual(secondResult.nodesMerged, 1)
+
+        // Both provenance rows must exist.
+        let provA = try await provenanceCount(memoryId: memA, nodeId: sharedRaw)
+        let provB = try await provenanceCount(memoryId: memB, nodeId: sharedRaw)
+        XCTAssertEqual(provA, 1)
+        XCTAssertEqual(provB, 1)
+
+        // Aliases merged into a set {a, b}.
+        let aliases = try await nodeAliases(forCanonicalId: sharedRaw)
+        XCTAssertEqual(Set(aliases), Set(["a", "b"]),
+                       "node aliases must be the union across memories")
+    }
+
+    // MARK: - 4. removeProvenance cascades selectively
+
+    func test_removeProvenance_cascadesOnlyOrphans() async throws {
+        let memA = nextMemoryId()
+        let memB = nextMemoryId()
+        defer { Task { await self.cleanup([memA, memB]) } }
+
+        let sharedId = "cascade-shared-\(memA)-\(memB)"
+        let aOnlyId = "cascade-aonly-\(memA)"
+
+        _ = try await KnowledgeGraphStorage.shared.upsert(
+            memoryId: memA,
+            nodes: [makeNode(id: sharedId), makeNode(id: aOnlyId)],
+            edges: []
+        )
+        _ = try await KnowledgeGraphStorage.shared.upsert(
+            memoryId: memB,
+            nodes: [makeNode(id: sharedId)],
+            edges: []
+        )
+
+        try await KnowledgeGraphStorage.shared.removeProvenance(forMemoryId: memA)
+
+        // memA's provenance is gone.
+        let memARows = try await nodeProvenanceRowCount(memoryId: memA)
+        XCTAssertEqual(memARows, 0)
+
+        // The aOnly node had only memA as provenance → cascade-deleted.
+        let aOnlyStillExists = try await nodeExists(aOnlyId)
+        XCTAssertFalse(aOnlyStillExists,
+                       "node referenced only by removed memory must be cascade-deleted")
+
+        // The shared node is still referenced by memB → preserved.
+        let sharedStillExists = try await nodeExists(sharedId)
+        XCTAssertTrue(sharedStillExists,
+                      "node still referenced by another memory must be preserved")
+    }
+
+    // MARK: - 5. memoriesWithExtractedKGCount excludes onboarding sentinel
+
+    func test_memoriesWithExtractedKGCount_excludesOnboardingSentinel() async throws {
+        let memA = nextMemoryId()
+        let memB = nextMemoryId()
+        defer { Task { await self.cleanup([memA, memB]) } }
+
+        let baseline = try await KnowledgeGraphStorage.shared.memoriesWithExtractedKGCount()
+
+        _ = try await KnowledgeGraphStorage.shared.upsert(
+            memoryId: memA,
+            nodes: [makeNode(id: "count-a-\(memA)")],
+            edges: []
+        )
+        _ = try await KnowledgeGraphStorage.shared.upsert(
+            memoryId: memB,
+            nodes: [makeNode(id: "count-b-\(memB)")],
+            edges: []
+        )
+        // Onboarding sentinel — must NOT count.
+        _ = try await KnowledgeGraphStorage.shared.upsert(
+            memoryId: ONBOARDING_SENTINEL,
+            nodes: [makeNode(id: "count-onboarding-\(memA)")],
+            edges: []
+        )
+        defer { Task { await self.cleanup([ONBOARDING_SENTINEL]) } }
+
+        let after = try await KnowledgeGraphStorage.shared.memoriesWithExtractedKGCount()
+        XCTAssertEqual(after - baseline, 2,
+                       "count must increase by exactly the two non-sentinel memories")
+    }
+
+    // MARK: - 6. clearAll wipes provenance tables
+
+    func test_clearAll_wipesProvenanceTables() async throws {
+        let memoryId = nextMemoryId()
+        // No defer cleanup — clearAll handles it.
+
+        _ = try await KnowledgeGraphStorage.shared.upsert(
+            memoryId: memoryId,
+            nodes: [makeNode(id: "wipe-\(memoryId)")],
+            edges: []
+        )
+        let beforeCount = try await nodeProvenanceRowCount(memoryId: memoryId)
+        XCTAssertEqual(beforeCount, 1)
+
+        await KnowledgeGraphStorage.shared.clearAll()
+
+        let afterCount = try await nodeProvenanceRowCount(memoryId: memoryId)
+        XCTAssertEqual(afterCount, 0, "clearAll must wipe local_kg_node_sources")
+
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+            return XCTFail("database queue unavailable")
+        }
+        let edgeRows = try await dbQueue.read { db in
+            try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM local_kg_edge_sources") ?? 0
+        }
+        XCTAssertEqual(edgeRows, 0, "clearAll must wipe local_kg_edge_sources")
+    }
+
+    // MARK: - 7. Migration adds kg_extraction_status column (NULL for fresh row)
+
+    func test_migration_addsKGExtractionStatusColumn() async throws {
+        // Force the migrator to run by reaching the actor (which will
+        // initialize RewindDatabase if not already done).
+        _ = try await KnowledgeGraphStorage.shared.memoriesWithExtractedKGCount()
+
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+            return XCTFail("database queue unavailable")
+        }
+
+        // Verify the column exists.
+        let columnExists = try await dbQueue.read { db -> Bool in
+            let columns = try Row.fetchAll(db, sql: "PRAGMA table_info(memories)")
+            return columns.contains { ($0["name"] as String?) == "kg_extraction_status" }
+        }
+        XCTAssertTrue(columnExists, "memories.kg_extraction_status column must exist after migration")
+
+        // Insert a minimal memory row and confirm the new column reads as NULL.
+        let now = Date()
+        let probeKey = "kg-status-probe-\(UUID().uuidString)"
+        let insertedId: Int64 = try await dbQueue.write { db in
+            try db.execute(sql: """
+                INSERT INTO memories (
+                    backendId, backendSynced, content, category,
+                    reviewed, manuallyAdded, isRead, isDismissed, deleted,
+                    createdAt, updatedAt
+                ) VALUES (?, 0, ?, 'manual', 0, 0, 0, 0, 0, ?, ?)
+                """, arguments: [probeKey, "probe", now, now])
+            return db.lastInsertedRowID
+        }
+        defer {
+            Task {
+                try? await dbQueue.write { db in
+                    try db.execute(sql: "DELETE FROM memories WHERE id = ?", arguments: [insertedId])
+                }
+            }
+        }
+
+        let status: String? = try await dbQueue.read { db in
+            try String.fetchOne(
+                db,
+                sql: "SELECT kg_extraction_status FROM memories WHERE id = ?",
+                arguments: [insertedId]
+            )
+        }
+        XCTAssertNil(status, "kg_extraction_status must default to NULL on a fresh memory row")
+    }
+}


### PR DESCRIPTION
## Summary

- Adds an idle-aware Knowledge Graph builder so Brain Map fills in continuously, not just at onboarding. New memories enqueue an `extractKG` work item that drains on device idle via the on-device MLX LLM, with provenance per memory and a one-time backfill for existing memories.
- Three-lane parallel build:
  - **Lane A — Storage**: atomic `upsert(memoryId:nodes:edges:)` + provenance join tables (`local_kg_node_sources`, `local_kg_edge_sources`) + `kg_extraction_status` column. New migration registered in the existing migrator.
  - **Lane B — Extractor**: DI-injectable `KGExtractor` actor, always uses `chatAutonomous` (never `complete()`), strict-JSON + recovery + truncation-retry pipeline, structured `ParseOutcome` (parsed/recovered/truncatedRetried/empty/failed). Shared `stripJSONFences` helper extracted from `VisionLLMClient`.
  - **Lane C — Wiring + UI**: handler in `PowerWorkBridge`, `.extractKG` in `BatteryAwareScheduler.requiresAutonomousReadiness`, atomic insert+enqueue in `MemoryStorage`, `KGBackfillService` (pattern from `ConversationSummaryBackfillService`), `KGProgressPublisher` AsyncStream with throttled emits + ETA, in-page VM in `MemoryGraphPage`, `BuildingProgressPill`, 3-mode adaptive empty state.
- Pre-build: 12-reviewer scope peer review (3 per type per lane). Post-build: 6-reviewer code review (3 initial + 3 escalators) → 11 consensus fix clusters applied (provenance cascade, atomic insert/enqueue/status, typed `KGExtractionStatus`, progress denominator integrity, dead-letter handler, LLM error preservation, undecodable-payload dead-letter, depth cap, throttle race, log distinction nil-vs-deleted, classifier purity).

## Test plan

- [x] `xcrun swift build -c debug --package-path Desktop` — green
- [x] `xcrun swift test --package-path Desktop --filter "KG|PowerWorkBridge"` — 37/37 pass
- [x] CI parity: `ci.yml` `rust-test` job runs locally green (79 tests)
- [ ] Manual: open Brain Map with existing memories — pill shows "Building — 0 / N", climbs as drains complete
- [ ] Manual: add a memory, verify new nodes/edges appear within one drain cycle and a `local_kg_node_sources` row exists
- [ ] Manual: toggle thermal/battery mid-drain — pill flips to "Paused — …"
- [ ] Manual: relaunch → `KGBackfillService.runIfNeeded()` no-ops via `migration_status.kg_backfill_v1`
- [ ] Manual: delete a memory → cascade removes orphan nodes/edges; nodes shared with other memories preserved

## Out of scope

Edge weights, re-extraction on memory edit, cross-memory entity resolution beyond alias merge, LLM model swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic brain map extraction from memories with background backfill and per-memory extraction status.
  * Real-time build progress pill and detailed empty-state messaging showing processed/succeeded counts and ETA.
  * Persistent, provenance-aware knowledge graph storage with idempotent upserts and alias merging.

* **Bug Fixes / Reliability**
  * Safer enqueueing and retry behavior for extraction work to reduce missed or duplicate jobs.

* **Tests**
  * Comprehensive tests added for extraction, storage, wiring, and progress reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->