### PR TITLE
fix(focus): split headline from content so H1 and Overview differ

### DIFF
--- a/Desktop/Sources/ProactiveAssistants/Assistants/Focus/FocusAssistant.swift
+++ b/Desktop/Sources/ProactiveAssistants/Assistants/Focus/FocusAssistant.swift
@@ -483,6 +483,7 @@ actor FocusAssistant: ProactiveAssistant {
             // e.g., if 3 frames all return "distracted", only the first one triggers
             if analysis.status == .distracted && lastNotifiedState != .distracted {
                 // Transitioning to distracted state
+                let priorState = lastNotifiedState
                 // Update notified state BEFORE other actions to prevent race with parallel frames
                 lastNotifiedState = .distracted
 
@@ -492,7 +493,7 @@ actor FocusAssistant: ProactiveAssistant {
                 }
 
                 // Save to SQLite and sync to backend
-                await saveFocusSessionToSQLite(analysis: analysis, screenshotId: frame.screenshotId, windowTitle: frame.windowTitle)
+                await saveFocusSessionToSQLite(analysis: analysis, screenshotId: frame.screenshotId, windowTitle: frame.windowTitle, priorState: priorState)
 
                 // Update FocusStorage UI state (sessions list, currentStatus, currentApp)
                 Task { @MainActor in
@@ -554,11 +555,12 @@ actor FocusAssistant: ProactiveAssistant {
                 }
             } else if analysis.status == .focused && lastNotifiedState != .focused {
                 // Transitioning to focused state (from distracted OR initial nil state)
-                let wasDistracted = lastNotifiedState == .distracted
+                let priorState = lastNotifiedState
+                let wasDistracted = priorState == .distracted
                 lastNotifiedState = .focused
 
                 // Save to SQLite and sync to backend
-                await saveFocusSessionToSQLite(analysis: analysis, screenshotId: frame.screenshotId, windowTitle: frame.windowTitle)
+                await saveFocusSessionToSQLite(analysis: analysis, screenshotId: frame.screenshotId, windowTitle: frame.windowTitle, priorState: priorState)
 
                 // Update FocusStorage UI state (sessions list, currentStatus, currentApp)
                 Task { @MainActor in
@@ -759,7 +761,7 @@ actor FocusAssistant: ProactiveAssistant {
     // MARK: - Storage
 
     /// Save focus session to SQLite (both tables) and sync to backend
-    private func saveFocusSessionToSQLite(analysis: ScreenAnalysis, screenshotId: Int64?, windowTitle: String? = nil) async {
+    private func saveFocusSessionToSQLite(analysis: ScreenAnalysis, screenshotId: Int64?, windowTitle: String?, priorState: FocusStatus?) async {
         // Save to focus_sessions table (for detailed tracking)
         let focusRecord = FocusSessionRecord(
             screenshotId: screenshotId,
@@ -780,10 +782,10 @@ actor FocusAssistant: ProactiveAssistant {
         }
 
         // Save to unified memories table (for search/filter)
-        let memoryId = await saveFocusToMemoriesTable(analysis: analysis, screenshotId: screenshotId, windowTitle: windowTitle)
+        let memoryId = await saveFocusToMemoriesTable(analysis: analysis, screenshotId: screenshotId, windowTitle: windowTitle, priorState: priorState)
 
         // Sync to backend once and update both tables with backendId
-        if let backendId = await syncFocusSessionToBackend(analysis: analysis, windowTitle: windowTitle) {
+        if let backendId = await syncFocusSessionToBackend(analysis: analysis, windowTitle: windowTitle, priorState: priorState) {
             // Update focus_sessions table
             if let recordId = focusSessionId {
                 do {
@@ -810,10 +812,8 @@ actor FocusAssistant: ProactiveAssistant {
 
     /// Save focus event to unified memories table for search/filter
     /// Returns the inserted memory ID if successful
-    private func saveFocusToMemoriesTable(analysis: ScreenAnalysis, screenshotId: Int64?, windowTitle: String? = nil) async -> Int64? {
-        // Build content for the memory
-        let statusText = analysis.status == .focused ? "Focused" : "Distracted"
-        let content = "\(statusText) on \(analysis.appOrSite): \(analysis.description)"
+    private func saveFocusToMemoriesTable(analysis: ScreenAnalysis, screenshotId: Int64?, windowTitle: String?, priorState: FocusStatus?) async -> Int64? {
+        let strings = Self.buildFocusMemoryStrings(analysis: analysis, windowTitle: windowTitle, priorState: priorState)
 
         // Build tags: ["focus", "focused"/"distracted", "app:{appName}"]
         let statusTag = analysis.status == .focused ? "focused" : "distracted"
@@ -836,14 +836,15 @@ actor FocusAssistant: ProactiveAssistant {
 
         let memoryRecord = MemoryRecord(
             backendSynced: false,
-            content: content,
+            content: strings.content,
             category: "system",
             tagsJson: tagsJson,
             source: "desktop",
             screenshotId: screenshotId,
             sourceApp: analysis.appOrSite,
             windowTitle: windowTitle,
-            contextSummary: analysis.description
+            contextSummary: analysis.description,
+            headline: strings.headline
         )
 
         do {
@@ -858,11 +859,10 @@ actor FocusAssistant: ProactiveAssistant {
     }
 
     /// Sync focus session to backend as a memory with focus tags, returns backend ID if successful
-    private func syncFocusSessionToBackend(analysis: ScreenAnalysis, windowTitle: String? = nil) async -> String? {
+    private func syncFocusSessionToBackend(analysis: ScreenAnalysis, windowTitle: String?, priorState: FocusStatus?) async -> String? {
         do {
-            // Build content for the memory
-            let statusText = analysis.status == .focused ? "Focused" : "Distracted"
-            let content = "\(statusText) on \(analysis.appOrSite): \(analysis.description)"
+            // Mirror the local memories-table content so backend and local records stay byte-equal.
+            let strings = Self.buildFocusMemoryStrings(analysis: analysis, windowTitle: windowTitle, priorState: priorState)
 
             // Build tags: ["focus", "focused"/"distracted", "app:{appName}"]
             let statusTag = analysis.status == .focused ? "focused" : "distracted"
@@ -875,7 +875,7 @@ actor FocusAssistant: ProactiveAssistant {
             }
 
             let response = try await APIClient.shared.createMemory(
-                content: content,
+                content: strings.content,
                 category: .system,
                 tags: tags,
                 source: "desktop",
@@ -888,6 +888,37 @@ actor FocusAssistant: ProactiveAssistant {
             logError("Focus: Failed to sync to backend", error: error)
             return nil
         }
+    }
+
+    /// Distinct headline vs content drive H1 vs Overview body in the exported markdown.
+    static func buildFocusMemoryStrings(
+        analysis: ScreenAnalysis,
+        windowTitle: String?,
+        priorState: FocusStatus?
+    ) -> (headline: String, content: String) {
+        let statusText = analysis.status.titleCased
+        let headline = "\(statusText) on \(analysis.appOrSite)"
+
+        let priorLabel = priorState?.rawValue ?? "new session"
+        let currentLabel = analysis.status.rawValue
+
+        var lines: [String] = []
+        lines.append("\(statusText) on \(analysis.appOrSite) · \(analysis.description)")
+        lines.append("")
+
+        var appLine = "App: \(analysis.appOrSite)"
+        if let wt = windowTitle, !wt.isEmpty {
+            appLine += " · Window: \(wt)"
+        }
+        lines.append(appLine)
+
+        var transitionLine = "Transition: \(priorLabel) → \(currentLabel)"
+        if let message = analysis.message, !message.isEmpty {
+            transitionLine += " · Note: \(message)"
+        }
+        lines.append(transitionLine)
+
+        return (headline: headline, content: lines.joined(separator: "\n"))
     }
 }
 

--- a/Desktop/Sources/ProactiveAssistants/Assistants/Focus/FocusModels.swift
+++ b/Desktop/Sources/ProactiveAssistants/Assistants/Focus/FocusModels.swift
@@ -5,6 +5,13 @@ import Foundation
 enum FocusStatus: String, Codable {
     case focused
     case distracted
+
+    var titleCased: String {
+        switch self {
+        case .focused: return "Focused"
+        case .distracted: return "Distracted"
+        }
+    }
 }
 
 // MARK: - Screen Analysis Result

--- a/Desktop/Tests/LocalIntegrationDispatcherTests.swift
+++ b/Desktop/Tests/LocalIntegrationDispatcherTests.swift
@@ -259,6 +259,43 @@ final class LocalIntegrationDispatcherTests: XCTestCase {
         XCTAssertEqual(payload.overview, "We agreed to ship the dispatcher refactor by EOQ.")
     }
 
+    /// Pins MemoryPayload's title-from-headline path so first-line-of-content fallback can't collapse title and overview.
+    func test_focusMemoryRecord_titleAndOverviewAreDistinct() throws {
+        let analysis = ScreenAnalysis(
+            status: .focused,
+            appOrSite: "Infinite Recall",
+            description: "Infinite Recall app is open",
+            message: nil
+        )
+        let strings = FocusAssistant.buildFocusMemoryStrings(
+            analysis: analysis,
+            windowTitle: "ProjectsView",
+            priorState: nil
+        )
+
+        XCTAssertEqual(strings.headline, "Focused on Infinite Recall")
+        XCTAssertTrue(strings.content.contains("App: Infinite Recall · Window: ProjectsView"))
+        XCTAssertTrue(strings.content.contains("Transition: new session → focused"))
+        XCTAssertNotEqual(strings.headline, strings.content)
+
+        let record = MemoryRecord(
+            backendSynced: false,
+            content: strings.content,
+            category: "system",
+            tagsJson: nil,
+            source: "desktop",
+            sourceApp: "Infinite Recall",
+            windowTitle: "ProjectsView",
+            contextSummary: analysis.description,
+            headline: strings.headline
+        )
+        let payload = MemoryPayload(from: record)
+
+        XCTAssertEqual(payload.title, "Focused on Infinite Recall")
+        XCTAssertEqual(payload.overview, strings.content)
+        XCTAssertNotEqual(payload.title, payload.overview)
+    }
+
     /// Multiple enabled integrations → exactly one outbox row per
     /// integration, all referencing the same memory id. Verifies the fan-out
     /// loop visits every enabled integration without duplicates or drops.


### PR DESCRIPTION
## Summary
- Focus events were rendering the same string in both the markdown H1 and the `## Overview` body. Root cause: `saveFocusToMemoriesTable` set `headline = nil` and packed the focus message into `content`, so `MemoryPayload.init(from:)` derived `title` from the first line of `content`.
- New `buildFocusMemoryStrings` helper produces a terse `"<Status> on <App>"` headline and a multi-line `content` (App/Window line, Transition `prior → current` line, optional Note). `priorState` is captured before mutation in both focus/distract branches and threaded through `saveFocusSessionToSQLite` → `saveFocusToMemoriesTable` / `syncFocusSessionToBackend`.
- `FocusStatus` gains a `titleCased` helper to remove duplicate ternaries.

## Test plan
- [x] `xcrun swift build -c debug --package-path Desktop`
- [x] `xcrun swift test --package-path Desktop --filter LocalIntegrationDispatcherTests` (new `test_focusMemoryRecord_titleAndOverviewAreDistinct` asserts payload `title` ≠ `overview` for focus-shaped records)
- [x] `cargo test --locked -p infinite-recall-api` (mirrors `ci.yml` rust-test job)
- [x] `cargo test --locked -p infinite-recall-api --features activity_test_wiring --test activity_endpoints` (mirrors second CI step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Focus state transitions now capture and record prior focus state information.
  * Focus status displays now use human-readable formatting.
  * Memory generation refactored to include detailed transition information (prior → current state) with consistent backend synchronization.

* **Tests**
  * Added test verification for focus memory payload generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->