### PR TITLE
ci(desktop): re-add swift-build + swift-test jobs (#63)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,31 +39,6 @@ jobs:
       - name: swift build
         run: xcrun swift build -c debug --package-path Desktop
 
-  swift-test:
-    name: Swift tests
-    runs-on: macos-15
-    needs: swift-build
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install libwebp
-        run: brew install webp
-
-      - name: Cache SwiftPM artifacts
-        uses: actions/cache@v4
-        with:
-          path: |
-            Desktop/.build
-            ~/Library/Caches/org.swift.swiftpm
-            ~/Library/Developer/Xcode/DerivedData/SourcePackages
-          key: swiftpm-${{ runner.os }}-${{ hashFiles('Desktop/Package.swift', 'Desktop/Package.resolved') }}
-          restore-keys: |
-            swiftpm-${{ runner.os }}-
-
-      - name: swift test
-        run: xcrun swift test --package-path Desktop
-
   rust-test:
     name: Rust tests (api)
     runs-on: macos-15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,55 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  # swift-build + swift-test deferred to #63 — pre-existing failures on main
-  # (#64, #65, #67) must be fixed before swift test can run green.
+  swift-build:
+    name: Swift build (debug)
+    runs-on: macos-15
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install libwebp (pkg-config dep for CWebP system library)
+        run: brew install webp
+
+      - name: Cache SwiftPM artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            Desktop/.build
+            ~/Library/Caches/org.swift.swiftpm
+            ~/Library/Developer/Xcode/DerivedData/SourcePackages
+          key: swiftpm-${{ runner.os }}-${{ hashFiles('Desktop/Package.swift', 'Desktop/Package.resolved') }}
+          restore-keys: |
+            swiftpm-${{ runner.os }}-
+
+      - name: swift build
+        run: xcrun swift build -c debug --package-path Desktop
+
+  swift-test:
+    name: Swift tests
+    runs-on: macos-15
+    needs: swift-build
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install libwebp
+        run: brew install webp
+
+      - name: Cache SwiftPM artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            Desktop/.build
+            ~/Library/Caches/org.swift.swiftpm
+            ~/Library/Developer/Xcode/DerivedData/SourcePackages
+          key: swiftpm-${{ runner.os }}-${{ hashFiles('Desktop/Package.swift', 'Desktop/Package.resolved') }}
+          restore-keys: |
+            swiftpm-${{ runner.os }}-
+
+      - name: swift test
+        run: xcrun swift test --package-path Desktop
+
   rust-test:
     name: Rust tests (api)
     runs-on: macos-15

--- a/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -2554,7 +2554,7 @@ struct SettingsContentView: View {
     guard visionModelDeleteInFlightId == nil else { return }
     visionModelDeleteInFlightId = modelId
     Task.detached(priority: .userInitiated) {
-      let ok = VLMLifecycleManager.deleteModel(modelId)
+      let ok = await VLMLifecycleManager.deleteModel(modelId)
       await MainActor.run {
         self.visionModelDeleteInFlightId = nil
         self.refreshVisionModelDiskSize(for: modelId)
@@ -3216,7 +3216,7 @@ struct SettingsContentView: View {
     guard localModelDeleteInFlightId == nil else { return }
     localModelDeleteInFlightId = modelId
     Task.detached(priority: .userInitiated) {
-      let ok = MLXLifecycleManager.deleteModel(modelId)
+      let ok = await MLXLifecycleManager.deleteModel(modelId)
       await MainActor.run {
         self.localModelDeleteInFlightId = nil
         self.refreshLocalModelDiskSize(for: modelId)


### PR DESCRIPTION
## Summary
- Restores the `swift-build` + `swift-test` CI jobs that were deferred while #64/#65/#67 were unresolved. All three are now closed and the Desktop test suite is green locally.

## Test plan
- [x] `xcrun swift test --package-path Desktop` passes locally
- [ ] CI green (this PR exercises the restored jobs themselves)

Closes #63

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI: added an explicit macOS Swift build job with dependency installation and build caching for faster, more reliable macOS builds.
* **Bug Fixes**
  * Fixed asynchronous model deletion so UI state, disk-size info, and success/failure messages update reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->