### PR TITLE
ci(api): re-add cargo test --features activity_test_wiring (#70)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,5 +35,5 @@ jobs:
       - name: cargo test -p infinite-recall-api
         run: cargo test --locked -p infinite-recall-api
 
-      - name: cargo test -p infinite-recall-api activity endpoints
-        run: cargo test --locked -p infinite-recall-api --features activity_test_wiring --test activity_endpoints
+      - name: cargo test -p infinite-recall-api --features activity_test_wiring
+        run: cargo test --locked -p infinite-recall-api --features activity_test_wiring


### PR DESCRIPTION
## Summary
- Restores the `cargo test --features activity_test_wiring` CI step that was removed while #69 (tower 0.4/0.5 collision) was unresolved. #69 is now closed and the test passes locally on a clean cache.
- The interim narrowed step (`--test activity_endpoints`) is broadened back to running the full feature-gated suite, matching the originally-intended coverage from #54 / `916fb9e`.

## Test plan
- [x] `cargo clean && cargo test --locked -p infinite-recall-api --features activity_test_wiring` passes locally on macOS (98 tests: 73 unit + 21 activity_endpoints + 4 terminate_endpoint, ~18.8s)
- [ ] CI green (this PR will exercise the restored step itself)

Closes #70

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**No end-user visible changes.** This release contains only internal CI/CD workflow updates to improve testing processes.

* **Chores**
  * Updated test execution configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->