### PR TITLE
test(onboarding): update OnboardingFlowTests for 19-step flow (#65)

### DIFF
--- a/Desktop/Tests/OnboardingFlowTests.swift
+++ b/Desktop/Tests/OnboardingFlowTests.swift
@@ -3,16 +3,16 @@ import XCTest
 @testable import Omi_Computer
 
 final class OnboardingFlowTests: XCTestCase {
-  func testMergedFlowUsesEighteenSteps() {
+  func testMergedFlowUsesNineteenSteps() {
     XCTAssertEqual(
       OnboardingFlow.steps,
       [
         "Name", "Language", "HowDidYouHear", "Trust", "ScreenRecording",
         "FullDiskAccess", "FileScan", "Microphone", "Accessibility", "Automation",
         "FloatingBarShortcut", "FloatingBar", "VoiceShortcut", "VoiceDemo", "DataSources",
-        "Exports", "Goal", "Tasks",
+        "Exports", "Goal", "BringYourOwnKeys", "Tasks",
       ])
-    XCTAssertEqual(OnboardingFlow.lastStepIndex, 17)
+    XCTAssertEqual(OnboardingFlow.lastStepIndex, 18)
   }
 
   func testMigrationMovesLegacyVoiceInputToMergedVoiceShortcutStep() {
@@ -121,7 +121,7 @@ final class OnboardingFlowTests: XCTestCase {
     XCTAssertEqual(migratedResearch, 15)
     XCTAssertEqual(migratedLegacyGoalAfterExportInsert, 17)
     XCTAssertEqual(migratedGoal, 17)
-    XCTAssertEqual(migratedTasks, 17)
+    XCTAssertEqual(migratedTasks, 18)
   }
 
   func testVoiceShortcutContinueUnlocksOnlyAfterReleaseFollowingObservedPress() {

--- a/Desktop/Tests/OnboardingFlowTests.swift
+++ b/Desktop/Tests/OnboardingFlowTests.swift
@@ -124,6 +124,48 @@ final class OnboardingFlowTests: XCTestCase {
     XCTAssertEqual(migratedTasks, 18)
   }
 
+  func testMigrationInsertingBYOKStepShiftsLaterStepsForward() {
+    // Legacy Tasks (index 17 before BYOK insertion) should land on the new
+    // Tasks index (18) once BringYourOwnKeys is inserted between Goal and Tasks.
+    let migratedLegacyTasks = OnboardingFlow.migratedStep(
+      currentStep: 17,
+      hasMigratedVideoStep: true,
+      hasInsertedVoiceShortcutStep: true,
+      hasMergedVoiceInputStep: true,
+      hasRemovedNotificationStep: true,
+      hasInsertedFloatingBarShortcutStep: true,
+      hasMigratedPagedIntro: true,
+      hasReorderedTrustStep: true,
+      hasInsertedHowDidYouHearStep: true,
+      hasInsertedDataSourcesStep: true,
+      hasInsertedExportsStep: true,
+      hasInsertedSecondBrainStep: false,
+      hasRemovedResearchStep: true,
+      hasInsertedBYOKStep: false
+    )
+
+    // Steps before the BYOK insertion point (e.g. Goal at index 16) must not shift.
+    let migratedGoal = OnboardingFlow.migratedStep(
+      currentStep: 16,
+      hasMigratedVideoStep: true,
+      hasInsertedVoiceShortcutStep: true,
+      hasMergedVoiceInputStep: true,
+      hasRemovedNotificationStep: true,
+      hasInsertedFloatingBarShortcutStep: true,
+      hasMigratedPagedIntro: true,
+      hasReorderedTrustStep: true,
+      hasInsertedHowDidYouHearStep: true,
+      hasInsertedDataSourcesStep: true,
+      hasInsertedExportsStep: true,
+      hasInsertedSecondBrainStep: false,
+      hasRemovedResearchStep: true,
+      hasInsertedBYOKStep: false
+    )
+
+    XCTAssertEqual(migratedLegacyTasks, 18)
+    XCTAssertEqual(migratedGoal, 16)
+  }
+
   func testVoiceShortcutContinueUnlocksOnlyAfterReleaseFollowingObservedPress() {
     XCTAssertFalse(
       OnboardingFlow.shouldUnlockVoiceShortcutContinue(


### PR DESCRIPTION
## Summary
- Updates `OnboardingFlowTests` to expect 19 steps after `BringYourOwnKeys` was merged into the flow at index 17 (between Goal and Tasks).
- Renames `testMergedFlowUsesEighteenSteps` -> `testMergedFlowUsesNineteenSteps`, adds `BringYourOwnKeys` to the expected sequence, and bumps `lastStepIndex` 17 -> 18.
- Bumps `migratedTasks` expectation 17 -> 18 (Tasks moved from index 17 to 18).

## Test plan
- [x] `xcrun swift test --package-path Desktop --filter OnboardingFlowTests` passes locally (5/5)
- [ ] CI green

Closes #65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Bring Your Own Keys" step to the onboarding flow between Goal and Tasks.

* **Bug Fixes**
  * Updated onboarding migration so existing users’ progress maps correctly after the new step is inserted (previous Tasks progress shifts forward; earlier steps remain unchanged).

* **Tests**
  * Added a migration test to verify the new step insertion and correct progress mapping for legacy users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->