### PR TITLE
fix(scheduler): surface PendingWorkStorage errors in KGProgressPublisher

### DIFF
--- a/Desktop/Sources/Rewind/Services/KGProgressPublisher.swift
+++ b/Desktop/Sources/Rewind/Services/KGProgressPublisher.swift
@@ -289,11 +289,15 @@ actor KGProgressPublisher {
         do {
             depth = try await PendingWorkStorage.shared.depthSummary()
         } catch {
+            // Mirror sample()'s skip-publish pattern (L243-248): a fallback to
+            // an empty PendingWorkDepth would yield pending=0 → .idleNoWork,
+            // causing the pill to flicker between "Up to date" and "Building"
+            // on transient DB errors. Preserve the prior state instead.
             logError(
-                "KGProgressPublisher: depthSummary threw, falling back to empty PendingWorkDepth",
+                "KGProgressPublisher: depthSummary threw, falling back to previous state",
                 error: error
             )
-            depth = PendingWorkDepth()
+            return lastSnapshot?.state ?? .idleNoWork
         }
         let key = PendingWork.Kind.extractKG.rawValue
         let pending = (depth.queued[key] ?? 0) + (depth.failed[key] ?? 0) + (depth.claimed[key] ?? 0)

--- a/Desktop/Sources/Rewind/Services/KGProgressPublisher.swift
+++ b/Desktop/Sources/Rewind/Services/KGProgressPublisher.swift
@@ -285,7 +285,16 @@ actor KGProgressPublisher {
         // Pending-work depth for `.extractKG` decides whether there's work at
         // all. If the queue is empty, treat as `idleNoWork` regardless of
         // power state — there's nothing pending to be paused.
-        let depth = (try? await PendingWorkStorage.shared.depthSummary()) ?? PendingWorkDepth()
+        let depth: PendingWorkDepth
+        do {
+            depth = try await PendingWorkStorage.shared.depthSummary()
+        } catch {
+            logError(
+                "KGProgressPublisher: depthSummary threw, falling back to empty PendingWorkDepth",
+                error: error
+            )
+            depth = PendingWorkDepth()
+        }
         let key = PendingWork.Kind.extractKG.rawValue
         let pending = (depth.queued[key] ?? 0) + (depth.failed[key] ?? 0) + (depth.claimed[key] ?? 0)
 


### PR DESCRIPTION
## Summary
- Replace silent `try?` against `PendingWorkStorage.shared.depthSummary()` in `KGProgressPublisher.swift` with do/catch + `logError`.
- Matches the pattern landed in #89 / PR #91 (`BatteryAwareScheduler`).

## Test plan
- [x] `xcrun swift build --package-path Desktop` passes
- [ ] Existing Swift tests still pass (CI)

Closes #92.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The build-status indicator is now more stable: transient errors no longer cause the status to flicker between “up to date” and “building.” Such errors are logged and the previous visible state is retained when a temporary error occurs, improving reliability and diagnostics of the build indicator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->