### PR TITLE
fix(scheduler): fire deadLetterCallback on sweeper claimed→dead transitions

### DIFF
--- a/Desktop/Sources/Rewind/Core/PendingWorkStorage.swift
+++ b/Desktop/Sources/Rewind/Core/PendingWorkStorage.swift
@@ -385,7 +385,26 @@ actor PendingWorkStorage {
     @discardableResult
     func runMaintenanceSweep(now: Date = Date()) async throws -> (recovered: Int, doneGC: Int, deadGC: Int) {
         let db = try await ensureInitialized()
-        let result = try await db.write { database -> (Int, Int, Int) in
+        let (result, deadLettered) = try await db.write {
+            database -> ((Int, Int, Int), [(workType: String, payload: Data)]) in
+
+            // Capture the rows that the lease-reclaim UPDATE will transition to
+            // `dead` BEFORE running the UPDATE, so we can fire the dead-letter
+            // callback once the transaction commits. Parity with `fail()`:
+            // a `.summarize` row whose worker crashes on every attempt would
+            // otherwise exhaust retries via the sweeper (lease expiry →
+            // attempts++) without ever getting the "Summary Unavailable"
+            // placeholder, leaving a stuck pending row in the UI.
+            let deadRows = try Row.fetchAll(database, sql: """
+                SELECT workType, payload FROM pending_work
+                WHERE status = 'claimed'
+                  AND leaseExpiresAt < ?
+                  AND attempts + 1 >= maxAttempts
+            """, arguments: [now])
+            let deadLettered: [(workType: String, payload: Data)] = deadRows.map { row in
+                (workType: row["workType"] ?? "", payload: row["payload"] ?? Data())
+            }
+
             try database.execute(sql: """
                 UPDATE pending_work
                 SET status = CASE
@@ -418,9 +437,18 @@ actor PendingWorkStorage {
             """, arguments: [now])
             let deadGCCount = database.changesCount
 
-            return (recoveredCount, doneGCCount, deadGCCount)
+            return ((recoveredCount, doneGCCount, deadGCCount), deadLettered)
         }
         notifyDidMutate()
+
+        // Fire dead-letter callbacks AFTER the transaction commits (mirrors
+        // `fail()`); the callback is async and may do its own DB writes.
+        if let cb = self.deadLetterCallback {
+            for entry in deadLettered where !entry.workType.isEmpty {
+                await cb(entry.workType, entry.payload)
+            }
+        }
+
         return result
     }
 

--- a/Desktop/Tests/PendingWorkStorageDelegateTests.swift
+++ b/Desktop/Tests/PendingWorkStorageDelegateTests.swift
@@ -86,11 +86,77 @@ final class PendingWorkStorageDelegateTests: XCTestCase {
     }
 
     override func tearDown() async throws {
-        // Always clear the delegate so the singleton doesn't carry a stale
-        // reference into the next test class.
+        // Always clear the delegate AND deadLetterCallback so the singleton
+        // doesn't carry a stale reference into the next test class. The
+        // callback reset has to be in async tearDown (not a per-test `defer`
+        // wrapping a fire-and-forget Task) so cleanup is deterministic and
+        // can't leak into the next test.
         await PendingWorkStorage.shared.setDelegate(nil)
+        await PendingWorkStorage.shared.setDeadLetterCallback(nil)
         try await purgeTestRows()
         try await super.tearDown()
+    }
+
+    // MARK: - Shared sweep-test helpers
+
+    /// Records `(workType, payload)` tuples observed by `deadLetterCallback`.
+    /// Wrapped in a final class so the closure can mutate state across the
+    /// actor boundary without capturing inout. Used by both sweep+callback
+    /// tests below.
+    private final class DeadLetterRecorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _calls: [(workType: String, payload: Data)] = []
+        var calls: [(workType: String, payload: Data)] {
+            lock.lock(); defer { lock.unlock() }
+            return _calls
+        }
+        func record(_ workType: String, _ payload: Data) {
+            lock.lock(); defer { lock.unlock() }
+            _calls.append((workType, payload))
+        }
+    }
+
+    /// Shared setup for the maintenance-sweep tests: enqueue a row with the
+    /// given payload+dedupKey, claim it, and (optionally) bump `attempts` so
+    /// the next attempt-bump trips it into `dead`. Returns the `storageId` of
+    /// the claimed row so the caller can assert the post-sweep state.
+    ///
+    /// `bumpToOneFromMax = true` forces `attempts = maxAttempts - 1`, so the
+    /// sweep's reclaim CASE evaluates `attempts + 1 >= maxAttempts` and lands
+    /// the row in `dead`. `false` leaves attempts at 0, exercising the
+    /// `claimed → queued` branch instead.
+    private struct SweepSetupError: Error { let message: String }
+
+    private func enqueueClaimedRow(
+        payload: Data,
+        dedupKey: String,
+        bumpToOneFromMax: Bool
+    ) async throws -> Int64 {
+        let storage = PendingWorkStorage.shared
+        _ = try await storage.enqueue(
+            workType: workType,
+            payload: payload,
+            dedupKey: dedupKey
+        )
+        guard let claimed = try await storage.claimNext(claimedBy: "delegate-test-worker"),
+              let sid = claimed.storageId else {
+            XCTFail("expected to claim our just-enqueued row")
+            throw SweepSetupError(message: "claim failed")
+        }
+        if bumpToOneFromMax {
+            guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+                XCTFail("database queue unavailable")
+                throw SweepSetupError(message: "no db queue")
+            }
+            try await dbQueue.write { db in
+                try db.execute(sql: """
+                    UPDATE pending_work
+                    SET attempts = maxAttempts - 1
+                    WHERE id = ?
+                """, arguments: [sid])
+            }
+        }
+        return sid
     }
 
     // MARK: - Mutators each fire exactly once
