### PR TITLE
fix(diarization): break stateLock deadlock on stop()

### DIFF
--- a/Desktop/Sources/Diarization/SpeakerDiarizationService.swift
+++ b/Desktop/Sources/Diarization/SpeakerDiarizationService.swift
@@ -343,7 +343,7 @@ final class SpeakerDiarizationService: @unchecked Sendable {
         guard durationSec >= minTurnSeconds else { return }
         guard let embedding = mfcc.embed(samples: samples) else { return }
 
-        let speakerId = assignSessionCluster(for: embedding)
+        let speakerId = assignSessionClusterLocked(for: embedding)
         let startSec = Double(startSample) / Double(MFCCConfig.sampleRate)
         let endSec = Double(endSample) / Double(MFCCConfig.sampleRate)
         let sid = sessionId
@@ -528,7 +528,11 @@ final class SpeakerDiarizationService: @unchecked Sendable {
     private func assignSessionCluster(for embedding: [Float]) -> Int {
         stateLock.lock()
         defer { stateLock.unlock() }
+        return assignSessionClusterLocked(for: embedding)
+    }
 
+    // Caller must hold stateLock.
+    private func assignSessionClusterLocked(for embedding: [Float]) -> Int {
         var bestIdx: Int = -1
         var bestSim: Float = -.infinity
         for (i, cluster) in sessionClusters.enumerated() {


### PR DESCRIPTION
## Summary

`SpeakerDiarizationService` was deadlocking the main thread on its non-recursive `stateLock` when audio capture was stopped while `inVoiced == true`. The MFCC and pyannote paths disagreed about who holds the lock when calling the shared `assignSessionCluster(for:)` helper:

- pyannote (`runPyannoteWindow`) called it without holding `stateLock` and relied on internal locking.
- MFCC (`flushMFCCIfPossible` → `finalizeMFCCTurnLocked`) was already inside `stateLock` when it called it.

`assignSessionCluster` then tried to re-acquire the same non-recursive `NSLock` and blocked forever.

## Deadlock stack (from issue #101)

```
AppState.stopAudioCapture                       (AppState.swift:1876)
 → SpeakerDiarizationService.stop              (line 237)
   → flushMFCCIfPossible                        (line 329)  // acquires stateLock
     → finalizeMFCCTurnLocked                   (line 346)  // caller holds lock
       → assignSessionCluster                   (line 529)  // tries to acquire stateLock again
         → __psynch_mutexwait                    (blocks forever)
```

## Fix

Split `assignSessionCluster(for:)` into:

- A public wrapper `assignSessionCluster(for:)` that takes `stateLock` then delegates — used by the pyannote path which does not hold the lock.
- An internal `assignSessionClusterLocked(for:)` helper whose caller must already hold `stateLock` — used by `finalizeMFCCTurnLocked`.

No other refactoring; bug fix only.

## Test plan

- [x] `xcrun swift build -c debug --package-path Desktop` — passes locally.
- [x] `cargo test --locked -p infinite-recall-api` (CI rust-test job) — passes locally.
- [x] `cargo test --locked -p infinite-recall-api --features activity_test_wiring` — passes locally.
- [ ] Manual: start a transcription session, speak so `inVoiced == true`, stop mid-utterance, confirm UI does not freeze (user will rebuild and verify).

Fixes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal speaker diarization processing to reduce redundant locking operations, improving efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->