### PR TITLE
fix(crisp): restore activation + refreshAllData observers in start/stop

### DIFF
--- a/Desktop/Sources/MainWindow/CrispManager.swift
+++ b/Desktop/Sources/MainWindow/CrispManager.swift
@@ -90,11 +90,11 @@ class CrispManager: ObservableObject {
         // no-op in this fork (see body).
         activationObserver = NotificationCenter.default.addObserver(
             forName: NSApplication.didBecomeActiveNotification, object: nil, queue: .main
-        ) { [weak self] _ in Task { @MainActor in self?.pollForMessages() } }
+        ) { @MainActor [weak self] _ in self?.pollForMessages() }
 
         refreshAllObserver = NotificationCenter.default.addObserver(
             forName: .refreshAllData, object: nil, queue: .main
-        ) { [weak self] _ in Task { @MainActor in self?.pollForMessages() } }
+        ) { @MainActor [weak self] _ in self?.pollForMessages() }
 
         log("CrispManager: started (event-driven, no polling timer)")
     }

--- a/Desktop/Sources/MainWindow/CrispManager.swift
+++ b/Desktop/Sources/MainWindow/CrispManager.swift
@@ -70,10 +70,33 @@ class CrispManager: ObservableObject {
     ///   from lifecycle unit tests that want to exercise observer registration
     ///   without touching the network, auth state, or firing real notifications.
     func start(performInitialPoll: Bool = true) {
-        log("[backend-stripped] CrispManager.start: no-op (local-first)")
-        // Disabled for local-first fork: no observers, no initial poll, no badge updates.
-        // Mark started so callers behave as if start() succeeded.
+        guard !isStarted else { return }
         isStarted = true
+
+        // Only set lastSeenTimestamp to "now" on first-ever launch.
+        // On subsequent launches, keep the persisted value so the first
+        // poll picks up messages that arrived while the app was closed.
+        if lastSeenTimestamp == 0 {
+            lastSeenTimestamp = UInt64(Date().timeIntervalSince1970)
+        }
+
+        if performInitialPoll {
+            pollForMessages()
+        }
+
+        // Refresh on app activation and Cmd+R (no periodic timer).
+        // Observers are local NotificationCenter wiring — no network — so they
+        // are kept in the local-first fork. `pollForMessages()` itself is a
+        // no-op in this fork (see body).
+        activationObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didBecomeActiveNotification, object: nil, queue: .main
+        ) { [weak self] _ in Task { @MainActor in self?.pollForMessages() } }
+
+        refreshAllObserver = NotificationCenter.default.addObserver(
+            forName: .refreshAllData, object: nil, queue: .main
+        ) { [weak self] _ in Task { @MainActor in self?.pollForMessages() } }
+
+        log("CrispManager: started (event-driven, no polling timer)")
     }
 
     /// Mark messages as read (called when user opens Help tab)


### PR DESCRIPTION
## Summary

- Restores the `!isStarted` idempotency guard, activation observer, and `.refreshAllData` observer in `CrispManager.start()` that were over-pruned by the privacy-strip commit `4aa62c0`.
- `stop()` already removed those observers, but `start()` no longer added them — `CrispManagerLifecycleTests` was failing 5 assertions as a result.
- NotificationCenter wiring is purely local (no network, no privacy implication). `pollForMessages()` itself stays a no-op in this fork, so the observers fire into a harmless stub that just bumps `pollInvocations` for the test seam.

## Diagnosis

`git log -p --follow Desktop/Sources/MainWindow/CrispManager.swift` shows two commits: the Omi vendor import (`95d26af`) and the privacy strip (`4aa62c0`). The strip removed the network body of `pollForMessages()` correctly but also stripped the observer-registration and idempotency-guard scaffolding from `start()`, even though those bits don't talk to the network. This was a refactor over-shoot, not an intentional architectural move — `stop()` was left half-functional (removing observers it never added).

## Test plan

- [x] `xcrun swift test --package-path Desktop --filter CrispManagerLifecycleTests` — 8/8 pass
- [x] `xcrun swift test --package-path Desktop --filter Crisp` — 8/8 pass
- [x] `xcrun swift build --package-path Desktop` — clean

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented multiple initializations on startup
  * Ensure last-seen timestamp is set only on first launch and preserved across restarts

* **Infrastructure**
  * Added event-driven data refresh when the app returns to focus
  * Added notifications to trigger background refresh and log event-driven start
<!-- end of auto-generated comment: release notes by coderabbit.ai -->