@@ -280,51 +346,17 @@ final class PendingWorkStorageDelegateTests: XCTestCase {
         try await drainQueue()
         let storage = PendingWorkStorage.shared
 
-        // Records (workType, payload) tuples observed by the callback. Wrapped
-        // in a final class so the closure can mutate state across the actor
-        // boundary without capturing inout.
-        final class Recorder: @unchecked Sendable {
-            private let lock = NSLock()
-            private var _calls: [(workType: String, payload: Data)] = []
-            var calls: [(workType: String, payload: Data)] {
-                lock.lock(); defer { lock.unlock() }
-                return _calls
-            }
-            func record(_ workType: String, _ payload: Data) {
-                lock.lock(); defer { lock.unlock() }
-                _calls.append((workType, payload))
-            }
-        }
-        let recorder = Recorder()
+        let recorder = DeadLetterRecorder()
         await storage.setDeadLetterCallback { workType, payload in
             recorder.record(workType, payload)
         }
-        defer {
-            // Best-effort cleanup; ignored if the actor's already torn down.
-            Task { await PendingWorkStorage.shared.setDeadLetterCallback(nil) }
-        }
 
         let payload = Data("delegate-test-deadletter-callback".utf8)
-        _ = try await storage.enqueue(
-            workType: workType,
+        _ = try await enqueueClaimedRow(
             payload: payload,
-            dedupKey: "delegate-deadletter-cb-\(UUID().uuidString)"
+            dedupKey: "delegate-deadletter-cb-\(UUID().uuidString)",
+            bumpToOneFromMax: true
         )
-        guard let claimed = try await storage.claimNext(claimedBy: "delegate-test-worker"),
-              let sid = claimed.storageId else {
-            return XCTFail("expected to claim our just-enqueued row")
-        }
-
-        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
-            return XCTFail("database queue unavailable")
-        }
-        try await dbQueue.write { db in
-            try db.execute(sql: """
-                UPDATE pending_work
-                SET attempts = maxAttempts - 1
-                WHERE id = ?
-            """, arguments: [sid])
-        }
 
         let result = try await storage.runMaintenanceSweep(now: Date().addingTimeInterval(3600))
         XCTAssertGreaterThanOrEqual(result.recovered, 1, "sweep should reclaim our row")
@@ -348,39 +380,21 @@ final class PendingWorkStorageDelegateTests: XCTestCase {
         try await drainQueue()
         let storage = PendingWorkStorage.shared
 
-        final class Recorder: @unchecked Sendable {
-            private let lock = NSLock()
-            private var _calls: [(workType: String, payload: Data)] = []
-            var calls: [(workType: String, payload: Data)] {
-                lock.lock(); defer { lock.unlock() }
-                return _calls
-            }
-            func record(_ workType: String, _ payload: Data) {
-                lock.lock(); defer { lock.unlock() }
-                _calls.append((workType, payload))
-            }
-        }
-        let recorder = Recorder()
+        let recorder = DeadLetterRecorder()
         await storage.setDeadLetterCallback { workType, payload in
             recorder.record(workType, payload)
         }
-        defer {
-            Task { await PendingWorkStorage.shared.setDeadLetterCallback(nil) }
-        }
 
         let payload = Data("delegate-test-deadletter-noop".utf8)
-        _ = try await storage.enqueue(
-            workType: workType,
+        // Note: we deliberately do NOT bump attempts (`bumpToOneFromMax: false`).
+        // With attempts at 0 and maxAttempts at the schema default (8),
+        // `attempts + 1 >= maxAttempts` is false, so the sweep should send the
+        // row back to `queued`.
+        let sid = try await enqueueClaimedRow(
             payload: payload,
-            dedupKey: "delegate-deadletter-noop-\(UUID().uuidString)"
+            dedupKey: "delegate-deadletter-noop-\(UUID().uuidString)",
+            bumpToOneFromMax: false
         )
-        guard let claimed = try await storage.claimNext(claimedBy: "delegate-test-worker"),
-              let sid = claimed.storageId else {
-            return XCTFail("expected to claim our just-enqueued row")
-        }
-        // Note: we deliberately do NOT bump attempts. With attempts at 0 and
-        // maxAttempts at the schema default (8), `attempts + 1 >= maxAttempts`
-        // is false, so the sweep should send the row back to `queued`.
 
         let result = try await storage.runMaintenanceSweep(now: Date().addingTimeInterval(3600))
         XCTAssertGreaterThanOrEqual(result.recovered, 1, "sweep should reclaim the expired-lease row")

--- a/Desktop/Tests/PendingWorkStorageDelegateTests.swift
+++ b/Desktop/Tests/PendingWorkStorageDelegateTests.swift
@@ -271,6 +271,133 @@ final class PendingWorkStorageDelegateTests: XCTestCase {
         XCTAssertEqual(landedStatus, "dead", "exhausted-attempts row should transition to dead, not queued")
     }
 
+    /// Issue #60: the sweeper's `claimed → dead` transition (lease-reclaim path
+    /// where `attempts + 1 >= maxAttempts`) must fire `deadLetterCallback`,
+    /// parity with `fail()`. Without this, `.summarize` work whose workers
+    /// crash on every attempt exhausts retries via the sweeper, never gets the
+    /// "Summary Unavailable" placeholder, and leaves a stuck pending row.
+    func test_runMaintenanceSweep_firesDeadLetterCallback_onClaimedToDeadTransition() async throws {
+        try await drainQueue()
+        let storage = PendingWorkStorage.shared
+
+        // Records (workType, payload) tuples observed by the callback. Wrapped
+        // in a final class so the closure can mutate state across the actor
+        // boundary without capturing inout.
+        final class Recorder: @unchecked Sendable {
+            private let lock = NSLock()
+            private var _calls: [(workType: String, payload: Data)] = []
+            var calls: [(workType: String, payload: Data)] {
+                lock.lock(); defer { lock.unlock() }
+                return _calls
+            }
+            func record(_ workType: String, _ payload: Data) {
+                lock.lock(); defer { lock.unlock() }
+                _calls.append((workType, payload))
+            }
+        }
+        let recorder = Recorder()
+        await storage.setDeadLetterCallback { workType, payload in
+            recorder.record(workType, payload)
+        }
+        defer {
+            // Best-effort cleanup; ignored if the actor's already torn down.
+            Task { await PendingWorkStorage.shared.setDeadLetterCallback(nil) }
+        }
+
+        let payload = Data("delegate-test-deadletter-callback".utf8)
+        _ = try await storage.enqueue(
+            workType: workType,
+            payload: payload,
+            dedupKey: "delegate-deadletter-cb-\(UUID().uuidString)"
+        )
+        guard let claimed = try await storage.claimNext(claimedBy: "delegate-test-worker"),
+              let sid = claimed.storageId else {
+            return XCTFail("expected to claim our just-enqueued row")
+        }
+
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+            return XCTFail("database queue unavailable")
+        }
+        try await dbQueue.write { db in
+            try db.execute(sql: """
+                UPDATE pending_work
+                SET attempts = maxAttempts - 1
+                WHERE id = ?
+            """, arguments: [sid])
+        }
+
+        let result = try await storage.runMaintenanceSweep(now: Date().addingTimeInterval(3600))
+        XCTAssertGreaterThanOrEqual(result.recovered, 1, "sweep should reclaim our row")
+
+        // Filter to our row's payload — the singleton DB may carry unrelated
+        // claimed rows in other tests' cleanup gaps.
+        let myCalls = recorder.calls.filter { $0.payload == payload }
+        XCTAssertEqual(
+            myCalls.count, 1,
+            "claimed→dead sweep transition must fire deadLetterCallback exactly once"
+        )
+        XCTAssertEqual(myCalls.first?.workType, workType, "callback must receive the correct workType")
+        XCTAssertEqual(myCalls.first?.payload, payload, "callback must receive the original payload")
+    }
+
+    /// Negative case for issue #60: the `claimed → queued` branch of the
+    /// lease-reclaim CASE (lease expired but attempts not yet exhausted) must
+    /// NOT fire `deadLetterCallback`. The row goes back to the queue with no
+    /// dead-letter side effects.
+    func test_runMaintenanceSweep_doesNotFireDeadLetterCallback_onClaimedToQueuedTransition() async throws {
+        try await drainQueue()
+        let storage = PendingWorkStorage.shared
+
+        final class Recorder: @unchecked Sendable {
+            private let lock = NSLock()
+            private var _calls: [(workType: String, payload: Data)] = []
+            var calls: [(workType: String, payload: Data)] {
+                lock.lock(); defer { lock.unlock() }
+                return _calls
+            }
+            func record(_ workType: String, _ payload: Data) {
+                lock.lock(); defer { lock.unlock() }
+                _calls.append((workType, payload))
+            }
+        }
+        let recorder = Recorder()
+        await storage.setDeadLetterCallback { workType, payload in
+            recorder.record(workType, payload)
+        }
+        defer {
+            Task { await PendingWorkStorage.shared.setDeadLetterCallback(nil) }
+        }
+
+        let payload = Data("delegate-test-deadletter-noop".utf8)
+        _ = try await storage.enqueue(
+            workType: workType,
+            payload: payload,
+            dedupKey: "delegate-deadletter-noop-\(UUID().uuidString)"
+        )
+        guard let claimed = try await storage.claimNext(claimedBy: "delegate-test-worker"),
+              claimed.storageId != nil else {
+            return XCTFail("expected to claim our just-enqueued row")
+        }
+        // Note: we deliberately do NOT bump attempts. With attempts at 0 and
+        // maxAttempts at the schema default (8), `attempts + 1 >= maxAttempts`
+        // is false, so the sweep should send the row back to `queued`.
+
+        let result = try await storage.runMaintenanceSweep(now: Date().addingTimeInterval(3600))
+        XCTAssertGreaterThanOrEqual(result.recovered, 1, "sweep should reclaim the expired-lease row")
+
+        let myCalls = recorder.calls.filter { $0.payload == payload }
+        XCTAssertEqual(
+            myCalls.count, 0,
+            "claimed→queued sweep transition must NOT fire deadLetterCallback"
+        )
+
+        // Cleanup: drain the now-`queued` row.
+        if let again = try await storage.claimNext(claimedBy: "delegate-test-worker"),
+           let aSid = again.storageId {
+            try? await storage.ack(storageId: aSid)
+        }
+    }
+
     // MARK: - Read methods do NOT fire
 
     func test_readMethods_doNotFireDelegate() async throws {

--- a/Desktop/Tests/PendingWorkStorageDelegateTests.swift
+++ b/Desktop/Tests/PendingWorkStorageDelegateTests.swift
@@ -375,7 +375,7 @@ final class PendingWorkStorageDelegateTests: XCTestCase {
             dedupKey: "delegate-deadletter-noop-\(UUID().uuidString)"
         )
         guard let claimed = try await storage.claimNext(claimedBy: "delegate-test-worker"),
-              claimed.storageId != nil else {
+              let sid = claimed.storageId else {
             return XCTFail("expected to claim our just-enqueued row")
         }
         // Note: we deliberately do NOT bump attempts. With attempts at 0 and
@@ -390,6 +390,26 @@ final class PendingWorkStorageDelegateTests: XCTestCase {
             myCalls.count, 0,
             "claimed→queued sweep transition must NOT fire deadLetterCallback"
         )
+
+        // Prove the row actually transitioned to `queued`. Without this, a
+        // stuck-`claimed` row (e.g. lease predicate didn't match) would also
+        // produce zero callbacks — a false pass. Mirrors the assertion style
+        // in `test_runMaintenanceSweep_transitionsExhaustedRowToDead` above.
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+            return XCTFail("database queue unavailable")
+        }
+        let landedStatus: String? = try await dbQueue.read { db in
+            try String.fetchOne(db, sql: "SELECT status FROM pending_work WHERE id = ?", arguments: [sid])
+        }
+        let landedAttempts: Int? = try await dbQueue.read { db in
+            try Int.fetchOne(db, sql: "SELECT attempts FROM pending_work WHERE id = ?", arguments: [sid])
+        }
+        let landedLeaseExpiresAt: Double? = try await dbQueue.read { db in
+            try Double.fetchOne(db, sql: "SELECT leaseExpiresAt FROM pending_work WHERE id = ?", arguments: [sid])
+        }
+        XCTAssertEqual(landedStatus, "queued", "lease-expired row with attempts < max should land in `queued`")
+        XCTAssertEqual(landedAttempts, 1, "sweep's reclaim should bump attempts from 0 to 1")
+        XCTAssertNil(landedLeaseExpiresAt, "queued rows must have no active lease")
 
         // Cleanup: drain the now-`queued` row.
         if let again = try await storage.claimNext(claimedBy: "delegate-test-worker"),


### PR DESCRIPTION
## Summary
- SELECT-then-UPDATE-then-callback in `PendingWorkStorage.runMaintenanceSweep()` so lease-reclaim transitions to `dead` fire `deadLetterCallback`, parity with `fail()`.
- Without this, `.summarize` work whose workers crash on every attempt exhausts retries via the sweeper, never gets the "Summary Unavailable" placeholder, and leaves a stuck pending row in the UI.

## Test plan
- [x] New test: claim a row, push attempts to `maxAttempts - 1`, expire lease, run sweep, assert one callback invocation with correct workType + payload.
- [x] Negative case: `claimed → queued` rows (attempts not yet exhausted) do NOT fire the callback.
- [x] `xcrun swift build --package-path Desktop` passes.
- [x] Targeted test suite passes locally (8/8 in `PendingWorkStorageDelegateTests`).

Closes #60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Maintenance sweeps now capture items destined for the dead queue and invoke dead-letter callbacks explicitly and asynchronously after the transaction commits; empty work types are skipped.

* **Tests**
  * Added isolated tests verifying dead-letter callback invocation only when retries are exhausted and confirming state transitions for reclaimed work items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->