### PR TITLE
fix(scheduler): surface handler errors + stop test pollution of prod queue

### DIFF
--- a/Desktop/Sources/Power/BatteryAwareScheduler.swift
+++ b/Desktop/Sources/Power/BatteryAwareScheduler.swift
@@ -502,6 +502,10 @@ public final class BatteryAwareScheduler: ObservableObject {
         }
         // === /activity:G ===
       } catch {
+        logError(
+          "BatteryAwareScheduler: handler threw for \(work.kind.rawValue) id=\(storageId)",
+          error: error
+        )
         try? await PendingWorkStorage.shared.fail(storageId: storageId, error: error)
         // === activity:G ===
         self.inFlight[work.kind] = nil

--- a/Desktop/Tests/PendingWorkStorageDelegateTests.swift
+++ b/Desktop/Tests/PendingWorkStorageDelegateTests.swift
@@ -58,10 +58,29 @@ final class PendingWorkStorageDelegateTests: XCTestCase {
         }
     }
 
+    /// Purge any leftover rows this test class has written to the real
+    /// `pending_work` table. Without this, `failed` and `dead` rows accumulate
+    /// in the developer's production DB and the `BatteryAwareScheduler` drain
+    /// loop later trips on their non-JSON payloads.
+    private func purgeTestRows() async throws {
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else { return }
+        try await dbQueue.write { db in
+            try db.execute(
+                sql: "DELETE FROM pending_work WHERE payload LIKE 'delegate-test-%'"
+            )
+        }
+    }
+
+    override func setUp() async throws {
+        try await super.setUp()
+        try await purgeTestRows()
+    }
+
     override func tearDown() async throws {
         // Always clear the delegate so the singleton doesn't carry a stale
         // reference into the next test class.
         await PendingWorkStorage.shared.setDelegate(nil)
+        try await purgeTestRows()
         try await super.tearDown()
     }
 

--- a/Desktop/Tests/PendingWorkStorageDelegateTests.swift
+++ b/Desktop/Tests/PendingWorkStorageDelegateTests.swift
@@ -63,16 +63,25 @@ final class PendingWorkStorageDelegateTests: XCTestCase {
     /// in the developer's production DB and the `BatteryAwareScheduler` drain
     /// loop later trips on their non-JSON payloads.
     private func purgeTestRows() async throws {
-        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else { return }
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+            XCTFail("purgeTestRows: no database queue available — test isolation cannot be guaranteed")
+            return
+        }
         try await dbQueue.write { db in
             try db.execute(
-                sql: "DELETE FROM pending_work WHERE payload LIKE 'delegate-test-%'"
+                sql: "DELETE FROM pending_work WHERE dedupKey LIKE 'delegate-%'"
             )
         }
     }
 
     override func setUp() async throws {
         try await super.setUp()
+        // Force the storage actor (and through it, RewindDatabase) to lazily
+        // initialize before `purgeTestRows` reaches into the raw db queue.
+        // Otherwise `getDatabaseQueue()` returns nil on the first setUp of
+        // the process and the purge XCTFails — the queue isn't broken, it
+        // just hasn't been opened yet.
+        _ = await PendingWorkStorage.shared.pendingCount()
         try await purgeTestRows()
     }
 


### PR DESCRIPTION
## Summary

Two coupled bugs surfaced by the silent failure of "Run now":

- `BatteryAwareScheduler` caught handler throws and called `fail()` without logging — the `pending_work` row got booked as `failed`, the next click reclaimed and re-failed it instantly, and the user saw nothing in `omi-dev.log`.
- Root cause of the throw was test pollution: `PendingWorkStorageDelegateTests` writes rows like `delegate-test-fail` directly into the real `~/Library/Application Support/Omi/users/anonymous/omi.db`, and never cleaned up. `BatteryAwareScheduler.handleTranscribe` later tried `JSONSerialization.jsonObject` on those non-JSON payloads and threw on every drain.

### Changes

- **`BatteryAwareScheduler.swift:505`** — log the error before `fail()` in the handler-throw catch arm so the next breakage is observable.
- **`PendingWorkStorageDelegateTests.swift`** — `setUp` + `tearDown` now `DELETE FROM pending_work WHERE dedupKey LIKE 'delegate-%'`. Hardened after multi-agent review: warm DB via `pendingCount()` before purge, `XCTFail` on nil DB queue (not silent return), use TEXT `dedupKey` column instead of BLOB `payload` for the LIKE.

### Out of scope (filed for follow-up)

The same drain loop has 4 sibling `try?` suppressions (lines 402, 419, 482, 540, 647) on `PendingWorkStorage` calls. Validators reached 2-of-3 consensus that singling out one in this PR would be arbitrary; full audit belongs in its own change.

## Test plan

- [x] `xcrun swift test --package-path Desktop --filter PendingWorkStorageDelegateTests` — 6/6 pass
- [x] `cargo test --locked -p infinite-recall-api` (CI rust-test #1) — pass
- [x] `cargo test --locked -p infinite-recall-api --features activity_test_wiring --test activity_endpoints` (CI rust-test #2) — 21/21 pass
- [x] Prod DB queried post-run: 0 `delegate-%` rows remaining
- [x] Cleaned 83 leaked rows from prod DB before this branch landed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for scheduled work operations, now providing comprehensive error logs when tasks fail to improve diagnostics and troubleshooting.

* **Tests**
  * Improved test isolation and reliability by implementing proper database cleanup during test initialization and completion phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->