### PR TITLE
fix(local-integrations): drop security-scoped bookmarks for filesystem

### DIFF
--- a/Desktop/Sources/LocalIntegrations/FilesystemWriter.swift
+++ b/Desktop/Sources/LocalIntegrations/FilesystemWriter.swift
@@ -1,91 +1,40 @@
 import Foundation
 
-/// Result of a filesystem dispatch. Carries the standard `DispatchOutcome`
-/// plus an optional refreshed bookmark — non-nil only when the resolved
-/// bookmark was `isStale` and we successfully re-created one. The caller
-/// persists the new bookmark blob to the integrations table.
+/// Writes a memory payload to a user-picked folder. Path scheme:
+/// `<root>/YYYY/MM-DD/HHMMSS-<slug>.<ext>` in the user's local timezone
+/// (matches what they see in the IR UI).
 ///
-/// INVARIANT (not enforced by the type): `refreshedBookmark` is nil whenever
-/// `outcome` is `.permanentFailure`. The producer (`FilesystemWriter.write`)
-/// upholds this; safe-to-persist on any outcome via `if let refreshed`.
-/// Revisit as a `WriteOutcome` enum (bookmark on success/retry only) post-v1.
-struct WriteResult {
-  let outcome: DispatchOutcome
-  let refreshedBookmark: Data?
-}
-
-/// Writes a memory payload to a user-picked folder via security-scoped
-/// bookmark. Path scheme: `<root>/YYYY/MM-DD/HHMMSS-<slug>.<ext>` in the
-/// user's local timezone (matches what they see in the IR UI).
+/// The app is non-sandboxed, so a plain path string is the I/O source of
+/// truth — no security-scoped bookmarks. (Bookmarks were the cause of
+/// intermittent Cocoa 259 "bookmark unresolvable" errors when Google
+/// Drive's File Provider remounted and changed the volume UUID.)
 enum FilesystemWriter {
-  /// Resolves the bookmark, builds the dated path, writes atomically.
+  /// Builds the dated path and writes atomically.
   ///
-  /// - Stale bookmark that we refresh successfully: returns the new
-  ///   bookmark in `refreshedBookmark` AND continues with the write.
-  /// - Bookmark resolve throws: `.permanentFailure` (user likely deleted
-  ///   or unmounted the folder).
+  /// - Empty `folderPath`: `.permanentFailure` (caller should never pass
+  ///   one, but defend so a bad row can't loop forever).
   /// - File I/O errors: treated as `.retry` (assume transient — better
   ///   to retry than lose data; iCloud-not-downloaded is the common case).
   static func write(
     payload: MemoryPayload,
     payloadJSON: Data,
     format: LocalIntegrationFormat,
-    bookmark: Data
-  ) async -> WriteResult {
-    // 1. Resolve the security-scoped bookmark.
-    var isStale = false
-    let rootURL: URL
-    do {
-      rootURL = try URL(
-        resolvingBookmarkData: bookmark,
-        options: [.withSecurityScope],
-        relativeTo: nil,
-        bookmarkDataIsStale: &isStale
-      )
-    } catch {
-      return WriteResult(
-        outcome: .permanentFailure(reason: "bookmark unresolvable: \(error.localizedDescription)"),
-        refreshedBookmark: nil
-      )
+    folderPath: String
+  ) async -> DispatchOutcome {
+    guard !folderPath.isEmpty else {
+      return .permanentFailure(reason: "no folder path")
     }
+    let rootURL = URL(fileURLWithPath: folderPath)
 
-    // 2. If stale, try to refresh — but don't fail the write if refresh
-    //    itself throws; the resolved URL still works for this attempt.
-    var refreshedBookmark: Data? = nil
-    if isStale {
-      do {
-        refreshedBookmark = try rootURL.bookmarkData(
-          options: [.withSecurityScope],
-          includingResourceValuesForKeys: nil,
-          relativeTo: nil
-        )
-      } catch {
-        // Stale and we can't re-bookmark — log so the failure isn't silent,
-        // then keep going. The resolved URL still works for THIS write, but
-        // on next launch the stale bookmark will resolve again (or fail).
-        // Caller sees refreshedBookmark == nil.
-        logError("FilesystemWriter: stale bookmark refresh failed; proceeding with this write but next launch may degrade", error: error)
-      }
-    }
-
-    // 3. Acquire scope. ALWAYS pair with stop in defer.
-    let didStart = rootURL.startAccessingSecurityScopedResource()
-    defer {
-      if didStart { rootURL.stopAccessingSecurityScopedResource() }
-    }
-
-    // 4. Compute dated subfolder + filename in the user's local timezone.
-    //    Calendar.current uses the user's default TZ — do not pass an
-    //    explicit TimeZone, per spec.
+    // Compute dated subfolder + filename in the user's local timezone.
+    // Calendar.current uses the user's default TZ — do not pass an
+    // explicit TimeZone, per spec.
     let cal = Calendar.current
     let comps = cal.dateComponents([.year, .month, .day, .hour, .minute, .second], from: payload.createdAt)
     guard let year = comps.year, let month = comps.month, let day = comps.day,
           let hour = comps.hour, let minute = comps.minute, let second = comps.second
     else {
-      return WriteResult(
-        outcome: .permanentFailure(reason: "could not extract date components from createdAt"),
-        refreshedBookmark: refreshedBookmark
-      )
+      return .permanentFailure(reason: "could not extract date components from createdAt")
     }
 
     let yearStr = String(format: "%04d", year)
@@ -105,10 +54,7 @@ enum FilesystemWriter {
       // .data(using: .utf8) on a Swift String is non-throwing-non-nil for
       // valid Strings; force-unwrap is safe here but we guard for paranoia.
       guard let utf8 = rendered.data(using: .utf8) else {
-        return WriteResult(
-          outcome: .permanentFailure(reason: "could not utf8-encode markdown"),
-          refreshedBookmark: refreshedBookmark
-        )
+        return .permanentFailure(reason: "could not utf8-encode markdown")
       }
       body = utf8
     }
@@ -118,14 +64,14 @@ enum FilesystemWriter {
       .appendingPathComponent(monthDayStr, isDirectory: true)
     let fileURL = dailyFolder.appendingPathComponent("\(timeStr)-\(slug).\(ext)")
 
-    // 5. Create directory + write atomically.
+    // Create directory + write atomically.
     do {
       try FileManager.default.createDirectory(
         at: dailyFolder,
         withIntermediateDirectories: true
       )
       try body.write(to: fileURL, options: .atomic)
-      return WriteResult(outcome: .success, refreshedBookmark: refreshedBookmark)
+      return .success
     } catch let nsError as NSError {
       // Map known transient cases to retry. Anything we don't recognize
       // also retries — losing a memory snapshot is worse than a redundant
@@ -139,11 +85,20 @@ enum FilesystemWriter {
       // forever and eventually escalate to permanent failure.
       if domain == NSCocoaErrorDomain && code == NSFileWriteFileExistsError {
         log("FilesystemWriter: file already exists at \(fileURL.path) — treating as idempotent success")
-        return WriteResult(outcome: .success, refreshedBookmark: refreshedBookmark)
+        return .success
+      }
+      // TCC denial / read-only filesystem / explicit "no permission" — retrying
+      // is futile until the user grants access in System Settings → Privacy &
+      // Security → Files and Folders. Mark permanent so the row parks (30 days)
+      // and the lastError surfaces in the integrations table; user can re-pick
+      // or "Retry now" once they've fixed the permission.
+      if (domain == NSCocoaErrorDomain && code == NSFileWriteNoPermissionError)
+          || (domain == NSPOSIXErrorDomain && code == Int(EACCES)) {
+        return .permanentFailure(reason: reason)
       }
       // Everything else: retry. Losing a memory snapshot is worse than a
       // redundant retry tick.
-      return WriteResult(outcome: .retry(reason: reason), refreshedBookmark: refreshedBookmark)
+      return .retry(reason: reason)
     }
   }
 

--- a/Desktop/Sources/LocalIntegrations/LocalIntegrationDrainService.swift
+++ b/Desktop/Sources/LocalIntegrations/LocalIntegrationDrainService.swift
@@ -283,9 +283,8 @@ final class LocalIntegrationDrainService: LocalIntegrationOutboxDelegate {
       // Rebuild MemoryPayload from the snapshot (NOT from APIClient — the
       // outbox row is authoritative).
       let bodyData = row.payloadJson.data(using: .utf8) ?? Data()
-      let bookmark = integration.folderBookmark ?? Data()
-      if bookmark.isEmpty {
-        outcome = .permanentFailure(reason: "no folder bookmark")
+      guard let folderPath = integration.folderDisplayPath, !folderPath.isEmpty else {
+        outcome = .permanentFailure(reason: "no folder path")
         break
       }
       let payload: MemoryPayload
@@ -298,24 +297,12 @@ final class LocalIntegrationDrainService: LocalIntegrationOutboxDelegate {
         outcome = .permanentFailure(reason: "payload decode failed: \(error.localizedDescription)")
         break
       }
-      let result = await FilesystemWriter.write(
+      outcome = await FilesystemWriter.write(
         payload: payload,
         payloadJSON: bodyData,
         format: integration.formatEnum ?? .json,
-        bookmark: bookmark
+        folderPath: folderPath
       )
-      // Persist the refreshed bookmark before processing the outcome so a
-      // crash here doesn't lose the new bookmark.
-      if let refreshed = result.refreshedBookmark {
-        var updated = integration
-        updated.folderBookmark = refreshed
-        do {
-          try await LocalIntegrationStorage.shared.update(updated)
-        } catch {
-          logError("LocalIntegrationDrainService: persist refreshed bookmark failed integration=\(integration.id)", error: error)
-        }
-      }
-      outcome = result.outcome
 
     case .none:
       // Unknown kind raw value — treat as permanent so the row doesn't

--- a/Desktop/Sources/LocalIntegrations/LocalIntegrationStorage.swift
+++ b/Desktop/Sources/LocalIntegrations/LocalIntegrationStorage.swift
@@ -48,7 +48,7 @@ enum LocalIntegrationFormat: String, Codable {
 ///
 /// INVARIANT (enforced at `create`/`update` callsites in `AddLocalAppSheet`,
 /// not in the type): `kind == "webhook"` ⇒ `webhookURL != nil`;
-/// `kind == "filesystem"` ⇒ `folderBookmark != nil && format != nil`.
+/// `kind == "filesystem"` ⇒ `folderDisplayPath != nil && format != nil`.
 /// The drainer defends against violations by mapping malformed rows to
 /// `.permanentFailure` rather than crashing. Revisit as a sum-type
 /// `LocalIntegrationConfig` once a third kind lands.
@@ -71,11 +71,17 @@ struct LocalIntegrationRecord: Codable, FetchableRecord, PersistableRecord, Iden
     /// Only populated when `kind == "webhook"`.
     var webhookURL: String?
 
-    /// Only populated when `kind == "filesystem"`. Security-scoped bookmark
-    /// blob — survives relaunch and folder moves.
+    /// Legacy security-scoped bookmark blob. Unused by the writer (the app
+    /// is non-sandboxed; `folderDisplayPath` is the I/O source of truth).
+    /// Kept for back-compat with old rows; new rows write nil. The GRDB
+    /// column stays so we don't need a schema migration.
+    /// Drop the column in the next migration that touches this table; until
+    /// then, leave it alone.
     var folderBookmark: Data?
 
-    /// Last-resolved path string. UI display only — never trust for I/O.
+    /// Path string for filesystem integrations. I/O source of truth — the
+    /// drainer reads this and hands it to `FilesystemWriter`. Only populated
+    /// when `kind == "filesystem"`.
     var folderDisplayPath: String?
 
     /// Raw value of `LocalIntegrationFormat` — "json" or "markdown".

--- a/Desktop/Sources/MainWindow/Pages/LocalIntegrations/AddLocalAppSheet.swift
+++ b/Desktop/Sources/MainWindow/Pages/LocalIntegrations/AddLocalAppSheet.swift
@@ -6,7 +6,7 @@ import SwiftUI
 /// The same sheet is reused for both flows — pass `editing: nil` for "Add",
 /// pass a populated record for "Edit". When editing, the kind picker is
 /// disabled (changing kind would invalidate the existing webhook/filesystem
-/// fields and there's no clean migration path); the existing folder bookmark
+/// fields and there's no clean migration path); the existing folder path
 /// is preserved unless the user explicitly re-picks a folder.
 struct AddLocalAppSheet: View {
   // MARK: - Inputs
@@ -23,9 +23,8 @@ struct AddLocalAppSheet: View {
   @State private var webhookURL: String = ""
   @State private var format: LocalIntegrationFormat = .json
 
-  /// Security-scoped bookmark for the chosen folder. Initialized from the
-  /// editing record so simply pressing Save preserves the existing bookmark.
-  @State private var folderBookmark: Data? = nil
+  /// Path string for the chosen folder. Initialized from the editing record
+  /// so simply pressing Save preserves the existing path.
   @State private var folderDisplayPath: String? = nil
 
   @State private var saveError: String? = nil
@@ -205,7 +204,7 @@ struct AddLocalAppSheet: View {
     case .webhook:
       return webhookURLValid
     case .filesystem:
-      return folderBookmark != nil
+      return !(folderDisplayPath ?? "").isEmpty
     }
   }
 
@@ -216,34 +215,21 @@ struct AddLocalAppSheet: View {
     name = editing.name
     if let k = editing.kindEnum { kind = k }
     webhookURL = editing.webhookURL ?? ""
-    folderBookmark = editing.folderBookmark
     folderDisplayPath = editing.folderDisplayPath
     if let f = editing.formatEnum { format = f }
   }
 
-  /// Open `NSOpenPanel` to choose a folder, then create a security-scoped
-  /// bookmark for the resulting URL. Persisting the bookmark (rather than the
-  /// raw path) lets the drainer re-resolve the folder across relaunches and
-  /// folder moves.
+  /// Open `NSOpenPanel` to choose a folder and store its path. The app is
+  /// non-sandboxed, so the path string is the I/O source of truth — TCC
+  /// handles permission, no security-scoped bookmark needed.
   private func chooseFolder() {
     let panel = NSOpenPanel()
     panel.canChooseDirectories = true
     panel.canChooseFiles = false
     panel.allowsMultipleSelection = false
     panel.prompt = "Choose"
-    let response = panel.runModal()
-    guard response == .OK, let url = panel.url else { return }
-    do {
-      let bookmark = try url.bookmarkData(
-        options: .withSecurityScope,
-        includingResourceValuesForKeys: nil,
-        relativeTo: nil
-      )
-      folderBookmark = bookmark
-      folderDisplayPath = url.path
-    } catch {
-      saveError = "Couldn't create bookmark for folder: \(error.localizedDescription)"
-    }
+    guard panel.runModal() == .OK, let url = panel.url else { return }
+    folderDisplayPath = url.path
   }
 
   private func save() async {
@@ -275,7 +261,7 @@ struct AddLocalAppSheet: View {
         kind: LocalIntegrationKind.filesystem.rawValue,
         enabled: editing?.enabled ?? true,
         webhookURL: nil,
-        folderBookmark: folderBookmark,
+        folderBookmark: nil,
         folderDisplayPath: folderDisplayPath,
         format: format.rawValue,
         createdAt: editing?.createdAt ?? now,


### PR DESCRIPTION
## Summary

- Drop security-scoped bookmark resolve / refresh / scope-acquire from `FilesystemWriter`. App is non-sandboxed (`app-sandbox: false`); bookmarks were carried over from a sandboxed ancestor and were the sole cause of Cocoa 259 errors on Google Drive remount.
- Use plain `URL(fileURLWithPath: folderDisplayPath)` — TCC handles permission, no bookmarks needed (same model as Obsidian / VS Code).
- Map TCC denial (`NSFileWriteNoPermissionError`, POSIX `EACCES`) to `.permanentFailure` so denied integrations park for 30d and surface `lastError`. `NSFileNoSuchFileError` (4) deliberately stays `.retry` to preserve volume-remount tolerance — the exact scenario this PR exists to fix.
- Legacy `folderBookmark` GRDB column kept (no schema migration); new rows write nil.

## Test plan

- [x] `xcrun swift build -c debug --package-path Desktop` — green
- [x] `cargo test --locked -p infinite-recall-api` (CI gate) — green
- [x] `cargo test --locked -p infinite-recall-api --features activity_test_wiring --test activity_endpoints` (CI gate) — green
- [ ] Local: open Settings → My Apps; the existing "Brain" Filesystem row drains its 73 pending items into the GD folder
- [ ] Local: add a fresh Filesystem integration (e.g. `~/Desktop/ir-test`), trigger a memory create, confirm a file lands at `<root>/YYYY/MM-DD/HHMMSS-<slug>.<ext>`
- [ ] Local: kill+restart Google Drive, trigger a memory create — should write through (regression test for the actual bug)

## Code review

Multi-agent review: `pr-review-toolkit:code-reviewer` + `pr-review-toolkit:silent-failure-hunter` + `pr-review-toolkit:comment-analyzer`. Silent-failure-hunter caught the missing TCC-denial → permanent-failure mapping; validated by 3 independent reviewers (drainer has zero retry cap — `LocalIntegrationDrainService.swift:28-30, 396-399`), fixed before opening the PR.

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced error handling for local filesystem integrations—permission-denied errors now fail immediately with clear feedback instead of retrying.
  * Simplified folder selection and storage mechanism for local filesystem integrations with more reliable path management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->