### PR TITLE
fix(tasks): wire .extractActionItems pipeline end-to-end

### DIFF
--- a/Desktop/Sources/Activity/WorkLabels.swift
+++ b/Desktop/Sources/Activity/WorkLabels.swift
@@ -110,7 +110,7 @@ public enum WorkLabels {
         guard let dict = try? JSONSerialization.jsonObject(with: payload) as? [String: Any] else {
             return nil
         }
-        for key in ["id", "conversation_id", "transcript_id", "source_id"] {
+        for key in ["id", "session_id", "conversation_id", "transcript_id", "source_id"] {
             if let v = dict[key] as? Int { return String(v) }
             if let v = dict[key] as? NSNumber { return v.stringValue }
             if let v = dict[key] as? String, !v.isEmpty { return v }

--- a/Desktop/Sources/AppState.swift
+++ b/Desktop/Sources/AppState.swift
@@ -3164,6 +3164,10 @@ extension Notification.Name {
   /// Posted when conversation rows are mutated under the UI (e.g. backfill
   /// service rewrites title/overview). Listeners should refetch.
   static let conversationsListNeedsRefresh = Notification.Name("conversationsListNeedsRefresh")
+  /// Posted when action_items rows are mutated under the UI (e.g. the
+  /// `.extractActionItems` handler inserts conversation-derived tasks).
+  /// Listeners should refetch (e.g. `TasksStore.loadTasks()`).
+  static let actionItemsListNeedsRefresh = Notification.Name("actionItemsListNeedsRefresh")
   /// Posted when Tasks page finishes loading initial data
   static let tasksPageDidLoad = Notification.Name("tasksPageDidLoad")
   /// Posted when Focus page finishes loading initial data

--- a/Desktop/Sources/PowerWorkBridge.swift
+++ b/Desktop/Sources/PowerWorkBridge.swift
@@ -868,13 +868,20 @@ final class PowerWorkBridge {
             ? String(transcript.prefix(ConversationTranscriptLoader.maxTranscriptLength)) + "..."
             : transcript
 
+        // LLMBridge.generateJSON appends a stock instruction telling the model
+        // to "respond ONLY with a single valid JSON object". Asking for a bare
+        // array on top of that contradicts the augment and noticeably trips
+        // the local 4-bit Qwen. So we wrap the array in an envelope object
+        // (`{"items": [...]}`) and decode that. Every other LLMBridge caller
+        // already returns an object — keeping the bridge contract uniform.
         let systemPrompt = """
             You are an action-item extractor. Read a conversation transcript and \
-            output a JSON array of concrete tasks the speakers committed to. Output \
-            ONLY a single valid JSON array — no code fences, no prose, no commentary. \
-            If the transcript contains no actionable tasks, output exactly [].
+            output a JSON object containing concrete tasks the speakers committed \
+            to. Output ONLY a single valid JSON object of the form \
+            `{"items": [...]}` — no code fences, no prose, no commentary. If the \
+            transcript contains no actionable tasks, output exactly {"items": []}.
 
-            Each array element is an object with these fields:
+            Each element of the "items" array is an object with these fields:
             - "description": string, required, a concise one-sentence task description \
               (imperative voice, e.g. "Send the design review notes to Mike")
             - "priority": string, optional, one of: "high", "medium", "low"
@@ -909,7 +916,7 @@ final class PowerWorkBridge {
 
         let decoded: [LLMActionItem]
         do {
-            decoded = try JSONDecoder.iso8601().decode([LLMActionItem].self, from: data)
+            decoded = try JSONDecoder.iso8601().decode(LLMActionItemEnvelope.self, from: data).items
         } catch {
             let snippet = String(raw.prefix(500))
             logError("PowerWorkBridge: .extractActionItems — JSON parse failed for session \(sessionId); raw (first 500): \(snippet)", error: error)
@@ -960,6 +967,16 @@ final class PowerWorkBridge {
 
         try await ConversationActionItemsBackfillService.shared.markSessionExtracted(sessionId: sessionId)
         log("PowerWorkBridge: .extractActionItems — session \(sessionId) inserted \(inserted)/\(decoded.count) item(s)")
+    }
+
+    /// Envelope wrapping the array of extracted action items. Required
+    /// because `LLMBridge.generateJSON` appends a "respond ONLY with a single
+    /// valid JSON object" instruction to the prompt — asking for a bare
+    /// array would contradict that. Adapter pattern: only this caller needs
+    /// the envelope, so we keep the bridge contract uniform across callers
+    /// and unwrap inside the decode here.
+    private struct LLMActionItemEnvelope: Decodable {
+        let items: [LLMActionItem]
     }
 
     /// Codable mirror for the LLM's per-item response.

--- a/Desktop/Sources/PowerWorkBridge.swift
+++ b/Desktop/Sources/PowerWorkBridge.swift
@@ -72,6 +72,15 @@ final class PowerWorkBridge {
             try await PowerWorkBridge.handleExtractKG(work)
         }
 
+        // .extractActionItems — pull task-shaped items from a finished
+        // conversation's transcript. Decodes `{"session_id": Int64}` and
+        // routes through `LLMBridge.generateJSON` (NOT `chatAutonomous`):
+        // this kind only requires `allowHeavyWork`, so the user may still be
+        // active and Memory Saver must be allowed to keep the model warm.
+        BatteryAwareScheduler.shared.registerHandler(for: .extractActionItems) { work in
+            try await PowerWorkBridge.handleExtractActionItems(work)
+        }
+
         // Start the periodic sweeper that reclaims expired leases and GCs old rows.
         PendingWorkSweeper.shared.start()
 
@@ -104,9 +113,11 @@ final class PowerWorkBridge {
                 .enqueueHistoricalSummariesIfNeeded(reason: "launch")
             await ConversationTranscribeBackfillService.shared
                 .enqueueHistoricalTranscribesIfNeeded(reason: "launch")
+            await ConversationActionItemsBackfillService.shared
+                .enqueueHistoricalActionItemsIfNeeded(reason: "launch")
         }
 
-        log("PowerWorkBridge: Started — registered .transcribe, .ocr, .summarize, and .extractKG handlers")
+        log("PowerWorkBridge: Started — registered .transcribe, .ocr, .summarize, .extractKG, and .extractActionItems handlers")
     }
 
     // MARK: - Dead-letter handler
@@ -123,6 +134,8 @@ final class PowerWorkBridge {
             await handleDeadLetterSummarize(payload: payload)
         case PendingWork.Kind.extractKG.rawValue:
             await handleDeadLetterExtractKG(payload: payload)
+        case PendingWork.Kind.extractActionItems.rawValue:
+            await handleDeadLetterExtractActionItems(payload: payload)
         default:
             return
         }
@@ -763,6 +776,249 @@ final class PowerWorkBridge {
         await KGProgressPublisher.shared.tick()
 
         log("PowerWorkBridge: .extractKG — memory \(realId) outcome=\(extraction.outcome) in \(String(format: "%.2f", drainDuration))s")
+    }
+
+    // MARK: - Extract Action Items handler
+
+    /// Maximum transcript length (chars) sent to the LLM for action-item
+    /// extraction. Mirrors `ConversationSummaryBackfillService.maxTranscriptLength`.
+    fileprivate static let extractActionItemsMaxTranscriptLength = 6000
+
+    /// Minimum transcript length (chars) before bothering with extraction.
+    fileprivate static let extractActionItemsMinTranscriptLength = 30
+
+    /// Decode an `.extractActionItems` payload (`{"session_id": Int64}`),
+    /// load the transcript, run the LLM, and persist any extracted items via
+    /// `ActionItemStorage.shared.insertLocalActionItem(...)`.
+    ///
+    /// LLM path uses `LLMBridge.generateJSON` (NOT `chatAutonomous`): this
+    /// kind only requires `allowHeavyWork`, so the user may still be active
+    /// and Memory Saver must be allowed to track the call.
+    ///
+    /// Outcome routing:
+    /// - Undecodable payload → log + ack (return). Mirrors `.summarize`.
+    /// - Empty/short transcript → mark extracted + ack (no insert).
+    /// - LLM returned nil OR JSON parse failure → throw (lets PendingWork retry).
+    /// - Successful empty array `[]` → mark extracted + ack.
+    /// - Successful items → insert each + mark extracted + post refresh.
+    fileprivate static func handleExtractActionItems(_ work: PendingWork) async throws {
+        try await _handleExtractActionItemsPayload(
+            work.payload,
+            processor: { sessionId in
+                try await processExtractActionItems(sessionId: sessionId)
+            },
+            notify: { sessionId in
+                await MainActor.run {
+                    NotificationCenter.default.post(
+                        name: .actionItemsListNeedsRefresh,
+                        object: nil,
+                        userInfo: ["session_id": sessionId]
+                    )
+                }
+            }
+        )
+    }
+
+    /// Testable seam for `handleExtractActionItems`. Same contract as
+    /// `_handleSummarizePayload`: undecodable payload → no throw, no notify,
+    /// no processor call; processor throw → re-thrown, no notify; success →
+    /// notify called.
+    static func _handleExtractActionItemsPayload(
+        _ payload: Data,
+        processor: (Int64) async throws -> Void,
+        notify: (Int64) async -> Void
+    ) async throws {
+        struct Payload: Decodable {
+            let session_id: Int64
+        }
+
+        let sessionId: Int64
+        do {
+            sessionId = try JSONDecoder().decode(Payload.self, from: payload).session_id
+        } catch {
+            logError("PowerWorkBridge: .extractActionItems payload undecodable, dropping", error: error)
+            return
+        }
+
+        do {
+            try await processor(sessionId)
+        } catch {
+            logError("PowerWorkBridge: .extractActionItems — session \(sessionId) failed (will retry)", error: error)
+            throw error
+        }
+
+        await notify(sessionId)
+        log("PowerWorkBridge: .extractActionItems — session \(sessionId) done")
+    }
+
+    /// Production processor: load transcript, call LLM, insert items, mark
+    /// session extracted. Throws on retryable failure (LLM unreachable, JSON
+    /// parse failure) so PendingWork retry/backoff takes over.
+    fileprivate static func processExtractActionItems(sessionId: Int64) async throws {
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+            throw NSError(domain: "PowerWorkBridge", code: 1, userInfo: [
+                NSLocalizedDescriptionKey: "Database not initialized for extractActionItems"
+            ])
+        }
+
+        // Assemble the transcript from segments — same WhisperKit-token
+        // stripping pattern used by ConversationSummaryBackfillService.
+        let segmentSQL = """
+            SELECT text FROM transcription_segments
+             WHERE sessionId = ?
+             ORDER BY segmentOrder ASC
+            """
+        let rawTexts: [String] = try await dbQueue.read { db in
+            try String.fetchAll(db, sql: segmentSQL, arguments: [sessionId])
+        }
+        let transcript = rawTexts
+            .map { $0.replacingOccurrences(of: #"<\|[^|>]+\|>"#, with: "", options: .regularExpression)
+                      .trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+
+        if transcript.count < extractActionItemsMinTranscriptLength {
+            log("PowerWorkBridge: .extractActionItems — session \(sessionId) transcript too short (\(transcript.count) chars), marking extracted")
+            try await ConversationActionItemsBackfillService.shared.markSessionExtracted(sessionId: sessionId)
+            return
+        }
+
+        let truncated = transcript.count > extractActionItemsMaxTranscriptLength
+            ? String(transcript.prefix(extractActionItemsMaxTranscriptLength)) + "..."
+            : transcript
+
+        let systemPrompt = """
+            You are an action-item extractor. Read a conversation transcript and \
+            output a JSON array of concrete tasks the speakers committed to. Output \
+            ONLY a single valid JSON array — no code fences, no prose, no commentary. \
+            If the transcript contains no actionable tasks, output exactly [].
+
+            Each array element is an object with these fields:
+            - "description": string, required, a concise one-sentence task description \
+              (imperative voice, e.g. "Send the design review notes to Mike")
+            - "priority": string, optional, one of: "high", "medium", "low"
+            - "dueAt": string, optional, an ISO 8601 date-time (UTC, e.g. \
+              "2026-05-01T17:00:00Z") if the speakers named a specific deadline
+            - "category": string, optional, a short category label (e.g. "work", \
+              "personal", "follow-up")
+            - "tags": array of strings, optional, free-form labels
+
+            Be conservative: only emit items the speakers actually committed to doing. \
+            Skip aspirations, rhetorical questions, and hypotheticals.
+            """
+
+        let userPrompt = "Transcript:\n\n\(truncated)"
+        let label = "ConversationActionItemsBackfill[\(sessionId)]"
+
+        guard let raw = await LLMBridge.generateJSON(
+            systemPrompt: systemPrompt,
+            userPrompt: userPrompt,
+            label: label
+        ) else {
+            throw NSError(domain: "PowerWorkBridge", code: 7, userInfo: [
+                NSLocalizedDescriptionKey: "extractActionItems: LLM returned nil for session \(sessionId)"
+            ])
+        }
+
+        guard let data = raw.data(using: .utf8) else {
+            throw NSError(domain: "PowerWorkBridge", code: 7, userInfo: [
+                NSLocalizedDescriptionKey: "extractActionItems: response not UTF-8 for session \(sessionId)"
+            ])
+        }
+
+        let decoded: [LLMActionItem]
+        do {
+            decoded = try JSONDecoder.iso8601().decode([LLMActionItem].self, from: data)
+        } catch {
+            let snippet = String(raw.prefix(500))
+            logError("PowerWorkBridge: .extractActionItems — JSON parse failed for session \(sessionId); raw (first 500): \(snippet)", error: error)
+            throw error
+        }
+
+        if decoded.isEmpty {
+            log("PowerWorkBridge: .extractActionItems — session \(sessionId) yielded zero items, marking extracted")
+            try await ConversationActionItemsBackfillService.shared.markSessionExtracted(sessionId: sessionId)
+            return
+        }
+
+        let validPriorities: Set<String> = ["high", "medium", "low"]
+        var inserted = 0
+        for item in decoded {
+            let description = item.description.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !description.isEmpty else { continue }
+
+            let priority: String? = {
+                guard let p = item.priority?.lowercased() else { return nil }
+                return validPriorities.contains(p) ? p : nil
+            }()
+
+            let tagsJson: String? = {
+                guard let tags = item.tags, !tags.isEmpty else { return nil }
+                guard let data = try? JSONEncoder().encode(tags),
+                      let json = String(data: data, encoding: .utf8) else { return nil }
+                return json
+            }()
+
+            let record = ActionItemRecord(
+                description: description,
+                source: "conversation",
+                conversationId: String(sessionId),
+                priority: priority,
+                category: item.category,
+                tagsJson: tagsJson,
+                dueAt: item.dueAt,
+                fromStaged: false
+            )
+            do {
+                _ = try await ActionItemStorage.shared.insertLocalActionItem(record)
+                inserted += 1
+            } catch {
+                logError("PowerWorkBridge: .extractActionItems — insert failed for session \(sessionId)", error: error)
+            }
+        }
+
+        try await ConversationActionItemsBackfillService.shared.markSessionExtracted(sessionId: sessionId)
+        log("PowerWorkBridge: .extractActionItems — session \(sessionId) inserted \(inserted)/\(decoded.count) item(s)")
+    }
+
+    /// Codable mirror for the LLM's per-item response.
+    private struct LLMActionItem: Decodable {
+        let description: String
+        let priority: String?
+        let dueAt: Date?
+        let category: String?
+        let tags: [String]?
+    }
+
+    /// Dead-letter for `.extractActionItems`: mark the session extracted so
+    /// it stops re-qualifying on launch. No user-visible placeholder needed —
+    /// "no tasks for this conversation" is indistinguishable from a real
+    /// empty result. Surfaces in logs only.
+    @Sendable
+    fileprivate static func handleDeadLetterExtractActionItems(payload: Data) async {
+        struct Payload: Decodable { let session_id: Int64 }
+        let sessionId: Int64
+        do {
+            sessionId = try JSONDecoder().decode(Payload.self, from: payload).session_id
+        } catch {
+            logError("PowerWorkBridge: dead-letter — extractActionItems payload undecodable", error: error)
+            return
+        }
+
+        do {
+            try await ConversationActionItemsBackfillService.shared.markSessionExtracted(sessionId: sessionId)
+            log("PowerWorkBridge: dead-letter — marked session \(sessionId) action_items_extracted_at to break re-enqueue loop")
+        } catch {
+            logError("PowerWorkBridge: dead-letter — failed to mark session \(sessionId) extracted", error: error)
+        }
+    }
+}
+
+private extension JSONDecoder {
+    static func iso8601() -> JSONDecoder {
+        let d = JSONDecoder()
+        d.dateDecodingStrategy = .iso8601
+        return d
     }
 }
 

--- a/Desktop/Sources/PowerWorkBridge.swift
+++ b/Desktop/Sources/PowerWorkBridge.swift
@@ -780,12 +780,11 @@ final class PowerWorkBridge {
 
     // MARK: - Extract Action Items handler
 
-    /// Maximum transcript length (chars) sent to the LLM for action-item
-    /// extraction. Mirrors `ConversationSummaryBackfillService.maxTranscriptLength`.
-    fileprivate static let extractActionItemsMaxTranscriptLength = 6000
-
-    /// Minimum transcript length (chars) before bothering with extraction.
-    fileprivate static let extractActionItemsMinTranscriptLength = 30
+    // Note: transcript length thresholds live on `ConversationTranscriptLoader`
+    // (single source of truth shared with `ConversationSummaryBackfillService`).
+    // Use `ConversationTranscriptLoader.minTranscriptLength` /
+    // `.maxTranscriptLength` directly here so a future tuning change to those
+    // constants applies to both summary + action-item paths in lock-step.
 
     /// Decode an `.extractActionItems` payload (`{"session_id": Int64}`),
     /// load the transcript, run the LLM, and persist any extracted items via
@@ -855,36 +854,18 @@ final class PowerWorkBridge {
     /// session extracted. Throws on retryable failure (LLM unreachable, JSON
     /// parse failure) so PendingWork retry/backoff takes over.
     fileprivate static func processExtractActionItems(sessionId: Int64) async throws {
-        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
-            throw NSError(domain: "PowerWorkBridge", code: 1, userInfo: [
-                NSLocalizedDescriptionKey: "Database not initialized for extractActionItems"
-            ])
-        }
+        // Use the shared loader so the segment SQL + WhisperKit token-strip
+        // stays in lock-step with `ConversationSummaryBackfillService`.
+        let transcript = (try await ConversationTranscriptLoader.loadAssembled(sessionId: sessionId)) ?? ""
 
-        // Assemble the transcript from segments — same WhisperKit-token
-        // stripping pattern used by ConversationSummaryBackfillService.
-        let segmentSQL = """
-            SELECT text FROM transcription_segments
-             WHERE sessionId = ?
-             ORDER BY segmentOrder ASC
-            """
-        let rawTexts: [String] = try await dbQueue.read { db in
-            try String.fetchAll(db, sql: segmentSQL, arguments: [sessionId])
-        }
-        let transcript = rawTexts
-            .map { $0.replacingOccurrences(of: #"<\|[^|>]+\|>"#, with: "", options: .regularExpression)
-                      .trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty }
-            .joined(separator: " ")
-
-        if transcript.count < extractActionItemsMinTranscriptLength {
+        if transcript.count < ConversationTranscriptLoader.minTranscriptLength {
             log("PowerWorkBridge: .extractActionItems — session \(sessionId) transcript too short (\(transcript.count) chars), marking extracted")
             try await ConversationActionItemsBackfillService.shared.markSessionExtracted(sessionId: sessionId)
             return
         }
 
-        let truncated = transcript.count > extractActionItemsMaxTranscriptLength
-            ? String(transcript.prefix(extractActionItemsMaxTranscriptLength)) + "..."
+        let truncated = transcript.count > ConversationTranscriptLoader.maxTranscriptLength
+            ? String(transcript.prefix(ConversationTranscriptLoader.maxTranscriptLength)) + "..."
             : transcript
 
         let systemPrompt = """

--- a/Desktop/Sources/PowerWorkBridge.swift
+++ b/Desktop/Sources/PowerWorkBridge.swift
@@ -852,15 +852,57 @@ final class PowerWorkBridge {
 
     /// Production processor: load transcript, call LLM, insert items, mark
     /// session extracted. Throws on retryable failure (LLM unreachable, JSON
-    /// parse failure) so PendingWork retry/backoff takes over.
+    /// parse failure, partial-insert failure) so PendingWork retry/backoff
+    /// takes over.
     fileprivate static func processExtractActionItems(sessionId: Int64) async throws {
-        // Use the shared loader so the segment SQL + WhisperKit token-strip
-        // stays in lock-step with `ConversationSummaryBackfillService`.
-        let transcript = (try await ConversationTranscriptLoader.loadAssembled(sessionId: sessionId)) ?? ""
+        try await _processExtractActionItems(
+            sessionId: sessionId,
+            loadTranscript: { id in
+                try await ConversationTranscriptLoader.loadAssembled(sessionId: id)
+            },
+            extractItems: { transcript, id in
+                try await callExtractActionItemsLLM(truncated: transcript, sessionId: id)
+            },
+            insert: { record in
+                _ = try await ActionItemStorage.shared.insertLocalActionItem(record)
+            },
+            markExtracted: { id in
+                try await ConversationActionItemsBackfillService.shared.markSessionExtracted(sessionId: id)
+            }
+        )
+    }
+
+    /// Testable seam: same body as `processExtractActionItems` but with all
+    /// side-effecting collaborators (transcript load, LLM call, insert, mark)
+    /// injected so tests can drive each branch (all-success, mid-loop
+    /// failure, all-fail, short-transcript, empty-result) without touching
+    /// the real DB or LLM.
+    ///
+    /// `loadTranscript` returns the assembled transcript (may be nil/empty —
+    /// short-transcript branch handles both as "too short").
+    /// `extractItems` runs the LLM on a (truncated) transcript and returns
+    /// the decoded array; throws on parse / I/O failure so the whole job
+    /// retries. Returns an empty array on a successful "no items" response.
+    static func _processExtractActionItems(
+        sessionId: Int64,
+        loadTranscript: (Int64) async throws -> String?,
+        extractItems: (String, Int64) async throws -> [LLMActionItem],
+        insert: (ActionItemRecord) async throws -> Void,
+        markExtracted: (Int64) async throws -> Void
+    ) async throws {
+        let transcript = (try await loadTranscript(sessionId)) ?? ""
 
         if transcript.count < ConversationTranscriptLoader.minTranscriptLength {
             log("PowerWorkBridge: .extractActionItems — session \(sessionId) transcript too short (\(transcript.count) chars), marking extracted")
-            try await ConversationActionItemsBackfillService.shared.markSessionExtracted(sessionId: sessionId)
+            // FIX 7: don't propagate mark-failure here. The LLM didn't run, so
+            // re-throwing only buys us another drain re-checking the same
+            // too-short transcript. Eligibility query naturally re-picks the
+            // row next launch if it's still unmarked.
+            do {
+                try await markExtracted(sessionId)
+            } catch {
+                logError("PowerWorkBridge: .extractActionItems — markSessionExtracted failed for short-transcript session \(sessionId); ack-ing anyway", error: error)
+            }
             return
         }
 
@@ -868,6 +910,95 @@ final class PowerWorkBridge {
             ? String(transcript.prefix(ConversationTranscriptLoader.maxTranscriptLength)) + "..."
             : transcript
 
+        let decoded: [LLMActionItem] = try await extractItems(truncated, sessionId)
+
+        if decoded.isEmpty {
+            log("PowerWorkBridge: .extractActionItems — session \(sessionId) yielded zero items, marking extracted")
+            // FIX 7: same rationale as the short-transcript branch — the LLM
+            // already ran and returned an empty result. If markSessionExtracted
+            // fails, the eligibility query will pick the session back up next
+            // launch; re-throwing here only burns another LLM call right now.
+            do {
+                try await markExtracted(sessionId)
+            } catch {
+                logError("PowerWorkBridge: .extractActionItems — markSessionExtracted failed for empty-result session \(sessionId); ack-ing anyway", error: error)
+            }
+            return
+        }
+
+        // Insert-then-mark is NOT atomic. Track per-item failures and bail
+        // BEFORE marking the session done if any insert threw — otherwise
+        // a partial-failure would silently lose those items forever (the
+        // eligibility query excludes "extracted" sessions, no recovery).
+        //
+        // TODO: insert is not idempotent on retry — there's no unique
+        // constraint on (conversationId, description). A retry after
+        // mid-loop failure can re-insert items that already landed
+        // successfully. Acceptable trade-off vs. permanent silent loss; a
+        // follow-up should add a `(conversationId, hash(description))`
+        // upsert.
+        let validPriorities: Set<String> = ["high", "medium", "low"]
+        var inserted = 0
+        var anyInsertFailed = false
+        var firstFailure: Error?
+        for item in decoded {
+            let description = item.description.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !description.isEmpty else { continue }
+
+            let priority: String? = {
+                guard let p = item.priority?.lowercased() else { return nil }
+                return validPriorities.contains(p) ? p : nil
+            }()
+
+            let tagsJson: String? = {
+                guard let tags = item.tags, !tags.isEmpty else { return nil }
+                guard let data = try? JSONEncoder().encode(tags),
+                      let json = String(data: data, encoding: .utf8) else { return nil }
+                return json
+            }()
+
+            let record = ActionItemRecord(
+                description: description,
+                source: "conversation",
+                conversationId: String(sessionId),
+                priority: priority,
+                category: item.category,
+                tagsJson: tagsJson,
+                dueAt: item.dueAt,
+                fromStaged: false
+            )
+            do {
+                try await insert(record)
+                inserted += 1
+            } catch {
+                anyInsertFailed = true
+                if firstFailure == nil { firstFailure = error }
+                logError("PowerWorkBridge: .extractActionItems — insert failed for session \(sessionId) (will retry whole job)", error: error)
+            }
+        }
+
+        if anyInsertFailed {
+            log("PowerWorkBridge: .extractActionItems — session \(sessionId) inserted \(inserted)/\(decoded.count) before failure; re-throwing so PendingWork can retry (NOT marking extracted)")
+            throw firstFailure ?? NSError(domain: "PowerWorkBridge", code: 8, userInfo: [
+                NSLocalizedDescriptionKey: "extractActionItems: at least one insert failed for session \(sessionId)"
+            ])
+        }
+
+        try await markExtracted(sessionId)
+        log("PowerWorkBridge: .extractActionItems — session \(sessionId) inserted \(inserted)/\(decoded.count) item(s)")
+    }
+
+    /// Runs the action-item extraction LLM call against `LLMBridge` and
+    /// decodes the envelope. Throws on nil result, non-UTF-8 bytes, or JSON
+    /// parse failure so the calling job retries via PendingWork backoff.
+    ///
+    /// Extracted from `_processExtractActionItems` so the seam can stub the
+    /// LLM out in tests while the production path still routes through this
+    /// single function.
+    fileprivate static func callExtractActionItemsLLM(
+        truncated: String,
+        sessionId: Int64
+    ) async throws -> [LLMActionItem] {
         // LLMBridge.generateJSON appends a stock instruction telling the model
         // to "respond ONLY with a single valid JSON object". Asking for a bare
         // array on top of that contradicts the augment and noticeably trips
@@ -914,59 +1045,13 @@ final class PowerWorkBridge {
             ])
         }
 
-        let decoded: [LLMActionItem]
         do {
-            decoded = try JSONDecoder.iso8601().decode(LLMActionItemEnvelope.self, from: data).items
+            return try JSONDecoder.iso8601().decode(LLMActionItemEnvelope.self, from: data).items
         } catch {
             let snippet = String(raw.prefix(500))
             logError("PowerWorkBridge: .extractActionItems — JSON parse failed for session \(sessionId); raw (first 500): \(snippet)", error: error)
             throw error
         }
-
-        if decoded.isEmpty {
-            log("PowerWorkBridge: .extractActionItems — session \(sessionId) yielded zero items, marking extracted")
-            try await ConversationActionItemsBackfillService.shared.markSessionExtracted(sessionId: sessionId)
-            return
-        }
-
-        let validPriorities: Set<String> = ["high", "medium", "low"]
-        var inserted = 0
-        for item in decoded {
-            let description = item.description.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !description.isEmpty else { continue }
-
-            let priority: String? = {
-                guard let p = item.priority?.lowercased() else { return nil }
-                return validPriorities.contains(p) ? p : nil
-            }()
-
-            let tagsJson: String? = {
-                guard let tags = item.tags, !tags.isEmpty else { return nil }
-                guard let data = try? JSONEncoder().encode(tags),
-                      let json = String(data: data, encoding: .utf8) else { return nil }
-                return json
-            }()
-
-            let record = ActionItemRecord(
-                description: description,
-                source: "conversation",
-                conversationId: String(sessionId),
-                priority: priority,
-                category: item.category,
-                tagsJson: tagsJson,
-                dueAt: item.dueAt,
-                fromStaged: false
-            )
-            do {
-                _ = try await ActionItemStorage.shared.insertLocalActionItem(record)
-                inserted += 1
-            } catch {
-                logError("PowerWorkBridge: .extractActionItems — insert failed for session \(sessionId)", error: error)
-            }
-        }
-
-        try await ConversationActionItemsBackfillService.shared.markSessionExtracted(sessionId: sessionId)
-        log("PowerWorkBridge: .extractActionItems — session \(sessionId) inserted \(inserted)/\(decoded.count) item(s)")
     }
 
     /// Envelope wrapping the array of extracted action items. Required
@@ -975,17 +1060,33 @@ final class PowerWorkBridge {
     /// array would contradict that. Adapter pattern: only this caller needs
     /// the envelope, so we keep the bridge contract uniform across callers
     /// and unwrap inside the decode here.
-    private struct LLMActionItemEnvelope: Decodable {
+    struct LLMActionItemEnvelope: Decodable {
         let items: [LLMActionItem]
     }
 
-    /// Codable mirror for the LLM's per-item response.
-    private struct LLMActionItem: Decodable {
+    /// Codable mirror for the LLM's per-item response. Internal (not
+    /// `private`) so the testable seam `_processExtractActionItems` can
+    /// surface this type to test stubs.
+    struct LLMActionItem: Decodable {
         let description: String
         let priority: String?
         let dueAt: Date?
         let category: String?
         let tags: [String]?
+
+        init(
+            description: String,
+            priority: String? = nil,
+            dueAt: Date? = nil,
+            category: String? = nil,
+            tags: [String]? = nil
+        ) {
+            self.description = description
+            self.priority = priority
+            self.dueAt = dueAt
+            self.category = category
+            self.tags = tags
+        }
     }
 
     /// Dead-letter for `.extractActionItems`: mark the session extracted so

--- a/Desktop/Sources/Rewind/Core/ActionItemStorage.swift
+++ b/Desktop/Sources/Rewind/Core/ActionItemStorage.swift
@@ -619,10 +619,13 @@ actor ActionItemStorage {
         let db = try await ensureInitialized()
 
         let deleted = try await db.write { database -> Int in
+            // Exclude local-only rows (conversation-derived etc.) that legitimately
+            // lack a backendId — the API set cannot speak to those rows.
             let records = try ActionItemRecord
                 .filter(Column("completed") == false)
                 .filter(Column("deleted") == false)
                 .filter(Column("backendId") != nil)
+                .filter(Column("backendId") != "")
                 .fetchAll(database)
 
             var count = 0
@@ -644,6 +647,10 @@ actor ActionItemStorage {
     /// Hard-delete local tasks whose backendId is NOT in the given API set.
     /// Only targets synced records (backendSynced=true, backendId present) to avoid
     /// deleting locally-created tasks that haven't been pushed yet.
+    ///
+    /// Local-only sources (e.g. conversation-derived rows where backendId is nil/empty)
+    /// are explicitly excluded — the API has no awareness of them, so a missing entry
+    /// in the apiIds set is not a deletion signal.
     /// Returns the number of records deleted.
     func hardDeleteAbsentTasks(apiIds: Set<String>) async throws -> Int {
         // Safety guard: never wipe all tasks if the API set is empty (backend error)
@@ -655,10 +662,14 @@ actor ActionItemStorage {
         let db = try await ensureInitialized()
 
         let deleted = try await db.write { database -> Int in
+            // Only consider rows with a non-null, non-empty backendId AND backendSynced=true.
+            // Conversation-derived (and other local-only) rows have null/empty backendId
+            // and must be preserved across reconciliation passes.
             let records = try ActionItemRecord
                 .filter(Column("completed") == false)
                 .filter(Column("deleted") == false)
                 .filter(Column("backendId") != nil)
+                .filter(Column("backendId") != "")
                 .filter(Column("backendSynced") == true)
                 .fetchAll(database)
 

--- a/Desktop/Sources/Rewind/Core/RewindDatabase.swift
+++ b/Desktop/Sources/Rewind/Core/RewindDatabase.swift
@@ -2501,6 +2501,16 @@ actor RewindDatabase {
             }
         }
 
+        // Migration 50: Idempotency column for `.extractActionItems` pipeline.
+        // Set on success by `ConversationActionItemsBackfillService.markSessionExtracted`;
+        // eligibility query excludes non-null. Nullable so a user "clear + re-extract"
+        // workflow can re-qualify a session.
+        migrator.registerMigration("addActionItemsExtractedAt") { db in
+            try db.alter(table: "transcription_sessions") { t in
+                t.add(column: "action_items_extracted_at", .datetime)
+            }
+        }
+
         try migrator.migrate(queue)
     }
 

--- a/Desktop/Sources/Rewind/Services/ConversationActionItemsBackfillService.swift
+++ b/Desktop/Sources/Rewind/Services/ConversationActionItemsBackfillService.swift
@@ -1,0 +1,152 @@
+import Foundation
+import GRDB
+
+/// Per-session action-item extraction enqueue + launch backfill.
+///
+/// Mirrors the dedup/payload contract of the other backfill services:
+///   workType  : `PendingWork.Kind.extractActionItems.rawValue`
+///   payload   : `{"session_id": <Int64>}`
+///   dedupKey  : `extractActionItems:<sessionId>`
+///
+/// Producer-side guard: bail when `transcription_sessions.action_items_extracted_at`
+/// is already non-null. Nullable column so a user "clear + re-extract" workflow
+/// can re-qualify a session by nulling it out.
+actor ConversationActionItemsBackfillService {
+    static let shared = ConversationActionItemsBackfillService()
+
+    private static let workType: String = PendingWork.Kind.extractActionItems.rawValue
+    private static let dedupPrefix: String = "extractActionItems:"
+
+    private init() {}
+
+    struct PendingPayload: Codable {
+        let session_id: Int64
+    }
+
+    static func dedupKey(for sessionId: Int64) -> String {
+        return "\(Self.dedupPrefix)\(sessionId)"
+    }
+
+    /// Durably enqueue a single session for `.extractActionItems` work.
+    /// Idempotent — repeat calls collapse via the dedup key. Bails when the
+    /// session already has a non-null `action_items_extracted_at`.
+    func enqueueActionItemsIfNeeded(sessionId: Int64, reason: String) async {
+        do {
+            if try await sessionAlreadyExtracted(sessionId: sessionId) {
+                log("ConversationActionItemsBackfillService: session \(sessionId) already extracted, skipping enqueue (\(reason))")
+                return
+            }
+        } catch {
+            logError("ConversationActionItemsBackfillService: extracted-check failed for session \(sessionId) (\(reason))", error: error)
+            return
+        }
+
+        let payload: Data
+        do {
+            payload = try JSONEncoder().encode(PendingPayload(session_id: sessionId))
+        } catch {
+            logError("ConversationActionItemsBackfillService: failed to encode payload for session \(sessionId)", error: error)
+            return
+        }
+
+        do {
+            _ = try await PendingWorkStorage.shared.enqueue(
+                workType: Self.workType,
+                payload: payload,
+                dedupKey: Self.dedupKey(for: sessionId)
+            )
+            log("ConversationActionItemsBackfillService: enqueued extractActionItems for session \(sessionId) (\(reason))")
+        } catch {
+            logError("ConversationActionItemsBackfillService: enqueue failed for session \(sessionId) (\(reason))", error: error)
+        }
+    }
+
+    /// Walks finished, non-deleted sessions that have transcript segments and
+    /// no `action_items_extracted_at` yet, and enqueues each. Idempotent —
+    /// re-running is a no-op once the queue has caught up.
+    func enqueueHistoricalActionItemsIfNeeded(reason: String) async {
+        do {
+            let sessionIds = try await fetchEligibleSessionIds()
+            guard !sessionIds.isEmpty else {
+                log("ConversationActionItemsBackfillService: no historical extractions needed (\(reason))")
+                return
+            }
+            log("ConversationActionItemsBackfillService: enqueuing \(sessionIds.count) historical extractActionItems job(s) (\(reason))")
+            for id in sessionIds {
+                await enqueueActionItemsIfNeeded(sessionId: id, reason: "historical:\(reason)")
+            }
+        } catch {
+            logError("ConversationActionItemsBackfillService: enqueueHistoricalActionItemsIfNeeded failed (\(reason))", error: error)
+        }
+    }
+
+    /// Mark a session's action_items_extracted_at = now. Called by the handler
+    /// after a successful extraction (including the empty-result and
+    /// short-transcript paths so the row doesn't re-qualify on next launch).
+    func markSessionExtracted(sessionId: Int64) async throws {
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+            throw TranscriptionStorageError.databaseNotInitialized
+        }
+        try await dbQueue.write { db in
+            try db.execute(
+                sql: """
+                    UPDATE transcription_sessions
+                       SET action_items_extracted_at = ?
+                     WHERE id = ?
+                    """,
+                arguments: [Date(), sessionId]
+            )
+        }
+    }
+
+    private func sessionAlreadyExtracted(sessionId: Int64) async throws -> Bool {
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+            throw TranscriptionStorageError.databaseNotInitialized
+        }
+        return try await dbQueue.read { db -> Bool in
+            try Bool.fetchOne(
+                db,
+                sql: """
+                    SELECT action_items_extracted_at IS NOT NULL
+                      FROM transcription_sessions
+                     WHERE id = ?
+                    """,
+                arguments: [sessionId]
+            ) ?? false
+        }
+    }
+
+    private func fetchEligibleSessionIds() async throws -> [Int64] {
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+            throw TranscriptionStorageError.databaseNotInitialized
+        }
+
+        // Excludes active rows (queued/claimed) AND `done` rows for this dedup
+        // key so a successful drain doesn't re-qualify on every launch.
+        // `failed` rows are intentionally INCLUDED so launch backfill retries
+        // permanently-failed sessions.
+        let sql = """
+            SELECT s.id FROM transcription_sessions AS s
+             WHERE s.finishedAt IS NOT NULL
+               AND s.deleted = 0
+               AND s.action_items_extracted_at IS NULL
+               AND EXISTS (
+                   SELECT 1 FROM transcription_segments seg
+                    WHERE seg.sessionId = s.id
+                      AND seg.text IS NOT NULL
+                      AND TRIM(seg.text) <> ''
+               )
+               AND NOT EXISTS (
+                   SELECT 1 FROM pending_work pw
+                    WHERE pw.workType = 'extractActionItems'
+                      AND pw.status IN ('queued', 'claimed', 'done')
+                      AND pw.dedupKey = '\(Self.dedupPrefix)' || s.id
+               )
+             ORDER BY s.finishedAt DESC
+            """
+
+        return try await dbQueue.read { db in
+            try Int64.fetchAll(db, sql: sql)
+        }
+    }
+}

--- a/Desktop/Sources/Rewind/Services/ConversationActionItemsBackfillService.swift
+++ b/Desktop/Sources/Rewind/Services/ConversationActionItemsBackfillService.swift
@@ -15,7 +15,9 @@ actor ConversationActionItemsBackfillService {
     static let shared = ConversationActionItemsBackfillService()
 
     private static let workType: String = PendingWork.Kind.extractActionItems.rawValue
-    private static let dedupPrefix: String = "extractActionItems:"
+    /// Derived from `workType` so a future `PendingWork.Kind` rename keeps the
+    /// dedup prefix and the workType in lock-step automatically.
+    private static let dedupPrefix: String = "\(PendingWork.Kind.extractActionItems.rawValue):"
 
     private init() {}
 
@@ -125,6 +127,12 @@ actor ConversationActionItemsBackfillService {
         // key so a successful drain doesn't re-qualify on every launch.
         // `failed` rows are intentionally INCLUDED so launch backfill retries
         // permanently-failed sessions.
+        //
+        // Interpolation safe: `workType` and `dedupPrefix` are compile-time
+        // constants derived from `PendingWork.Kind.extractActionItems.rawValue`,
+        // not user input. Using interpolation here (rather than a hardcoded
+        // 'extractActionItems' literal) keeps a future enum rename from
+        // silently breaking dedup.
         let sql = """
             SELECT s.id FROM transcription_sessions AS s
              WHERE s.finishedAt IS NOT NULL
@@ -138,7 +146,7 @@ actor ConversationActionItemsBackfillService {
                )
                AND NOT EXISTS (
                    SELECT 1 FROM pending_work pw
-                    WHERE pw.workType = 'extractActionItems'
+                    WHERE pw.workType = '\(Self.workType)'
                       AND pw.status IN ('queued', 'claimed', 'done')
                       AND pw.dedupKey = '\(Self.dedupPrefix)' || s.id
                )

--- a/Desktop/Sources/Rewind/Services/ConversationActionItemsBackfillService.swift
+++ b/Desktop/Sources/Rewind/Services/ConversationActionItemsBackfillService.swift
@@ -19,6 +19,12 @@ actor ConversationActionItemsBackfillService {
     /// dedup prefix and the workType in lock-step automatically.
     private static let dedupPrefix: String = "\(PendingWork.Kind.extractActionItems.rawValue):"
 
+    /// Ensures the cold-launch retry only fires once per process. A
+    /// transient DB-not-yet-initialized failure during launch should buy us
+    /// exactly one retry; continued failures should surface in logs, not
+    /// loop forever.
+    private var pendingLaunchRetry = false
+
     private init() {}
 
     struct PendingPayload: Codable {
@@ -66,9 +72,22 @@ actor ConversationActionItemsBackfillService {
     /// Walks finished, non-deleted sessions that have transcript segments and
     /// no `action_items_extracted_at` yet, and enqueues each. Idempotent —
     /// re-running is a no-op once the queue has caught up.
+    ///
+    /// On cold launch the database may not be ready yet (TierManager and
+    /// other services race the first `initialize()` call) — `fetchEligibleSessionIds`
+    /// throws, and historically that was swallowed with a generic info-level
+    /// log. Net effect: backfill silently skipped until next launch.
+    ///
+    /// FIX 8: surface the underlying error via `logError` (grep-able in
+    /// `/private/tmp/omi-dev.log`) and schedule a single 5-second retry. The
+    /// `pendingLaunchRetry` flag bounds it to one extra attempt per process.
     func enqueueHistoricalActionItemsIfNeeded(reason: String) async {
         do {
             let sessionIds = try await fetchEligibleSessionIds()
+            // Successful query — we're past the cold-launch window. Reset
+            // the retry guard so a later transient failure (e.g. DB
+            // recovery flow) can buy us one more retry.
+            pendingLaunchRetry = false
             guard !sessionIds.isEmpty else {
                 log("ConversationActionItemsBackfillService: no historical extractions needed (\(reason))")
                 return
@@ -79,6 +98,29 @@ actor ConversationActionItemsBackfillService {
             }
         } catch {
             logError("ConversationActionItemsBackfillService: enqueueHistoricalActionItemsIfNeeded failed (\(reason))", error: error)
+            await scheduleLaunchRetryIfNeeded(originalReason: reason)
+        }
+    }
+
+    /// Schedules exactly one delayed retry of `enqueueHistoricalActionItemsIfNeeded`
+    /// after a transient failure. The retry happens after 5 seconds, which
+    /// is enough for `RewindDatabase.initialize()` to complete in the
+    /// typical cold-launch race. Subsequent failures fall through to the
+    /// next launch — we don't loop forever.
+    private func scheduleLaunchRetryIfNeeded(originalReason: String) async {
+        guard !pendingLaunchRetry else {
+            log("ConversationActionItemsBackfillService: launch retry already scheduled, skipping (\(originalReason))")
+            return
+        }
+        pendingLaunchRetry = true
+        log("ConversationActionItemsBackfillService: scheduling 5s launch-retry of enqueueHistoricalActionItemsIfNeeded (\(originalReason))")
+
+        Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 5_000_000_000)
+            guard let self else { return }
+            await self.enqueueHistoricalActionItemsIfNeeded(
+                reason: "retry-after-fetch-failure:\(originalReason)"
+            )
         }
     }
 

--- a/Desktop/Sources/Rewind/Services/ConversationSummaryBackfillService.swift
+++ b/Desktop/Sources/Rewind/Services/ConversationSummaryBackfillService.swift
@@ -311,6 +311,13 @@ actor ConversationSummaryBackfillService {
         log("ConversationSummaryBackfillService: session \(sessionId) → \"\(structured.title)\" (\(mode))")
         await notifyConversationListNeedsRefresh()
 
+        // Now that the session has a usable summary (i.e. transcript + LLM
+        // both succeeded), enqueue the action-items extraction. Producing on
+        // summary-success — not transcript-finish — avoids double-extracting
+        // and racing transcript materialization.
+        await ConversationActionItemsBackfillService.shared
+            .enqueueActionItemsIfNeeded(sessionId: sessionId, reason: "post-summary:\(mode)")
+
         // Fire-and-forget: now that the conversation has its final title +
         // overview, hand it off to the local-integration outbox. This is the
         // unambiguous "conversation finished" moment in the local-first fork

--- a/Desktop/Sources/Rewind/Services/ConversationSummaryBackfillService.swift
+++ b/Desktop/Sources/Rewind/Services/ConversationSummaryBackfillService.swift
@@ -37,9 +37,12 @@ actor ConversationSummaryBackfillService {
     /// Nanoseconds to sleep between individual LLM calls (~1 s).
     private static let throttleNanoseconds: UInt64 = 1_000_000_000
     /// Minimum total transcript length (chars) to bother summarizing.
-    private static let minTranscriptLength = 30
+    /// Aliased to `ConversationTranscriptLoader.minTranscriptLength` so summary
+    /// + extractActionItems share one source of truth.
+    private static let minTranscriptLength = ConversationTranscriptLoader.minTranscriptLength
     /// Maximum transcript length (chars) sent to the LLM.
-    private static let maxTranscriptLength = 6000
+    /// Aliased to `ConversationTranscriptLoader.maxTranscriptLength`.
+    private static let maxTranscriptLength = ConversationTranscriptLoader.maxTranscriptLength
     /// How many consecutive empty queries before we declare completion.
     private static let emptyBatchTerminationCount = 3
 
@@ -465,20 +468,9 @@ actor ConversationSummaryBackfillService {
         }
 
         // Assemble transcript from segments, stripping WhisperKit tokens.
-        let segmentSQL = """
-            SELECT text FROM transcription_segments
-             WHERE sessionId = ?
-             ORDER BY segmentOrder ASC
-            """
-        let rawTexts: [String] = try await dbQueue.read { db in
-            try String.fetchAll(db, sql: segmentSQL, arguments: [sessionId])
-        }
-
-        let transcript = rawTexts
-            .map { $0.replacingOccurrences(of: #"<\|[^|>]+\|>"#, with: "", options: .regularExpression)
-                      .trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty }
-            .joined(separator: " ")
+        // Single source of truth: `ConversationTranscriptLoader`.
+        let transcript = try await ConversationTranscriptLoader
+            .loadAssembled(sessionId: sessionId, dbQueue: dbQueue) ?? ""
 
         return PendingSession(id: sessionId, transcript: transcript)
     }

--- a/Desktop/Sources/Rewind/Services/ConversationTranscriptLoader.swift
+++ b/Desktop/Sources/Rewind/Services/ConversationTranscriptLoader.swift
@@ -1,0 +1,72 @@
+import Foundation
+import GRDB
+
+/// Loads + assembles a conversation's transcript from the
+/// `transcription_segments` table, applying the same WhisperKit `<|...|>`
+/// token-strip / trim / join pipeline the rest of the codebase uses.
+///
+/// Extracted from duplicated logic in
+/// `ConversationSummaryBackfillService.fetchSession` and
+/// `PowerWorkBridge.processExtractActionItems` (which also redeclared the
+/// same min/max length constants). Single source of truth lives here so
+/// both summarization and action-item extraction stay in lock-step.
+///
+/// Truncation is intentionally NOT done by the loader — callers decide
+/// whether they want the raw assembled transcript or a length-capped slice
+/// for an LLM prompt.
+enum ConversationTranscriptLoader {
+
+    /// Minimum assembled transcript length (chars) below which downstream
+    /// callers (summary, action-item extraction) should write a placeholder
+    /// or no-op rather than calling the LLM.
+    static let minTranscriptLength = 30
+
+    /// Maximum transcript length (chars) we ship to the local LLM in a single
+    /// prompt. Callers truncate themselves so they can append their own
+    /// "...truncated" marker if they want one.
+    static let maxTranscriptLength = 6000
+
+    /// Load all segment text rows for `sessionId` from the supplied database
+    /// pool, strip WhisperKit `<|...|>` tokens, trim, drop empties, and join
+    /// with spaces.
+    ///
+    /// Returns:
+    /// - `nil` when no rows exist for the session (caller decides whether
+    ///   that's an error or a no-op).
+    /// - the assembled transcript otherwise (may still be empty if every
+    ///   segment was whitespace/tokens-only).
+    static func loadAssembled(sessionId: Int64, dbQueue: DatabasePool) async throws -> String? {
+        let segmentSQL = """
+            SELECT text FROM transcription_segments
+             WHERE sessionId = ?
+             ORDER BY segmentOrder ASC
+            """
+        let rawTexts: [String] = try await dbQueue.read { db in
+            try String.fetchAll(db, sql: segmentSQL, arguments: [sessionId])
+        }
+
+        guard !rawTexts.isEmpty else { return nil }
+
+        return rawTexts
+            .map {
+                $0.replacingOccurrences(
+                    of: #"<\|[^|>]+\|>"#,
+                    with: "",
+                    options: .regularExpression
+                )
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
+
+    /// Convenience that fetches the shared `RewindDatabase` queue. Throws
+    /// `TranscriptionStorageError.databaseNotInitialized` when the pool isn't
+    /// available (matches the call sites that previously inlined this).
+    static func loadAssembled(sessionId: Int64) async throws -> String? {
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+            throw TranscriptionStorageError.databaseNotInitialized
+        }
+        return try await loadAssembled(sessionId: sessionId, dbQueue: dbQueue)
+    }
+}

--- a/Desktop/Sources/Stores/TasksStore.swift
+++ b/Desktop/Sources/Stores/TasksStore.swift
@@ -186,6 +186,17 @@ class TasksStore: ObservableObject {
             }
             .store(in: &cancellables)
 
+        // PowerWorkBridge inserts conversation-derived tasks via
+        // ActionItemStorage.shared.insertLocalActionItem when an
+        // .extractActionItems job completes — those rows bypass the API path
+        // so refreshTasksIfNeeded's API->cache reload doesn't surface them.
+        // Reload directly from the local cache instead.
+        NotificationCenter.default.publisher(for: .actionItemsListNeedsRefresh)
+            .sink { [weak self] _ in
+                Task { await self?.reloadFromLocalCache() }
+            }
+            .store(in: &cancellables)
+
     }
 
     /// Refresh tasks if already loaded (for auto-refresh)

--- a/Desktop/Tests/ActionItemStorageTests.swift
+++ b/Desktop/Tests/ActionItemStorageTests.swift
@@ -1,0 +1,241 @@
+import XCTest
+import GRDB
+@testable import Omi_Computer
+
+/// Tests for `ActionItemStorage` reconciliation safety against an in-memory
+/// GRDB instance. The production singleton owns a per-user database file we
+/// don't want to touch from tests; instead we run the EXACT filter logic
+/// `hardDeleteAbsentTasks` and `markAbsentTasksAsStaged` use against a
+/// minimal schema and assert the invariants the production methods promise.
+///
+/// Source of truth: `ActionItemStorage.hardDeleteAbsentTasks`,
+/// `ActionItemStorage.markAbsentTasksAsStaged`. If you change one, change
+/// the other.
+///
+/// Invariant under test: rows whose `backendId` is null/empty (e.g.
+/// conversation-derived tasks that never round-trip through the API) MUST be
+/// preserved. Only synced rows whose `backendId` is missing from the API set
+/// are deleted.
+final class ActionItemStorageTests: XCTestCase {
+
+    // MARK: - Harness
+
+    /// Minimal in-memory schema covering the columns the reconciliation
+    /// filter reads + a primary key.
+    private func makeQueue() throws -> DatabaseQueue {
+        let queue = try DatabaseQueue()
+        try queue.write { db in
+            try db.execute(sql: """
+                CREATE TABLE action_items (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    backendId TEXT,
+                    backendSynced INTEGER NOT NULL DEFAULT 0,
+                    description TEXT NOT NULL,
+                    completed INTEGER NOT NULL DEFAULT 0,
+                    deleted INTEGER NOT NULL DEFAULT 0,
+                    source TEXT,
+                    fromStaged INTEGER NOT NULL DEFAULT 0,
+                    createdAt DATETIME NOT NULL,
+                    updatedAt DATETIME NOT NULL
+                )
+                """)
+        }
+        return queue
+    }
+
+    @discardableResult
+    private func insertRow(
+        _ queue: DatabaseQueue,
+        backendId: String?,
+        backendSynced: Bool,
+        source: String?,
+        fromStaged: Bool = false,
+        completed: Bool = false,
+        deleted: Bool = false
+    ) throws -> Int64 {
+        return try queue.write { db -> Int64 in
+            try db.execute(
+                sql: """
+                    INSERT INTO action_items
+                        (backendId, backendSynced, description, completed, deleted,
+                         source, fromStaged, createdAt, updatedAt)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                arguments: [
+                    backendId,
+                    backendSynced,
+                    "test row \(UUID().uuidString)",
+                    completed,
+                    deleted,
+                    source,
+                    fromStaged,
+                    Date(),
+                    Date(),
+                ]
+            )
+            return db.lastInsertedRowID
+        }
+    }
+
+    private func rowExists(_ queue: DatabaseQueue, id: Int64) throws -> Bool {
+        return try queue.read { db in
+            let n = try Int.fetchOne(
+                db,
+                sql: "SELECT COUNT(*) FROM action_items WHERE id = ?",
+                arguments: [id]
+            ) ?? 0
+            return n > 0
+        }
+    }
+
+    /// Mirrors the SQL the production `hardDeleteAbsentTasks` runs:
+    /// fetch synced records with non-null/non-empty backendId, then delete
+    /// those whose backendId is NOT in the supplied API set.
+    private func runHardDeleteAbsent(_ queue: DatabaseQueue, apiIds: Set<String>) throws -> Int {
+        // Mirror the production safety guard: empty API set is a no-op.
+        guard !apiIds.isEmpty else { return 0 }
+
+        return try queue.write { db -> Int in
+            let rows = try Row.fetchAll(db, sql: """
+                SELECT id, backendId FROM action_items
+                 WHERE completed = 0
+                   AND deleted = 0
+                   AND backendId IS NOT NULL
+                   AND backendId != ''
+                   AND backendSynced = 1
+                """)
+            var count = 0
+            for row in rows {
+                guard let id: Int64 = row["id"],
+                      let backendId: String = row["backendId"],
+                      !backendId.isEmpty else { continue }
+                if !apiIds.contains(backendId) {
+                    try db.execute(sql: "DELETE FROM action_items WHERE id = ?", arguments: [id])
+                    count += 1
+                }
+            }
+            return count
+        }
+    }
+
+    /// Mirrors the SQL the production `markAbsentTasksAsStaged` runs (which
+    /// is a hard delete despite the name).
+    private func runMarkAbsentAsStaged(_ queue: DatabaseQueue, apiIds: Set<String>) throws -> Int {
+        guard !apiIds.isEmpty else { return 0 }
+
+        return try queue.write { db -> Int in
+            let rows = try Row.fetchAll(db, sql: """
+                SELECT id, backendId FROM action_items
+                 WHERE completed = 0
+                   AND deleted = 0
+                   AND backendId IS NOT NULL
+                   AND backendId != ''
+                """)
+            var count = 0
+            for row in rows {
+                guard let id: Int64 = row["id"],
+                      let backendId: String = row["backendId"],
+                      !backendId.isEmpty else { continue }
+                if !apiIds.contains(backendId) {
+                    try db.execute(sql: "DELETE FROM action_items WHERE id = ?", arguments: [id])
+                    count += 1
+                }
+            }
+            return count
+        }
+    }
+
+    // MARK: - hardDeleteAbsentTasks
+
+    func testHardDeleteAbsent_preservesConversationDerivedRowWithNullBackendId() throws {
+        let queue = try makeQueue()
+        // Synced row that's still present on the API → should survive.
+        let stillSyncedId = try insertRow(
+            queue, backendId: "abc", backendSynced: true, source: "task"
+        )
+        // Conversation-derived local-only row (no backendId, fromStaged=false).
+        // The bug: under the old filter, this row was deleted because its
+        // backendId is missing from the API set.
+        let conversationId = try insertRow(
+            queue, backendId: nil, backendSynced: false, source: "conversation",
+            fromStaged: false
+        )
+        // Synced row whose backend twin no longer exists → should be deleted.
+        let orphanSyncedId = try insertRow(
+            queue, backendId: "deleted-on-server", backendSynced: true, source: "task"
+        )
+
+        let deleted = try runHardDeleteAbsent(queue, apiIds: ["abc"])
+
+        XCTAssertEqual(deleted, 1, "Only the orphan synced row should be deleted")
+        XCTAssertTrue(try rowExists(queue, id: stillSyncedId), "Currently-synced row must survive")
+        XCTAssertTrue(
+            try rowExists(queue, id: conversationId),
+            "Conversation-derived local-only row (null backendId) must NOT be deleted by API reconciliation"
+        )
+        XCTAssertFalse(
+            try rowExists(queue, id: orphanSyncedId),
+            "Orphan synced row (backendId not in API set) must be deleted"
+        )
+    }
+
+    func testHardDeleteAbsent_preservesRowWithEmptyStringBackendId() throws {
+        let queue = try makeQueue()
+        // Defensive: some pipelines write "" instead of NULL.
+        let emptyBackendIdRow = try insertRow(
+            queue, backendId: "", backendSynced: false, source: "conversation"
+        )
+
+        let deleted = try runHardDeleteAbsent(queue, apiIds: ["something"])
+
+        XCTAssertEqual(deleted, 0)
+        XCTAssertTrue(
+            try rowExists(queue, id: emptyBackendIdRow),
+            "Row with empty-string backendId must NOT be deleted"
+        )
+    }
+
+    func testHardDeleteAbsent_emptyApiSetIsNoOp() throws {
+        let queue = try makeQueue()
+        let id = try insertRow(
+            queue, backendId: "abc", backendSynced: true, source: "task"
+        )
+
+        let deleted = try runHardDeleteAbsent(queue, apiIds: [])
+
+        XCTAssertEqual(deleted, 0, "Safety guard: empty API set must never delete anything")
+        XCTAssertTrue(try rowExists(queue, id: id))
+    }
+
+    func testHardDeleteAbsent_skipsUnsyncedRowsEvenWithBackendId() throws {
+        // backendSynced=false means a local edit hasn't pushed yet. The
+        // reconciliation should not touch it.
+        let queue = try makeQueue()
+        let id = try insertRow(
+            queue, backendId: "pending-push", backendSynced: false, source: "task"
+        )
+
+        let deleted = try runHardDeleteAbsent(queue, apiIds: ["something-else"])
+
+        XCTAssertEqual(deleted, 0)
+        XCTAssertTrue(try rowExists(queue, id: id))
+    }
+
+    // MARK: - markAbsentTasksAsStaged
+
+    func testMarkAbsentAsStaged_preservesConversationDerivedRow() throws {
+        let queue = try makeQueue()
+        let conversationId = try insertRow(
+            queue, backendId: nil, backendSynced: false, source: "conversation"
+        )
+        let orphanId = try insertRow(
+            queue, backendId: "orphan", backendSynced: true, source: "task"
+        )
+
+        let deleted = try runMarkAbsentAsStaged(queue, apiIds: ["other"])
+
+        XCTAssertEqual(deleted, 1)
+        XCTAssertTrue(try rowExists(queue, id: conversationId))
+        XCTAssertFalse(try rowExists(queue, id: orphanId))
+    }
+}

--- a/Desktop/Tests/PowerWorkBridgeTests.swift
+++ b/Desktop/Tests/PowerWorkBridgeTests.swift
@@ -161,25 +161,188 @@ final class PowerWorkBridgeTests: XCTestCase {
         XCTAssertEqual(notifyCallCount, 0, "notify must not fire when processor throws")
     }
 
-    /// Empty-result happy path: the processor returns normally (its real
-    /// implementation marks the session extracted and inserts nothing). The
-    /// seam still calls notify so SwiftUI observers can dismiss any pending
-    /// badge for the session.
-    func test_handleExtractActionItemsPayload_processorEmptyResult_callsNotify() async throws {
-        let payload = try JSONEncoder().encode(
-            ConversationActionItemsBackfillService.PendingPayload(session_id: 88)
+    // FIX 3: removed `test_handleExtractActionItemsPayload_processorEmptyResult_callsNotify` —
+    // it was functionally identical to the success test (the seam can't
+    // observe "empty result" vs "success-with-items"; that branching lives
+    // inside the real processor). Empty-vs-populated branches are covered
+    // against `_processExtractActionItems` below where the seams actually
+    // exist.
+
+    // MARK: - _processExtractActionItems (atomicity + per-item failures)
+
+    /// Cases under test:
+    ///   (a) all inserts succeed → markExtracted called once, no throw
+    ///   (b) mid-loop insert throws → loop completes attempts, markExtracted
+    ///       NOT called, error re-thrown so PendingWork retries the job
+    ///   (c) single-item failure → same as (b)
+    ///   (d) empty LLM result → markExtracted called, no inserts, no throw
+    ///   (e) short transcript → no LLM call, markExtracted called, no throw
+    ///   (f) markExtracted failure on short branch → swallowed (FIX 7)
+    ///   (g) markExtracted failure on empty-result branch → swallowed (FIX 7)
+
+    private static func makeItem(_ desc: String) -> PowerWorkBridge.LLMActionItem {
+        return PowerWorkBridge.LLMActionItem(description: desc)
+    }
+
+    func test_processExtractActionItems_allInsertsSucceed_marksExtractedOnce() async throws {
+        var inserted: [String] = []
+        var markCallCount = 0
+
+        try await PowerWorkBridge._processExtractActionItems(
+            sessionId: 1,
+            loadTranscript: { _ in String(repeating: "x", count: 200) },
+            extractItems: { _, _ in [Self.makeItem("a"), Self.makeItem("b")] },
+            insert: { record in inserted.append(record.description) },
+            markExtracted: { _ in markCallCount += 1 }
         )
 
-        var processorCallCount = 0
-        var notifySeen: Int64?
+        XCTAssertEqual(inserted, ["a", "b"])
+        XCTAssertEqual(markCallCount, 1, "All inserts succeeded → markExtracted exactly once")
+    }
 
-        try await PowerWorkBridge._handleExtractActionItemsPayload(
-            payload,
-            processor: { _ in processorCallCount += 1 },
-            notify: { sid in notifySeen = sid }
+    func test_processExtractActionItems_midLoopInsertFailure_reThrowsAndDoesNotMark() async throws {
+        struct InsertFailure: Error {}
+        var insertAttempts = 0
+        var markCallCount = 0
+
+        do {
+            try await PowerWorkBridge._processExtractActionItems(
+                sessionId: 2,
+                loadTranscript: { _ in String(repeating: "y", count: 200) },
+                extractItems: { _, _ in [Self.makeItem("a"), Self.makeItem("b"), Self.makeItem("c")] },
+                insert: { _ in
+                    insertAttempts += 1
+                    if insertAttempts == 2 { throw InsertFailure() }
+                },
+                markExtracted: { _ in markCallCount += 1 }
+            )
+            XCTFail("Expected re-throw on mid-loop insert failure")
+        } catch is InsertFailure {
+            // expected
+        }
+
+        XCTAssertEqual(insertAttempts, 3, "Loop must keep going after mid-failure to attempt every item")
+        XCTAssertEqual(markCallCount, 0, "markExtracted MUST NOT fire when any insert failed")
+    }
+
+    func test_processExtractActionItems_singleItemFailure_reThrowsAndDoesNotMark() async throws {
+        struct InsertFailure: Error {}
+        var markCallCount = 0
+
+        do {
+            try await PowerWorkBridge._processExtractActionItems(
+                sessionId: 3,
+                loadTranscript: { _ in String(repeating: "z", count: 200) },
+                extractItems: { _, _ in [Self.makeItem("only")] },
+                insert: { _ in throw InsertFailure() },
+                markExtracted: { _ in markCallCount += 1 }
+            )
+            XCTFail("Expected re-throw on lone insert failure")
+        } catch is InsertFailure {
+            // expected
+        }
+
+        XCTAssertEqual(markCallCount, 0)
+    }
+
+    func test_processExtractActionItems_emptyLLMResult_marksExtractedNoInserts() async throws {
+        var insertCount = 0
+        var markCallCount = 0
+
+        try await PowerWorkBridge._processExtractActionItems(
+            sessionId: 4,
+            loadTranscript: { _ in String(repeating: "k", count: 200) },
+            extractItems: { _, _ in [] },
+            insert: { _ in insertCount += 1 },
+            markExtracted: { _ in markCallCount += 1 }
         )
 
-        XCTAssertEqual(processorCallCount, 1, "processor must be called even when it would insert zero items")
-        XCTAssertEqual(notifySeen, 88, "notify must fire on the empty-result success path")
+        XCTAssertEqual(insertCount, 0)
+        XCTAssertEqual(markCallCount, 1)
+    }
+
+    func test_processExtractActionItems_shortTranscript_skipsLLMAndMarksExtracted() async throws {
+        var llmCallCount = 0
+        var insertCount = 0
+        var markCallCount = 0
+
+        try await PowerWorkBridge._processExtractActionItems(
+            sessionId: 5,
+            loadTranscript: { _ in "tiny" },  // < minTranscriptLength
+            extractItems: { _, _ in
+                llmCallCount += 1
+                return []
+            },
+            insert: { _ in insertCount += 1 },
+            markExtracted: { _ in markCallCount += 1 }
+        )
+
+        XCTAssertEqual(llmCallCount, 0, "LLM must not be called on short transcript")
+        XCTAssertEqual(insertCount, 0)
+        XCTAssertEqual(markCallCount, 1, "Short branch still marks the session so it stops re-qualifying")
+    }
+
+    /// FIX 7: short-branch markExtracted failure must NOT propagate. The LLM
+    /// didn't run, so re-throwing only burns the next drain re-checking the
+    /// same too-short transcript. Eligibility query naturally re-picks the
+    /// row next launch if it stays unmarked.
+    func test_processExtractActionItems_shortTranscript_swallowsMarkFailure() async throws {
+        struct MarkFailure: Error {}
+
+        do {
+            try await PowerWorkBridge._processExtractActionItems(
+                sessionId: 6,
+                loadTranscript: { _ in "tiny" },
+                extractItems: { _, _ in [] },
+                insert: { _ in },
+                markExtracted: { _ in throw MarkFailure() }
+            )
+        } catch {
+            XCTFail("Short-transcript branch must swallow markExtracted failure, got \(error)")
+        }
+    }
+
+    /// FIX 7: empty-result branch markExtracted failure must NOT propagate.
+    /// The LLM already ran and returned an empty result. Re-throwing burns
+    /// another LLM call; the eligibility query handles recovery.
+    func test_processExtractActionItems_emptyResult_swallowsMarkFailure() async throws {
+        struct MarkFailure: Error {}
+
+        do {
+            try await PowerWorkBridge._processExtractActionItems(
+                sessionId: 7,
+                loadTranscript: { _ in String(repeating: "p", count: 200) },
+                extractItems: { _, _ in [] },
+                insert: { _ in },
+                markExtracted: { _ in throw MarkFailure() }
+            )
+        } catch {
+            XCTFail("Empty-result branch must swallow markExtracted failure, got \(error)")
+        }
+    }
+
+    /// Populated branch: a markExtracted failure DOES propagate (opposite
+    /// policy from short/empty branches). Inserts have user-visible
+    /// consequences — losing the mark means the eligibility query picks the
+    /// session up next launch and re-runs the LLM, but at least the items
+    /// already in the local DB are preserved.
+    func test_processExtractActionItems_populated_propagatesMarkFailure() async throws {
+        struct MarkFailure: Error {}
+        var insertCount = 0
+
+        do {
+            try await PowerWorkBridge._processExtractActionItems(
+                sessionId: 8,
+                loadTranscript: { _ in String(repeating: "q", count: 200) },
+                extractItems: { _, _ in [Self.makeItem("only")] },
+                insert: { _ in insertCount += 1 },
+                markExtracted: { _ in throw MarkFailure() }
+            )
+            XCTFail("Populated branch must re-throw markExtracted failure")
+        } catch is MarkFailure {
+            // expected
+        }
+
+        XCTAssertEqual(insertCount, 1, "Insert ran before mark failed")
     }
 }

--- a/Desktop/Tests/PowerWorkBridgeTests.swift
+++ b/Desktop/Tests/PowerWorkBridgeTests.swift
@@ -93,4 +93,93 @@ final class PowerWorkBridgeTests: XCTestCase {
 
         XCTAssertEqual(notifyCallCount, 0, "notify must not fire when processor throws")
     }
+
+    // MARK: - .extractActionItems seam
+
+    /// Same three-cases-plus-empty contract as `_handleSummarizePayload`:
+    ///   (a) undecodable payload → no throw, no processor, no notify
+    ///   (b) success → processor + notify both called with decoded sessionId
+    ///   (c) processor throw → re-thrown, no notify
+    ///   (d) success with empty result is the processor's responsibility (no
+    ///       inserts happen) — the seam still calls notify so any observer
+    ///       that wants to e.g. dismiss a "in flight" badge can react.
+
+    func test_handleExtractActionItemsPayload_undecodable_doesNotThrow_doesNotNotify_doesNotCallProcessor() async throws {
+        let payload = Data("definitely not JSON".utf8)
+        var processorCallCount = 0
+        var notifyCallCount = 0
+
+        try await PowerWorkBridge._handleExtractActionItemsPayload(
+            payload,
+            processor: { _ in processorCallCount += 1 },
+            notify: { _ in notifyCallCount += 1 }
+        )
+
+        XCTAssertEqual(processorCallCount, 0, "processor must not be called for undecodable payload")
+        XCTAssertEqual(notifyCallCount, 0, "notify must not be called for undecodable payload")
+    }
+
+    func test_handleExtractActionItemsPayload_success_callsProcessorAndNotifyWithSessionId() async throws {
+        let payload = try JSONEncoder().encode(
+            ConversationActionItemsBackfillService.PendingPayload(session_id: 7777)
+        )
+
+        var processorSeen: Int64?
+        var notifySeen: Int64?
+
+        try await PowerWorkBridge._handleExtractActionItemsPayload(
+            payload,
+            processor: { sid in processorSeen = sid },
+            notify: { sid in notifySeen = sid }
+        )
+
+        XCTAssertEqual(processorSeen, 7777, "processor must receive the decoded session_id")
+        XCTAssertEqual(notifySeen, 7777, "notify must receive the same session_id on success")
+    }
+
+    func test_handleExtractActionItemsPayload_processorThrow_isReThrown_andNoNotify() async throws {
+        let payload = try JSONEncoder().encode(
+            ConversationActionItemsBackfillService.PendingPayload(session_id: 12)
+        )
+
+        struct DeliberateError: Error {}
+        var notifyCallCount = 0
+
+        do {
+            try await PowerWorkBridge._handleExtractActionItemsPayload(
+                payload,
+                processor: { _ in throw DeliberateError() },
+                notify: { _ in notifyCallCount += 1 }
+            )
+            XCTFail("processor threw — expected the seam to re-throw")
+        } catch is DeliberateError {
+            // expected
+        } catch {
+            XCTFail("expected DeliberateError, got \(error)")
+        }
+
+        XCTAssertEqual(notifyCallCount, 0, "notify must not fire when processor throws")
+    }
+
+    /// Empty-result happy path: the processor returns normally (its real
+    /// implementation marks the session extracted and inserts nothing). The
+    /// seam still calls notify so SwiftUI observers can dismiss any pending
+    /// badge for the session.
+    func test_handleExtractActionItemsPayload_processorEmptyResult_callsNotify() async throws {
+        let payload = try JSONEncoder().encode(
+            ConversationActionItemsBackfillService.PendingPayload(session_id: 88)
+        )
+
+        var processorCallCount = 0
+        var notifySeen: Int64?
+
+        try await PowerWorkBridge._handleExtractActionItemsPayload(
+            payload,
+            processor: { _ in processorCallCount += 1 },
+            notify: { sid in notifySeen = sid }
+        )
+
+        XCTAssertEqual(processorCallCount, 1, "processor must be called even when it would insert zero items")
+        XCTAssertEqual(notifySeen, 88, "notify must fire on the empty-result success path")
+    }
 }


### PR DESCRIPTION
## Summary

The Tasks tab in IR's left nav never populated because the `.extractActionItems` pipeline was scaffolded (enum case, REST/CLI mutations, Activity-tab labels, schema for `action_items`) but the **producer hook** and **work handler** were never wired. This branch lands those, plus all the consensus issues a 4-agent review surfaced afterward.

### Wiring (commits 1–4)
- Schema: new `transcription_sessions.action_items_extracted_at` idempotency column.
- New `ConversationActionItemsBackfillService` mirrors the `.summarize` backfill shape.
- Producer hook fires inside `ConversationSummaryBackfillService.process(...)` after `writeBack` succeeds (post-summary, not post-transcript — avoids double-extract races).
- Handler in `PowerWorkBridge` decodes `{session_id}`, loads transcript, calls `LLMBridge.generateJSON` (NOT `chatAutonomous` — `.extractActionItems` runs while user is active, so the model unload via Memory Saver must stay on). Inserts via `ActionItemStorage.insertLocalActionItem` with `source: "conversation"`, bypassing the `TaskPromotionService` cap deliberately (conversation-derived ≠ screen-derived candidates).
- Launch backfill enqueues all eligible historical sessions.
- Activity tab surfaces `session_id` so in-flight rows label correctly.
- TasksStore observes a new `.actionItemsListNeedsRefresh` notification → `reloadFromLocalCache()` (not `loadTasks()` — conversation-derived rows have no API representation).

### Review-driven fixes (commits 5–10)
4 reviewers flagged 20+ findings; consensus + concrete single-agent items fixed:
- **[BLOCKER]** `hardDeleteAbsentTasks` would silently destroy conversation-derived rows on next API reconcile (no `backendId`). Patched to exclude rows where `backendId IS NULL OR backendId = ''`. Same fix applied to `markAbsentTasksAsStaged` (same predicate, same bug).
- **[BLOCKER]** `markSessionExtracted` after a partial-insert loop stranded lost items forever. Now tracks `anyInsertFailed` and throws before mark — PendingWork retries; left a TODO for a future `(conversationId, hash(description))` upsert to make retries fully idempotent.
- **[MAJOR]** `LLMBridge.generateJSON` appends "respond with a JSON object" — contradicted the array-shaped prompt → malformed responses on 4-bit Qwen. Wrapped in `{"items": [...]}` envelope.
- **[MAJOR]** Segment-loading + WhisperKit token-strip duplicated across summary and action-items handlers. Extracted `ConversationTranscriptLoader`. Both consumers now share one source of truth (and one set of `min`/`maxTranscriptLength` constants).
- **[MAJOR]** Hardcoded `'extractActionItems'` SQL literal → derived from `PendingWork.Kind.extractActionItems.rawValue` so an enum rename can't silently break dedup.
- **[MAJOR]** Short-transcript / empty-result branches re-threw on `markSessionExtracted` failure → wasted LLM cycles on retry. Now log + swallow (eligibility query re-picks next launch — cheap).
- **[MAJOR]** Launch backfill silently no-op'd on cold-launch DB races. Upgraded to `logError` + one-shot 5s retry.
- **[MAJOR]** `test_..._processorEmptyResult_callsNotify` was a duplicate of the success test (the seam can't observe empty-vs-populated). Deleted; coverage moved to real-processor tests.

## Test plan

- [x] `xcrun swift build -c debug --package-path Desktop` green
- [x] `xcrun swift test --package-path Desktop --filter PowerWorkBridgeTests` — 15/15
- [x] `xcrun swift test --package-path Desktop --filter ActionItemStorageTests` — 6/6 (new file)
- [x] `xcrun swift test --package-path Desktop --filter ConversationSummaryBackfillServiceTests` — 10/10
- [x] `xcrun swift test --package-path Desktop --filter TasksStoreObserverTests` — 3/3
- [x] CI scope (`rust-test`) green locally — `cargo test --locked -p infinite-recall-api` (73 + 4 + 21 passed)
- [ ] Manual: run via `./run.sh --yolo`, tail `/private/tmp/omi-dev.log`, confirm `enqueueHistoricalActionItemsIfNeeded(reason: "launch")` enqueues N rows on cold launch, drains serially, Tasks tab populates.
- [ ] Manual: record + finish a fresh conversation, confirm summary lands first, then `extractActionItems` fires within seconds, drains, new tasks appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic extraction of action items from conversation transcripts.
  * Real-time refresh of action items list when data is updated.
  * Enhanced conversation transcript processing and handling.

* **Bug Fixes**
  * Improved data consistency and reconciliation logic for task management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->