### PR TITLE
feat(activity): allow Run now while device is active

### DIFF
--- a/Desktop/Sources/Activity/ActivityPage.swift
+++ b/Desktop/Sources/Activity/ActivityPage.swift
@@ -92,6 +92,7 @@ func activityShouldShowRunNowButton(
 ) -> Bool {
     if isThermalBlocked || snapshotGate?.blockReason?.disablesRunNowOverride == true { return false }
     if isRunOnceActive { return true }
+    if snapshotGate?.blockReason == .deviceActive && queued > 0 { return true }
     guard let resources, activityPowerBlock(resources: resources, queued: queued) != nil else { return false }
     return correctedGate?.blockReason == .onBattery
 }

--- a/Desktop/Sources/Activity/ActivityPage.swift
+++ b/Desktop/Sources/Activity/ActivityPage.swift
@@ -17,6 +17,30 @@
 
 import SwiftUI
 
+extension BlockReason {
+    /// True when this reason should not be replaced by `.onBattery` in the
+    /// activity banner. Used by `activityCorrectedGate` so power blocks don't
+    /// mask more-specific reasons.
+    var dominatesPowerBlock: Bool {
+        switch self {
+        case .thermal, .locked, .deviceActive, .manualPause: return true
+        case .onBattery, .initializing: return false
+        }
+    }
+
+    /// True when the "Run now" button should be disabled for this reason.
+    /// `.deviceActive` is excluded — `runOnceIgnoringPower` bypasses idle at
+    /// the engine layer (`ProcessingGateReporter.swift:130`).
+    /// `.thermal` IS included — engine refuses one-shot under thermal
+    /// pressure (`ProcessingGateReporter.swift:120`).
+    var disablesRunNowOverride: Bool {
+        switch self {
+        case .thermal, .locked, .manualPause: return true
+        case .deviceActive, .onBattery, .initializing: return false
+        }
+    }
+}
+
 // MARK: - Power gate helpers
 
 /// Local Activity-page power blocker. The wire model currently exposes the
@@ -34,16 +58,6 @@ func activityPowerBlock(resources: ResourceSample, queued: UInt32) -> ActivityPo
     return nil
 }
 
