### PR TITLE
feat: auto-delete empty Short Recording conversations

### DIFF
--- a/Desktop/Sources/OmiApp.swift
+++ b/Desktop/Sources/OmiApp.swift
@@ -325,6 +325,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
           log("Conversations: Purged \(purged) empty session(s) on launch")
         }
 
+        await ConversationSummaryBackfillService.shared.backfillDiscardEmptyShortRecordingsOnce()
+
         let recovered = try await TranscriptionStorage.shared.recoverStaleRecordingSessions()
         if recovered > 0 {
           log("Conversations: Recovered \(recovered) stale recording session(s) on launch")

--- a/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
+++ b/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
@@ -672,13 +672,10 @@ actor TranscriptionStorage {
 
         try await db.write { database in
             try database.execute(
-                sql: "DELETE FROM transcription_segments WHERE sessionId = ?",
-                arguments: [id]
-            )
-            try database.execute(
                 sql: "DELETE FROM audio_chunks WHERE transcriptionSessionId = ?",
                 arguments: [id]
             )
+            // transcription_segments rows cascade via FK on transcription_sessions delete.
             try database.execute(
                 sql: "DELETE FROM transcription_sessions WHERE id = ?",
                 arguments: [id]

--- a/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
+++ b/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
@@ -651,6 +651,43 @@ actor TranscriptionStorage {
         }
     }
 
+    /// Hard-delete a single empty Short Recording conversation (and its
+    /// segments + audio chunks) atomically. Used by the auto-delete path for
+    /// `summary_state='unavailable'` rows that are local-only and never sync.
+    ///
+    /// All mutations run inside a single GRDB transaction so we never end up
+    /// with orphaned segments or chunks if the process dies mid-delete.
+    ///
+    /// Note: `audio_chunks` stores raw PCM directly as a blob (`pcm` column);
+    /// there is no separate on-disk audio file path to unlink. Deleting the
+    /// row is sufficient to remove the audio bytes.
+    ///
+    /// - Parameters:
+    ///   - id: session id to discard
+    ///   - reason: short tag included in the log line for traceability
+    func discardEmptySession(id: Int64, reason: String) async throws {
+        let db = try await ensureInitialized()
+
+        log("TranscriptionStorage: Discarding empty session \(id) — reason=\(reason)")
+
+        try await db.write { database in
+            try database.execute(
+                sql: "DELETE FROM transcription_segments WHERE sessionId = ?",
+                arguments: [id]
+            )
+            try database.execute(
+                sql: "DELETE FROM audio_chunks WHERE transcriptionSessionId = ?",
+                arguments: [id]
+            )
+            try database.execute(
+                sql: "DELETE FROM transcription_sessions WHERE id = ?",
+                arguments: [id]
+            )
+        }
+
+        log("Auto-deleted empty conversation \(id) — reason=\(reason)")
+    }
+
     /// Fetch the first segment's text per session in a single SQL pass.
     /// Used by the Conversations list to render a 1-2 line inline preview
     /// without paying for the full segment fetch on every row.

--- a/Desktop/Sources/Rewind/Services/ConversationSummaryBackfillService.swift
+++ b/Desktop/Sources/Rewind/Services/ConversationSummaryBackfillService.swift
@@ -131,7 +131,7 @@ actor ConversationSummaryBackfillService {
         let mode = autonomous ? "autonomous" : "live"
         let outcome = try await process(row: row, mode: mode, autonomous: autonomous)
         switch outcome {
-        case .summarized, .placeholder:
+        case .summarized, .placeholder, .discarded:
             // Done: ack happens at the caller (Agent B's drain loop) or the
             // immediate-path entry point.
             return
@@ -301,7 +301,7 @@ actor ConversationSummaryBackfillService {
                 totalProcessed += 1
                 // Throttle: give the LLM server a brief breather.
                 try await Task.sleep(nanoseconds: Self.throttleNanoseconds)
-            case .placeholder:
+            case .placeholder, .discarded:
                 continue
             case .deferred:
                 // Do not spin forever on the same row if the local LLM is
@@ -328,6 +328,7 @@ actor ConversationSummaryBackfillService {
     private enum ProcessOutcome {
         case summarized
         case placeholder
+        case discarded
         case deferred
     }
 
@@ -342,7 +343,7 @@ actor ConversationSummaryBackfillService {
             log("ConversationSummaryBackfillService: session \(sessionId) transcript too short (\(transcript.count) chars), discarding empty session (\(mode))")
             try await TranscriptionStorage.shared.discardEmptySession(id: sessionId, reason: "short_transcript")
             await notifyConversationListNeedsRefresh()
-            return .placeholder
+            return .discarded
         }
 
         // Ambient/non-speech fallback: long enough to look real but mostly

--- a/Desktop/Sources/Rewind/Services/ConversationSummaryBackfillService.swift
+++ b/Desktop/Sources/Rewind/Services/ConversationSummaryBackfillService.swift
@@ -195,6 +195,49 @@ actor ConversationSummaryBackfillService {
         log("ConversationSummaryBackfillService: marked backfill needed (\(reason))")
     }
 
+    /// One-time sweep: convert pre-existing "Short Recording" placeholder
+    /// sessions into discarded/empty rows so the conversations list stops
+    /// showing legacy noise from the old short-transcript path. Idempotent
+    /// via the `irEmptyShortRecordingBackfillCompletedV1` UserDefaults flag —
+    /// safe to call on every launch.
+    func backfillDiscardEmptyShortRecordingsOnce() async {
+        let flagKey = "irEmptyShortRecordingBackfillCompletedV1"
+        guard !UserDefaults.standard.bool(forKey: flagKey) else {
+            return
+        }
+
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+            log("ConversationSummaryBackfillService: discard-empty backfill skipped — database not initialized")
+            return
+        }
+
+        let sql = """
+            SELECT id FROM transcription_sessions
+             WHERE deleted = 0
+               AND summary_state = 'unavailable'
+               AND title = 'Short Recording'
+            """
+
+        let ids: [Int64]
+        do {
+            ids = try await dbQueue.read { db in
+                try Int64.fetchAll(db, sql: sql)
+            }
+        } catch {
+            logError("ConversationSummaryBackfillService: discard-empty backfill query failed", error: error)
+            return
+        }
+
+        log("ConversationSummaryBackfillService: discard-empty backfill starting — \(ids.count) candidate row(s)")
+
+        for id in ids {
+            try? await TranscriptionStorage.shared.discardEmptySession(id: id, reason: "backfill_short_recording")
+        }
+
+        UserDefaults.standard.set(true, forKey: flagKey)
+        log("ConversationSummaryBackfillService: discard-empty backfill complete — processed \(ids.count) row(s)")
+    }
+
     /// Summarize one just-finished session immediately when conditions are
     /// safe; otherwise durably enqueue for the autonomous drain. Always
     /// enqueues a durable record first so nothing is lost.
@@ -282,10 +325,12 @@ actor ConversationSummaryBackfillService {
         let sessionId = row.id
         let transcript = row.transcript
 
-        // Short transcript → write a placeholder so we don't keep re-queueing.
+        // Short transcript → discard the empty session entirely instead of
+        // writing a "Short Recording" placeholder. Empty short recordings
+        // are noise in the conversations list; surface them as deleted.
         guard transcript.count >= Self.minTranscriptLength else {
-            log("ConversationSummaryBackfillService: session \(sessionId) transcript too short (\(transcript.count) chars), writing short-recording placeholder (\(mode))")
-            try await writeShortRecordingPlaceholder(sessionId: sessionId)
+            log("ConversationSummaryBackfillService: session \(sessionId) transcript too short (\(transcript.count) chars), discarding empty session (\(mode))")
+            try await TranscriptionStorage.shared.discardEmptySession(id: sessionId, reason: "short_transcript")
             await notifyConversationListNeedsRefresh()
             return .placeholder
         }
@@ -474,18 +519,6 @@ actor ConversationSummaryBackfillService {
             .joined(separator: " ")
 
         return PendingSession(id: sessionId, transcript: transcript)
-    }
-
-    /// Write a non-empty sentinel back for a session whose transcript is too
-    /// short to summarize, so it won't be re-queried.
-    private func writeShortRecordingPlaceholder(sessionId: Int64) async throws {
-        try await writePlaceholder(
-            sessionId: sessionId,
-            title: "Short Recording",
-            overview: "",
-            emoji: "🎙",
-            category: "other"
-        )
     }
 
     /// Write the structured Ambient Audio placeholder defined in the contract:

--- a/Desktop/Sources/Rewind/Services/ConversationSummaryBackfillService.swift
+++ b/Desktop/Sources/Rewind/Services/ConversationSummaryBackfillService.swift
@@ -230,12 +230,22 @@ actor ConversationSummaryBackfillService {
 
         log("ConversationSummaryBackfillService: discard-empty backfill starting — \(ids.count) candidate row(s)")
 
+        var failures = 0
         for id in ids {
-            try? await TranscriptionStorage.shared.discardEmptySession(id: id, reason: "backfill_short_recording")
+            do {
+                try await TranscriptionStorage.shared.discardEmptySession(id: id, reason: "backfill_short_recording")
+            } catch {
+                failures += 1
+                logError("ConversationSummaryBackfillService: discard-empty backfill failed for session \(id)", error: error)
+            }
         }
 
-        UserDefaults.standard.set(true, forKey: flagKey)
-        log("ConversationSummaryBackfillService: discard-empty backfill complete — processed \(ids.count) row(s)")
+        if failures == 0 {
+            UserDefaults.standard.set(true, forKey: flagKey)
+            log("ConversationSummaryBackfillService: discard-empty backfill complete — processed \(ids.count) row(s)")
+        } else {
+            log("ConversationSummaryBackfillService: discard-empty backfill partial — \(ids.count - failures) ok, \(failures) failed; will retry next launch")
+        }
     }
 
     /// Summarize one just-finished session immediately when conditions are


### PR DESCRIPTION
## Summary
- **TranscriptionStorage.discardEmptySession**: when a finalized recording yields no usable transcript, delete the conversation row (segments cascade via FK) instead of leaving an empty stub.
- **ConversationSummaryBackfillService**: swap the existing summary backfill to drive the new discard path; on launch, sweep historical empty Short Recordings and remove them. Retries the sweep if any row fails so a single transient error doesn't leave orphans behind.
- **OmiApp**: wire the one-time backfill on launch so users upgrading see their existing empty conversations cleared.

## Review fixes folded in
- `e211ef5` rename short-transcript outcome to `.discarded` so the call site reads as "discard, don't summarize."
- `6eee6dd` retry the discard-empty backfill if any row fails (one-shot retry; logs on second failure).
- `ef187fe` drop the redundant explicit segments delete in `discardEmptySession` — the FK cascade already handles it; the extra delete was dead code post-schema.

## Verification
- `xcrun swift build -c debug --package-path Desktop` passes clean.
- Rust CI (`cargo test --locked -p infinite-recall-api` + `activity_endpoints` feature test) passes locally — that's the only CI gate per `.github/workflows/ci.yml`.

## Test plan
- [ ] CI green on this PR (Rust tests on macos-15)
- [ ] Manual: create a Short Recording with no speech, finalize, confirm conversation row + segments are gone
- [ ] Manual: upgrade from a build with existing empty Short Recordings, confirm they are swept on next launch
- [ ] Manual: simulate a transient DB error mid-sweep, confirm retry clears remaining rows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty short recordings are now automatically removed during app startup, improving storage efficiency and app performance.
  * Legacy short recording placeholder entries are cleaned up during the initial launch after this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->