### PR TITLE
fix(summary): explicit summary_state column unblocks stuck badges

### DIFF
--- a/Desktop/Sources/APIClient.swift
+++ b/Desktop/Sources/APIClient.swift
@@ -676,6 +676,7 @@ struct ServerConversation: Codable, Identifiable, Equatable {
       && lhs.finishedAt == rhs.finishedAt && lhs.structured == rhs.structured
       && lhs.status == rhs.status && lhs.discarded == rhs.discarded && lhs.deleted == rhs.deleted
       && lhs.starred == rhs.starred && lhs.folderId == rhs.folderId && lhs.source == rhs.source
+      && lhs.summaryState == rhs.summaryState
   }
 
   let id: String
@@ -699,6 +700,7 @@ struct ServerConversation: Codable, Identifiable, Equatable {
   var starred: Bool
   let folderId: String?
   let inputDeviceName: String?
+  var summaryState: String
 
   enum CodingKeys: String, CodingKey {
     case id
@@ -719,6 +721,7 @@ struct ServerConversation: Codable, Identifiable, Equatable {
     case starred
     case folderId = "folder_id"
     case inputDeviceName = "input_device_name"
+    case summaryState = "summary_state"
   }
 
   init(from decoder: Decoder) throws {
@@ -743,6 +746,7 @@ struct ServerConversation: Codable, Identifiable, Equatable {
     starred = try container.decodeIfPresent(Bool.self, forKey: .starred) ?? false
     folderId = try container.decodeIfPresent(String.self, forKey: .folderId)
     inputDeviceName = try container.decodeIfPresent(String.self, forKey: .inputDeviceName)
+    summaryState = try container.decodeIfPresent(String.self, forKey: .summaryState) ?? "pending"
   }
 
   /// Memberwise initializer for creating from local storage
@@ -764,7 +768,8 @@ struct ServerConversation: Codable, Identifiable, Equatable {
     isLocked: Bool,
     starred: Bool,
     folderId: String?,
-    inputDeviceName: String?
+    inputDeviceName: String?,
+    summaryState: String = "pending"
   ) {
     self.id = id
     self.createdAt = createdAt
@@ -784,6 +789,7 @@ struct ServerConversation: Codable, Identifiable, Equatable {
     self.starred = starred
     self.folderId = folderId
     self.inputDeviceName = inputDeviceName
+    self.summaryState = summaryState
   }
 
   /// Returns the title from structured data, or a derived one from the overview.
@@ -847,41 +853,24 @@ struct ServerConversation: Codable, Identifiable, Equatable {
   }
 }
 
-// MARK: - Summary pending inference (shared across ConversationRowView /
-// ConversationDetailView so the list and detail views render identical
-// pending-state copy without diverging logic). Pure UI inference from
-// existing `ServerConversation` fields — no model changes, no DB queries.
+// MARK: - Summary display state
+//
+// The DB column `summary_state` is the source of truth — written explicitly by
+// the summarize pipeline (`done`), the placeholder/dead-letter paths
+// (`unavailable`), or left at the default (`pending`). The list and detail
+// views read this enum so badge/copy can branch without re-deriving state from
+// title/overview heuristics.
+enum SummaryDisplayState { case done, pending, unavailable }
+
 extension ServerConversation {
-  /// True when the recording finished but the LLM has not yet produced a
-  /// title/overview.
-  ///
-  /// Conditions (all must hold):
-  ///   - `status == .completed` (finished, not actively recording)
-  ///   - `structured.overview` is empty/whitespace
-  ///   - we have evidence the session contains audio: either a non-empty
-  ///     `cachedPreview` snippet (passed by callers from
-  ///     `appState.conversationPreviews[id]`), OR `transcriptSegments` is
-  ///     non-empty, OR `(finishedAt - startedAt)` is greater than ~10 s.
-  ///
-  /// - Parameter cachedPreview: optional cached preview text from
-  ///   `AppState.conversationPreviews[id]`. Pass `nil` from callers that
-  ///   don't have AppState in scope (e.g. detail view).
-  func isSummaryPending(cachedPreview: String?) -> Bool {
-    guard status == .completed else { return false }
-    let overview = structured.overview
-      .trimmingCharacters(in: .whitespacesAndNewlines)
-    guard overview.isEmpty else { return false }
-    if let cached = cachedPreview,
-       !cached.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-      return true
+  var summaryDisplayState: SummaryDisplayState {
+    switch summaryState {
+    case "done": return .done
+    case "unavailable": return .unavailable
+    default:
+      logError("ServerConversation.summaryDisplayState: unknown summary_state value \"\(summaryState)\" — falling back to .pending")
+      return .pending
     }
-    if !transcriptSegments.isEmpty {
-      return true
-    }
-    if let start = startedAt, let end = finishedAt {
-      return end.timeIntervalSince(start) > 10
-    }
-    return false
   }
 }
 

--- a/Desktop/Sources/MainWindow/Components/ConversationRowView.swift
+++ b/Desktop/Sources/MainWindow/Components/ConversationRowView.swift
@@ -38,14 +38,12 @@ struct ConversationRowView: View {
     Date().timeIntervalSince(conversation.createdAt) < 60
   }
 
-  /// True when the recording finished but the LLM has not yet produced a
-  /// title/overview. Delegates to the shared
-  /// `ServerConversation.isSummaryPending(cachedPreview:)` extension so the
-  /// list and detail views never diverge (PR #30 review).
-  var isSummaryPending: Bool {
-    conversation.isSummaryPending(
-      cachedPreview: appState.conversationPreviews[conversation.id]
-    )
+  private var summaryState: SummaryDisplayState {
+    conversation.summaryDisplayState
+  }
+
+  private var isSummaryPending: Bool {
+    summaryState == .pending
   }
 
   private static let timeFormatter: DateFormatter = {
@@ -167,16 +165,14 @@ struct ConversationRowView: View {
     }
   }
 
-  /// Title to display in the row. Replaces the "Untitled Conversation"
-  /// fallback with "Summary Pending" when `isSummaryPending` so the user
-  /// understands the LLM hasn't run yet rather than seeing a generic
-  /// untitled placeholder.
   private var displayTitle: String {
     let raw = conversation.title
-    if isSummaryPending && raw == "Untitled Conversation" {
-      return "Summary Pending"
+    let isEmpty = raw.isEmpty || raw == "Untitled Conversation"
+    guard isEmpty else { return raw }
+    switch summaryState {
+    case .pending: return "Summary Pending"
+    case .unavailable, .done: return "Untitled recording"
     }
-    return raw
   }
 
   /// Label for the conversation source
@@ -408,9 +404,7 @@ struct ConversationRowView: View {
             NewBadge()
           }
 
-          if isSummaryPending {
-            SummaryPendingBadge()
-          }
+          SummaryStateBadge(state: summaryState)
 
           // Inline action buttons (show on hover)
           if isHovering && !isMultiSelectMode {
@@ -504,9 +498,7 @@ struct ConversationRowView: View {
             NewBadge()
           }
 
-          if isSummaryPending {
-            SummaryPendingBadge()
-          }
+          SummaryStateBadge(state: summaryState)
 
           // Inline action buttons (show on hover)
           if isHovering && !isMultiSelectMode {
@@ -697,21 +689,34 @@ struct ConversationRowView: View {
   .background(OmiColors.backgroundPrimary)
 }
 
-// MARK: - Summary Pending Badge
+// MARK: - Summary State Badge
 
-/// Small inline badge displayed next to a conversation title when the
-/// recording is finished but the autonomous summarizer hasn't produced a
-/// title/overview yet. Styled to mirror `NewBadge` (TasksPage.swift:4896)
-/// so the row keeps a consistent visual rhythm.
-struct SummaryPendingBadge: View {
+struct SummaryStateBadge: View {
+  let state: SummaryDisplayState
+
   var body: some View {
-    Text("Summary Pending")
-      .scaledFont(size: 10, weight: .semibold)
-      .foregroundColor(OmiColors.purplePrimary)
-      .padding(.horizontal, 6)
-      .padding(.vertical, 2)
-      .background(OmiColors.purplePrimary.opacity(0.15))
-      .cornerRadius(4)
-      .help("Will summarize when your Mac is plugged in and idle or locked.")
+    switch state {
+    case .done:
+      EmptyView()
+    case .pending:
+      Text("Summary Pending")
+        .scaledFont(size: 10, weight: .semibold)
+        .foregroundColor(OmiColors.purplePrimary)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 2)
+        .background(OmiColors.purplePrimary.opacity(0.15))
+        .cornerRadius(4)
+        .help("Will summarize when your Mac is plugged in and idle or locked.")
+        .accessibilityLabel("Summary pending")
+    case .unavailable:
+      Text("No transcript available")
+        .scaledFont(size: 10, weight: .semibold)
+        .foregroundColor(OmiColors.textTertiary)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 2)
+        .background(OmiColors.textTertiary.opacity(0.15))
+        .cornerRadius(4)
+        .accessibilityLabel("No transcript available")
+    }
   }
 }

--- a/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
+++ b/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
@@ -564,32 +564,47 @@ struct ConversationDetailView: View {
         }
     }
 
-    // MARK: - Summary Pending
+    // MARK: - Summary State
 
-    /// True when the recording finished but the LLM has not yet produced an
-    /// overview. Delegates to the shared
-    /// `ServerConversation.isSummaryPending(cachedPreview:)` extension so
-    /// the list and detail views never diverge (PR #30 review). Detail view
-    /// passes `nil` for cachedPreview — it doesn't have AppState in scope.
-    private var isSummaryPending: Bool {
-        displayConversation.isSummaryPending(cachedPreview: nil)
+    private var summaryState: SummaryDisplayState {
+        displayConversation.summaryDisplayState
     }
 
-    /// Banner shown above the (empty) overview section when the recording
-    /// has finished but the autonomous summarizer hasn't run yet.
-    private var summaryPendingPanel: some View {
+    @ViewBuilder
+    private var summaryStatePanel: some View {
+        switch summaryState {
+        case .done:
+            EmptyView()
+        case .pending:
+            statePanel(
+                icon: "hourglass",
+                tint: OmiColors.purplePrimary,
+                title: "Summary pending",
+                body: "Infinite Recall will summarize this transcript when your Mac is plugged in and idle or locked."
+            )
+        case .unavailable:
+            statePanel(
+                icon: "exclamationmark.triangle",
+                tint: OmiColors.textTertiary,
+                title: "No transcript available",
+                body: "No transcript was captured for this recording."
+            )
+        }
+    }
+
+    private func statePanel(icon: String, tint: Color, title: String, body: String) -> some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(spacing: 8) {
-                Image(systemName: "hourglass")
+                Image(systemName: icon)
                     .scaledFont(size: 13)
-                    .foregroundColor(OmiColors.purplePrimary)
+                    .foregroundColor(tint)
 
-                Text("Summary pending")
+                Text(title)
                     .scaledFont(size: 14, weight: .semibold)
                     .foregroundColor(OmiColors.textPrimary)
             }
 
-            Text("Infinite Recall will summarize this transcript when your Mac is plugged in and idle or locked.")
+            Text(body)
                 .scaledFont(size: 12)
                 .foregroundColor(OmiColors.textSecondary)
                 .fixedSize(horizontal: false, vertical: true)
@@ -598,11 +613,11 @@ struct ConversationDetailView: View {
         .padding(12)
         .background(
             RoundedRectangle(cornerRadius: 10, style: .continuous)
-                .fill(OmiColors.purplePrimary.opacity(0.10))
+                .fill(tint.opacity(0.10))
         )
         .overlay(
             RoundedRectangle(cornerRadius: 10, style: .continuous)
-                .stroke(OmiColors.purplePrimary.opacity(0.25), lineWidth: 1)
+                .stroke(tint.opacity(0.25), lineWidth: 1)
         )
     }
 
@@ -610,10 +625,8 @@ struct ConversationDetailView: View {
 
     @ViewBuilder
     private var summaryContent: some View {
-        // Pending panel — rendered above the overview section when the
-        // recording is finished but the LLM hasn't summarized yet.
-        if isSummaryPending {
-            summaryPendingPanel
+        if summaryState != .done {
+            summaryStatePanel
         }
 
         // Overview section

--- a/Desktop/Sources/Rewind/Core/RewindDatabase.swift
+++ b/Desktop/Sources/Rewind/Core/RewindDatabase.swift
@@ -1135,6 +1135,7 @@ actor RewindDatabase {
                 t.column("backendSynced", .boolean).notNull().defaults(to: false)
                 t.column("createdAt", .datetime).notNull()
                 t.column("updatedAt", .datetime).notNull()
+                t.column("summary_state", .text).notNull().defaults(to: "pending")
             }
 
             // Transcript segments (child)
@@ -2456,6 +2457,26 @@ actor RewindDatabase {
             // every UI reload — index it so a backlog doesn't full-scan.
             try db.create(index: "idx_local_integration_outbox_integration_id",
                           on: "local_integration_outbox", columns: ["integrationId"])
+        }
+
+        migrator.registerMigration("addSummaryStateColumn") { db in
+            try db.execute(sql: """
+                ALTER TABLE transcription_sessions
+                  ADD COLUMN summary_state TEXT NOT NULL DEFAULT 'pending'
+                """)
+            try db.execute(sql: """
+                UPDATE transcription_sessions
+                  SET summary_state = CASE
+                    WHEN title IS NOT NULL
+                         AND title NOT IN ('', 'Short Recording', 'Ambient Audio', 'Summary Unavailable')
+                         AND overview IS NOT NULL AND overview != ''
+                      THEN 'done'
+                    WHEN title IN ('Short Recording', 'Ambient Audio', 'Summary Unavailable')
+                         AND (overview IS NULL OR overview = '')
+                      THEN 'unavailable'
+                    ELSE 'pending'
+                  END
+                """)
         }
 
         try migrator.migrate(queue)

--- a/Desktop/Sources/Rewind/Core/TranscriptionModels.swift
+++ b/Desktop/Sources/Rewind/Core/TranscriptionModels.swift
@@ -64,7 +64,21 @@ struct TranscriptionSessionRecord: Codable, FetchableRecord, PersistableRecord, 
     var starred: Bool
     var folderId: String?
 
+    // MARK: - Summary State
+    /// Explicit summary lifecycle: "pending" | "done" | "unavailable"
+    var summaryState: String
+
     static let databaseTableName = "transcription_sessions"
+
+    enum CodingKeys: String, CodingKey {
+        case id, startedAt, finishedAt, source, language, timezone, inputDeviceName
+        case status, retryCount, lastError, backendId, backendSynced
+        case createdAt, updatedAt
+        case title, overview, emoji, category, actionItemsJson, eventsJson
+        case geolocationJson, photosJson, appsResultsJson
+        case conversationStatus, discarded, deleted, isLocked, starred, folderId
+        case summaryState = "summary_state"
+    }
 
     // MARK: - Initialization
 
@@ -100,7 +114,8 @@ struct TranscriptionSessionRecord: Codable, FetchableRecord, PersistableRecord, 
         deleted: Bool = false,
         isLocked: Bool = false,
         starred: Bool = false,
-        folderId: String? = nil
+        folderId: String? = nil,
+        summaryState: String = "pending"
     ) {
         self.id = id
         self.startedAt = startedAt
@@ -134,6 +149,7 @@ struct TranscriptionSessionRecord: Codable, FetchableRecord, PersistableRecord, 
         self.isLocked = isLocked
         self.starred = starred
         self.folderId = folderId
+        self.summaryState = summaryState
     }
 
     // MARK: - Persistence Callbacks
@@ -346,7 +362,8 @@ extension TranscriptionSessionRecord {
             deleted: conversation.deleted,
             isLocked: conversation.isLocked,
             starred: conversation.starred,
-            folderId: conversation.folderId
+            folderId: conversation.folderId,
+            summaryState: conversation.summaryState
         )
     }
 
@@ -391,6 +408,7 @@ extension TranscriptionSessionRecord {
         self.isLocked = conversation.isLocked
         self.starred = conversation.starred
         self.folderId = conversation.folderId
+        self.summaryState = conversation.summaryState
 
         // Mark as synced
         self.backendId = conversation.id
@@ -526,7 +544,8 @@ extension TranscriptionSessionRecord {
             isLocked: isLocked,
             starred: starred,
             folderId: folderId,
-            inputDeviceName: inputDeviceName
+            inputDeviceName: inputDeviceName,
+            summaryState: summaryState
         )
     }
 }

--- a/Desktop/Sources/Rewind/Services/ConversationSummaryBackfillService.swift
+++ b/Desktop/Sources/Rewind/Services/ConversationSummaryBackfillService.swift
@@ -374,6 +374,7 @@ actor ConversationSummaryBackfillService {
             SELECT s.id FROM transcription_sessions AS s
              WHERE s.finishedAt IS NOT NULL
                AND s.deleted = 0
+               AND s.summary_state = 'pending'
                AND ((s.title IS NULL OR s.title = '')
                     OR (s.overview IS NULL OR s.overview = ''))
                AND EXISTS (
@@ -403,8 +404,9 @@ actor ConversationSummaryBackfillService {
         let sql = """
             SELECT id FROM transcription_sessions
              WHERE finishedAt IS NOT NULL
-               AND (title IS NULL OR title = '')
-               AND (overview IS NULL OR overview = '')
+               AND summary_state = 'pending'
+               AND ((title IS NULL OR title = '')
+                    OR (overview IS NULL OR overview = ''))
              ORDER BY finishedAt DESC
              LIMIT 1
             """
@@ -424,12 +426,17 @@ actor ConversationSummaryBackfillService {
         }
 
         if onlyIfNeedsSummary {
+            // Filter must match `fetchEligibleSessionIds`'s OR-shape — otherwise
+            // a session enqueued because (e.g.) only `overview` is empty gets
+            // skipped here when it has a placeholder title, and the same row
+            // bounces between enqueue and skip on every drain.
             let needsSummarySQL = """
                 SELECT COUNT(*) FROM transcription_sessions
                  WHERE id = ?
                    AND finishedAt IS NOT NULL
-                   AND (title IS NULL OR title = '')
-                   AND (overview IS NULL OR overview = '')
+                   AND summary_state = 'pending'
+                   AND ((title IS NULL OR title = '')
+                        OR (overview IS NULL OR overview = ''))
                 """
             let needsSummary = try await dbQueue.read { db in
                 try Int.fetchOne(db, sql: needsSummarySQL, arguments: [sessionId]) ?? 0
@@ -512,6 +519,7 @@ actor ConversationSummaryBackfillService {
                    overview = ?,
                    emoji = ?,
                    category = ?,
+                   summary_state = 'unavailable',
                    updatedAt = ?
              WHERE id = ?
             """
@@ -521,6 +529,27 @@ actor ConversationSummaryBackfillService {
                 arguments: [title, overview, emoji, category, Date(), sessionId]
             )
         }
+    }
+
+    /// Mark a session unsummarizable without overwriting its title/overview.
+    /// Used when the dead-letter path or skip path needs to break the
+    /// re-enqueue loop without touching the visible structured fields.
+    func writeUnsummarizableState(sessionId: Int64, reason: String) async throws {
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+            throw TranscriptionStorageError.databaseNotInitialized
+        }
+        try await dbQueue.write { db in
+            try db.execute(
+                sql: """
+                    UPDATE transcription_sessions
+                       SET summary_state = 'unavailable',
+                           updatedAt = ?
+                     WHERE id = ?
+                    """,
+                arguments: [Date(), sessionId]
+            )
+        }
+        log("ConversationSummaryBackfillService: marked session \(sessionId) summary_state=unavailable (\(reason))")
     }
 
     /// Write the LLM-generated structured fields back to the session row.
@@ -534,6 +563,7 @@ actor ConversationSummaryBackfillService {
                    overview = ?,
                    emoji = ?,
                    category = ?,
+                   summary_state = 'done',
                    updatedAt = ?
              WHERE id = ?
             """


### PR DESCRIPTION
## Summary

- Three compound bugs left Conversations stuck on "Summary Pending" forever — even after clicking "Run now" with mlx-lm running. Replace ad-hoc multi-criteria badge inference with an explicit `summary_state` column threaded DB → record → `ServerConversation` → UI.
- Align the launch-enqueue filter and `processSummary`'s drain-path filter (Bug A: enqueue used OR, drain used AND, so placeholder-titled rows were re-enqueued every launch and silently skipped). Both filters now also require `summary_state = 'pending'` so `unavailable` rows can't re-enter the queue.
- Differentiate "summary not yet generated" from "no transcript was captured" in the badge + detail panel — multi-hour recordings with zero segments no longer get the misleading "plug in and idle" gate copy.

## Plan

`/Users/mjaverto/.claude/plans/sharded-snacking-rocket.md` — peer-reviewed by 3 frontend + 3 backend agents pre-implementation, then 3 more (code-reviewer, silent-failure-hunter, type-design-analyzer) post-implementation. Consensus must-fix items applied:
- Migration backfill `unavailable` branch now requires `overview IS NULL OR overview = ''` so placeholder-titled rows with real overviews stay `pending`/`done`.
- `summaryDisplayState` default arm now `logError`s unknown raw values instead of silently mapping to `.pending`.
- `fetchSession(onlyIfNeedsSummary:)` got the `summary_state = 'pending'` guard (closes Bug A on the drain path too).

## Test plan

- [ ] Build: `xcrun swift build -c debug --package-path Desktop` and `-c release` — both clean
- [ ] Launch under `IR_APP_NAME="Infinite Recall" IR_SKIP_BACKEND=1 IR_SKIP_AUTH=1 IR_SKIP_TUNNEL=1 IR_SKIP_PYTHON=1 ./run.sh --yolo` and verify migration applies cleanly
- [ ] DB sanity: `sqlite3 ~/Library/Application\ Support/Omi/users/anonymous/omi.db "SELECT id, title, length(overview), summary_state FROM transcription_sessions WHERE id IN (48,61,82,98);"` — expect 61=`pending` (will summarize), 82+98=`unavailable`, 48=`unavailable`
- [ ] Stuck session 61 produces a real title + clears the badge after a drain
- [ ] Sessions 82, 98 show "No transcript available" badge; detail panel reads "No transcript was captured for this recording." (NOT the "plug in and idle" copy)
- [ ] "Run now" is idempotent — no re-enqueue churn for `unavailable` rows in `/private/tmp/omi-dev.log`
- [ ] Record 30+s of fresh speech → `summary_state` transitions `pending → done` and badge clears

## Out of scope (filed as follow-ups)

- Why does WhisperKit drop multi-hour recordings? (sessions 82, 98 had audio but zero segments)
- "Retry transcription" UI affordance for failed-transcription rows
- Activity tab "Run now" should also kick the transcription queue
- Proactive sweep for zero-segment completed sessions to mark them `unavailable` immediately (today they wait for the dead-letter retry budget)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced explicit summary state tracking with three states: pending, done, and unavailable.
  * Added new badge display for unavailable transcripts.

* **Bug Fixes**
  * Fixed inaccurate summary status display by replacing heuristic-based inference with explicit state field.

* **Refactor**
  * Replaced boolean summary availability checks with richer state-based model for more accurate UI presentation across conversation rows and detail views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->