-func activitySuppressesRunNow(_ gate: GateState?) -> Bool {
-    guard case .blocked(let reason, _, _) = gate else { return false }
-    switch reason {
-    case .thermal, .locked, .deviceActive, .manualPause:
-        return true
-    case .onBattery, .initializing:
-        return false
-    }
-}
-
 func activityCorrectedGate(
     snapshotGate: GateState,
     resources: ResourceSample,
@@ -59,7 +73,7 @@ func activityCorrectedGate(
     if isRunOnceActive {
         return .allowed(since: runOnceStartedAt ?? now)
     }
-    if activitySuppressesRunNow(snapshotGate) {
+    if snapshotGate.blockReason?.dominatesPowerBlock == true {
         return snapshotGate
     }
     if activityPowerBlock(resources: resources, queued: queued) != nil {
@@ -76,7 +90,7 @@ func activityShouldShowRunNowButton(
     isThermalBlocked: Bool,
     isRunOnceActive: Bool
 ) -> Bool {
-    if isThermalBlocked || activitySuppressesRunNow(snapshotGate) { return false }
+    if isThermalBlocked || snapshotGate?.blockReason?.disablesRunNowOverride == true { return false }
     if isRunOnceActive { return true }
     guard let resources, activityPowerBlock(resources: resources, queued: queued) != nil else { return false }
     return correctedGate?.blockReason == .onBattery
@@ -269,6 +283,7 @@ struct ActivityPage: View {
                 .fill(OmiColors.backgroundPrimary.opacity(0.8))
         )
         .disabled(running || totalQueued == 0)
+        .accessibilityLabel("Run now — process \(totalQueued) queued item\(totalQueued == 1 ? "" : "s")")
         .accessibilityIdentifier("activity_run_now_button")
     }
 
@@ -323,7 +338,7 @@ struct ActivityPage: View {
             return BannerInfo(
                 icon: "keyboard.fill",
                 title: "Waiting for idle — \(queued) item\(queued == 1 ? "" : "s") queued",
-                detail: "Resumes after \(detail).",
+                detail: "Resumes after \(detail) — or run now.",
                 color: OmiColors.warning
             )
         case .onBattery:

--- a/Desktop/Sources/Activity/ActivityPage.swift
+++ b/Desktop/Sources/Activity/ActivityPage.swift
@@ -284,7 +284,9 @@ struct ActivityPage: View {
                 .fill(OmiColors.backgroundPrimary.opacity(0.8))
         )
         .disabled(running || totalQueued == 0)
-        .accessibilityLabel("Run now — process \(totalQueued) queued item\(totalQueued == 1 ? "" : "s")")
+        .accessibilityLabel(running
+            ? "Processing queued items"
+            : "Run now — process \(totalQueued) queued item\(totalQueued == 1 ? "" : "s")")
         .accessibilityIdentifier("activity_run_now_button")
     }
 

--- a/Desktop/Sources/Activity/ActivityPage.swift
+++ b/Desktop/Sources/Activity/ActivityPage.swift
@@ -18,10 +18,11 @@
 import SwiftUI
 
 extension BlockReason {
-    /// True when this reason should not be replaced by `.onBattery` in the
-    /// activity banner. Used by `activityCorrectedGate` so power blocks don't
-    /// mask more-specific reasons.
-    var dominatesPowerBlock: Bool {
+    /// True when this reason outranks the `.onBattery` substitution in
+    /// `activityCorrectedGate` — the activity banner keeps this reason
+    /// instead of swapping in a power block, so more-specific gates aren't
+    /// masked by battery state.
+    var outranksOnBattery: Bool {
         switch self {
         case .thermal, .locked, .deviceActive, .manualPause: return true
         case .onBattery, .initializing: return false
@@ -73,7 +74,7 @@ func activityCorrectedGate(
     if isRunOnceActive {
         return .allowed(since: runOnceStartedAt ?? now)
     }
-    if snapshotGate.blockReason?.dominatesPowerBlock == true {
+    if snapshotGate.blockReason?.outranksOnBattery == true {
         return snapshotGate
     }
     if activityPowerBlock(resources: resources, queued: queued) != nil {

--- a/Desktop/Tests/ActivityPagePowerGateTests.swift
+++ b/Desktop/Tests/ActivityPagePowerGateTests.swift
@@ -73,11 +73,11 @@ final class ActivityPagePowerGateTests: XCTestCase {
         let res = resources(onBattery: false, lowPower: true)
         let corrected = GateState.blocked(reason: .onBattery, since: now, waitingFor: .acPower)
 
-        for reason in [BlockReason.thermal, .locked, .deviceActive, .manualPause] {
+        for reason in [BlockReason.thermal, .locked, .manualPause] {
             let snapshotGate = GateState.blocked(
                 reason: reason,
                 since: now,
-                waitingFor: reason == .deviceActive ? .idleFor(seconds: 60) : .manual
+                waitingFor: .manual
             )
             XCTAssertFalse(activityShouldShowRunNowButton(
                 snapshotGate: snapshotGate,
@@ -88,5 +88,23 @@ final class ActivityPagePowerGateTests: XCTestCase {
                 isRunOnceActive: false
             ), "Run now should stay hidden for \(reason)")
         }
+    }
+
+    func test_runNowButtonShownForDeviceActiveWithQueuedWork() {
+        let res = resources(onBattery: false, lowPower: false)
+        let snapshotGate = GateState.blocked(
+            reason: .deviceActive,
+            since: now,
+            waitingFor: .idleFor(seconds: 60)
+        )
+
+        XCTAssertTrue(activityShouldShowRunNowButton(
+            snapshotGate: snapshotGate,
+            correctedGate: snapshotGate,
+            resources: res,
+            queued: 2,
+            isThermalBlocked: false,
+            isRunOnceActive: false
+        ), "Run now should be visible when device is active so the user can override the idle gate.")
     }
 }

--- a/Desktop/Tests/ActivityPagePowerGateTests.swift
+++ b/Desktop/Tests/ActivityPagePowerGateTests.swift
@@ -107,4 +107,80 @@ final class ActivityPagePowerGateTests: XCTestCase {
             isRunOnceActive: false
         ), "Run now should be visible when device is active so the user can override the idle gate.")
     }
+
+    func test_runNowButtonHiddenForDeviceActiveWhenQueueEmpty() {
+        let res = resources(onBattery: false, lowPower: false)
+        let snapshotGate = GateState.blocked(
+            reason: .deviceActive,
+            since: now,
+            waitingFor: .idleFor(seconds: 60)
+        )
+
+        XCTAssertFalse(activityShouldShowRunNowButton(
+            snapshotGate: snapshotGate,
+            correctedGate: snapshotGate,
+            resources: res,
+            queued: 0,
+            isThermalBlocked: false,
+            isRunOnceActive: false
+        ), "Run now should stay hidden when device is active but the queue is empty — nothing to process.")
+    }
+
+    func test_correctedGateOverridesInitializingForAcLowPower() {
+        let res = resources(onBattery: false, lowPower: true)
+        let snapshotGate = GateState.blocked(
+            reason: .initializing,
+            since: now,
+            waitingFor: .manual
+        )
+
+        let corrected = activityCorrectedGate(
+            snapshotGate: snapshotGate,
+            resources: res,
+            queued: 3,
+            thermalState: .nominal,
+            isRunOnceActive: false,
+            runOnceStartedAt: nil,
+            now: now
+        )
+
+        XCTAssertEqual(corrected.blockReason, .onBattery, ".initializing must NOT dominate the power block — corrected gate should swap to .onBattery.")
+        XCTAssertEqual(corrected.waitingFor, .acPower)
+    }
+
+    func test_runNowButtonVisibleDuringRunOnceWhileDeviceActive() {
+        let res = resources(onBattery: false, lowPower: false)
+        let snapshotGate = GateState.blocked(
+            reason: .deviceActive,
+            since: now,
+            waitingFor: .idleFor(seconds: 60)
+        )
+
+        XCTAssertTrue(activityShouldShowRunNowButton(
+            snapshotGate: snapshotGate,
+            correctedGate: .allowed(since: now),
+            resources: res,
+            queued: 2,
+            isThermalBlocked: false,
+            isRunOnceActive: true
+        ), "Run now should remain visible during run-once even when the snapshot gate is still .deviceActive.")
+    }
+
+    func test_runNowButtonHiddenForThermalReasonEvenWhenThermalFlagFalse() {
+        let res = resources(onBattery: false, lowPower: false)
+        let snapshotGate = GateState.blocked(
+            reason: .thermal,
+            since: now,
+            waitingFor: .thermalCooldown
+        )
+
+        XCTAssertFalse(activityShouldShowRunNowButton(
+            snapshotGate: snapshotGate,
+            correctedGate: snapshotGate,
+            resources: res,
+            queued: 2,
+            isThermalBlocked: false,
+            isRunOnceActive: false
+        ), "Run now must hide for .thermal via disablesRunNowOverride alone, independent of the isThermalBlocked flag.")
+    }
 }


### PR DESCRIPTION
## Summary
- Splits overloaded `activitySuppressesRunNow` into two `BlockReason` predicates so `.deviceActive` no longer hides the "Run now" override button. The engine already supports the override (`runOnceIgnoringPower` short-circuits the device-active idle gate); the UI was the only thing in the way.
- Banner copy gains "— or run now." in the device-active state to advertise the override; new `accessibilityLabel` on the button switches on running state.
- 4 new tests cover queue-empty + deviceActive, initializing in `activityCorrectedGate`, run-once × deviceActive button visibility, and thermal-without-flag.
- Rename: `dominatesPowerBlock` → `outranksOnBattery` (per code review tiebreak: more concrete name at the call site).

## Test plan
- [x] `xcrun swift build -c debug --package-path Desktop` — clean.
- [x] `xcrun swift test --package-path Desktop --filter ActivityPagePowerGateTests` — 8/8 pass.
- [x] `cargo test --locked -p infinite-recall-api` (Phase F: matches CI rust-test gate) — pass.
- [x] Multi-agent code review (4 reviewers + 3 tiebreakers); consensus + tiebreak fixes applied.
- [ ] Manual: queue items while typing → "Run now" visible → tap → drains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added accessibility description to the "Run now" button showing queued item processing status.

* **Improvements**
  * Refined "Run now" button visibility and override behavior based on device and power states.
  * Enhanced battery substitution logic for snapshot gates.
  * Improved activity banner messaging for device-active scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->