### PR TITLE
feat(auth): one-time migrate legacy user dir to anonymous on launch

### DIFF
--- a/Desktop/Sources/LegacyUserDirMigrator.swift
+++ b/Desktop/Sources/LegacyUserDirMigrator.swift
@@ -1,0 +1,197 @@
+import Foundation
+
+/// One-time migrator for the auth-strip rebuild.
+///
+/// Background: prior to the auth strip, user data lived under
+/// `~/Library/Application Support/Omi/users/<firebase-uid>/` (e.g.
+/// `mpwtlyQCq9h4XWwpgVPRGOyNEgh1`). After the strip, the userId is hardcoded
+/// to the literal string `anonymous`. Without this migrator, an existing user
+/// upgrades and sees an empty conversation list because the new build looks
+/// at `users/anonymous/` while the historical data sits orphaned at
+/// `users/<old-uid>/`.
+///
+/// Behavior: on launch, if `users/anonymous/omi.db` is missing or 0 bytes
+/// **and** there is exactly one sibling user dir with a non-zero `omi.db`,
+/// copy that sibling into `users/anonymous/`. Filesystem-only — no SQL, no
+/// GRDB, no schema knowledge. GRDB runs its own pending migrations on first
+/// open as it normally does.
+///
+/// Runs once: a UserDefaults flag (`legacyAnonymousMigrationCompleted`) gates
+/// re-runs across launches even if `anonymous/` later becomes empty again
+/// (e.g. user wipes data deliberately).
+enum LegacyUserDirMigrator {
+
+    static let completedFlagKey = "legacyAnonymousMigrationCompleted"
+    static let multipleCandidatesFlagKey = "legacyMigrationSkipped_multipleCandidates"
+
+    /// Default support root: `~/Library/Application Support/Omi/users/`.
+    /// Mirrors the path computed inside `RewindDatabase.userBaseDirectory()`.
+    static func defaultSupportRoot() -> URL {
+        let appSupport = FileManager.default.urls(
+            for: .applicationSupportDirectory, in: .userDomainMask
+        ).first!
+        return appSupport
+            .appendingPathComponent("Omi", isDirectory: true)
+            .appendingPathComponent("users", isDirectory: true)
+    }
+
+    /// Run the migration. Safe to call repeatedly; the flag short-circuits
+    /// after a successful copy.
+    ///
+    /// - Parameters:
+    ///   - usersRoot: Directory containing per-user folders (defaults to the
+    ///     real Application Support path). Tests inject a temp dir.
+    ///   - defaults: UserDefaults to read/write the completion flag against.
+    ///     Tests inject an isolated suite.
+    static func runIfNeeded(
+        usersRoot: URL = defaultSupportRoot(),
+        defaults: UserDefaults = .standard
+    ) {
+        // 1. Hard gate: if we already migrated, never run again.
+        if defaults.bool(forKey: completedFlagKey) {
+            return
+        }
+
+        let fm = FileManager.default
+        let anonymousDir = usersRoot.appendingPathComponent("anonymous", isDirectory: true)
+        let anonymousDB = anonymousDir.appendingPathComponent("omi.db")
+
+        // 2. Decide if anonymous is "empty" using filesystem state only.
+        //    Empty = dir doesn't exist, OR file missing, OR file is 0 bytes.
+        //    Do NOT open the DB to count rows — at this point in launch
+        //    GRDB hasn't run migrations yet and opening it would be racy.
+        if !isEmptyDB(at: anonymousDB) {
+            return
+        }
+
+        // 3. Enumerate candidate sibling directories.
+        let candidates = findCandidates(in: usersRoot, fileManager: fm)
+
+        switch candidates.count {
+        case 0:
+            // Fresh install or already-migrated state we can't tell apart
+            // from fresh. Either way: nothing to do.
+            return
+
+        case 1:
+            let source = candidates[0]
+            do {
+                try migrate(
+                    from: source,
+                    to: anonymousDir,
+                    fileManager: fm
+                )
+                defaults.set(true, forKey: completedFlagKey)
+                log(
+                    "[legacy-migrate] Successfully migrated \(source.lastPathComponent) "
+                        + "-> anonymous/. Original retained as safety net.")
+            } catch {
+                // Don't mark the flag — let the user retry on next launch.
+                // Better to see no conversations than a half-copied DB.
+                logError(
+                    "[legacy-migrate] FAILED to copy \(source.lastPathComponent) to "
+                        + "anonymous/. Manual recovery: copy the contents of "
+                        + "\(source.path) into \(anonymousDir.path) and set "
+                        + "UserDefaults key '\(completedFlagKey)' to true.",
+                    error: error)
+            }
+
+        default:
+            // Multiple candidates — refuse to guess. Set a flag so we don't
+            // re-log on every launch.
+            let names = candidates.map { $0.lastPathComponent }.sorted().joined(separator: ", ")
+            log(
+                "[legacy-migrate] Skipping migration: multiple candidate user dirs found "
+                    + "(\(names)). Refusing to guess. Set "
+                    + "UserDefaults key '\(completedFlagKey)' to true to suppress this "
+                    + "and migrate manually.")
+            defaults.set(true, forKey: multipleCandidatesFlagKey)
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// `omi.db` at `path` is considered empty if it doesn't exist or is 0 bytes.
+    private static func isEmptyDB(at url: URL) -> Bool {
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: url.path) else { return true }
+        let size = fileSize(at: url)
+        return size == 0
+    }
+
+    /// Returns the file size in bytes, or 0 if it can't be determined.
+    private static func fileSize(at url: URL) -> Int64 {
+        guard let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
+              let n = attrs[.size] as? NSNumber
+        else { return 0 }
+        return n.int64Value
+    }
+
+    /// Finds sibling user dirs under `usersRoot` that look like real legacy
+    /// data we should consider migrating. Skips:
+    ///   - `anonymous` itself
+    ///   - hidden dirs (start with `.`)
+    ///   - backup/bak names
+    ///   - dirs without an `omi.db` file
+    ///   - dirs whose `omi.db` is 0 bytes
+    private static func findCandidates(
+        in usersRoot: URL, fileManager fm: FileManager
+    ) -> [URL] {
+        guard fm.fileExists(atPath: usersRoot.path) else { return [] }
+
+        let entries: [URL]
+        do {
+            entries = try fm.contentsOfDirectory(
+                at: usersRoot,
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles])
+        } catch {
+            logError("[legacy-migrate] Failed to list \(usersRoot.path)", error: error)
+            return []
+        }
+
+        return entries.filter { url in
+            guard isDirectory(url, fileManager: fm) else { return false }
+            let name = url.lastPathComponent
+            if name == "anonymous" { return false }
+            if name.hasPrefix(".") { return false }
+            let lower = name.lowercased()
+            if lower.contains(".bak") || lower.contains("backup") { return false }
+            let dbURL = url.appendingPathComponent("omi.db")
+            guard fm.fileExists(atPath: dbURL.path) else { return false }
+            return fileSize(at: dbURL) > 0
+        }
+    }
+
+    private static func isDirectory(_ url: URL, fileManager fm: FileManager) -> Bool {
+        var isDir: ObjCBool = false
+        guard fm.fileExists(atPath: url.path, isDirectory: &isDir) else { return false }
+        return isDir.boolValue
+    }
+
+    /// Copy `source` to `destination`. If `destination` already exists (an
+    /// empty `users/anonymous/` created earlier in launch by the new build),
+    /// rename it aside first so `copyItem` can succeed.
+    private static func migrate(
+        from source: URL,
+        to destination: URL,
+        fileManager fm: FileManager
+    ) throws {
+        let dbSize = fileSize(at: source.appendingPathComponent("omi.db"))
+        log(
+            "[legacy-migrate] Migrating user dir: source=\(source.lastPathComponent) "
+                + "omi.db size=\(dbSize) bytes")
+
+        // If the empty anonymous dir exists, move it aside first.
+        if fm.fileExists(atPath: destination.path) {
+            let ts = Int(Date().timeIntervalSince1970)
+            let backup = destination.deletingLastPathComponent()
+                .appendingPathComponent("anonymous.empty.bak.\(ts)", isDirectory: true)
+            try fm.moveItem(at: destination, to: backup)
+            log("[legacy-migrate] Moved pre-existing empty anonymous/ to \(backup.lastPathComponent)")
+        }
+
+        // Copy (not move) — keep the original intact as a safety net.
+        try fm.copyItem(at: source, to: destination)
+    }
+}

--- a/Desktop/Sources/LegacyUserDirMigrator.swift
+++ b/Desktop/Sources/LegacyUserDirMigrator.swift
@@ -1,31 +1,22 @@
+import AppKit
 import Foundation
+import SwiftUI
 
-/// One-time migrator for the auth-strip rebuild.
-///
-/// Background: prior to the auth strip, user data lived under
-/// `~/Library/Application Support/Omi/users/<firebase-uid>/` (e.g.
-/// `mpwtlyQCq9h4XWwpgVPRGOyNEgh1`). After the strip, the userId is hardcoded
-/// to the literal string `anonymous`. Without this migrator, an existing user
-/// upgrades and sees an empty conversation list because the new build looks
-/// at `users/anonymous/` while the historical data sits orphaned at
-/// `users/<old-uid>/`.
-///
-/// Behavior: on launch, if `users/anonymous/omi.db` is missing or 0 bytes
-/// **and** there is exactly one sibling user dir with a non-zero `omi.db`,
-/// copy that sibling into `users/anonymous/`. Filesystem-only — no SQL, no
-/// GRDB, no schema knowledge. GRDB runs its own pending migrations on first
-/// open as it normally does.
-///
-/// Runs once: a UserDefaults flag (`legacyAnonymousMigrationCompleted`) gates
-/// re-runs across launches even if `anonymous/` later becomes empty again
-/// (e.g. user wipes data deliberately).
+/// One-time filesystem migrator for the auth-strip rebuild: copies a pre-strip
+/// `users/<firebase-uid>/` dir into `users/anonymous/` so existing users don't
+/// upgrade into an empty conversation list.
 enum LegacyUserDirMigrator {
 
     static let completedFlagKey = "legacyAnonymousMigrationCompleted"
     static let multipleCandidatesFlagKey = "legacyMigrationSkipped_multipleCandidates"
 
-    /// Default support root: `~/Library/Application Support/Omi/users/`.
-    /// Mirrors the path computed inside `RewindDatabase.userBaseDirectory()`.
+    enum MigrationOutcome: Equatable {
+        case noop
+        case migrated(sourceName: String)
+        case skippedMultipleCandidates(names: [String])
+        case failed(reason: String)
+    }
+
     static func defaultSupportRoot() -> URL {
         let appSupport = FileManager.default.urls(
             for: .applicationSupportDirectory, in: .userDomainMask
@@ -35,105 +26,100 @@ enum LegacyUserDirMigrator {
             .appendingPathComponent("users", isDirectory: true)
     }
 
-    /// Run the migration. Safe to call repeatedly; the flag short-circuits
-    /// after a successful copy.
+    /// Run the migration. Safe to call repeatedly.
     ///
-    /// - Parameters:
-    ///   - usersRoot: Directory containing per-user folders (defaults to the
-    ///     real Application Support path). Tests inject a temp dir.
-    ///   - defaults: UserDefaults to read/write the completion flag against.
-    ///     Tests inject an isolated suite.
+    /// File I/O runs on a background executor so a multi-GB copy doesn't trip
+    /// the macOS launch watchdog. To retry after a multi-candidate skip the UI
+    /// must clear both `multipleCandidatesFlagKey` and `completedFlagKey`.
     static func runIfNeeded(
         usersRoot: URL = defaultSupportRoot(),
         defaults: UserDefaults = .standard
-    ) {
-        // 1. Hard gate: if we already migrated, never run again.
+    ) async -> MigrationOutcome {
+        await Task.detached(priority: .userInitiated) {
+            performMigration(usersRoot: usersRoot, defaults: defaults)
+        }.value
+    }
+
+    static func performMigration(
+        usersRoot: URL,
+        defaults: UserDefaults
+    ) -> MigrationOutcome {
         if defaults.bool(forKey: completedFlagKey) {
-            return
+            return .noop
+        }
+        if defaults.bool(forKey: multipleCandidatesFlagKey) {
+            return .skippedMultipleCandidates(names: [])
         }
 
         let fm = FileManager.default
+        cleanupOrphanedTempDirs(in: usersRoot, fileManager: fm)
+
         let anonymousDir = usersRoot.appendingPathComponent("anonymous", isDirectory: true)
         let anonymousDB = anonymousDir.appendingPathComponent("omi.db")
 
-        // 2. Decide if anonymous is "empty" using filesystem state only.
-        //    Empty = dir doesn't exist, OR file missing, OR file is 0 bytes.
-        //    Do NOT open the DB to count rows — at this point in launch
-        //    GRDB hasn't run migrations yet and opening it would be racy.
+        // Don't open the DB to count rows — at this point in launch GRDB
+        // hasn't run migrations yet and opening it would be racy.
         if !isEmptyDB(at: anonymousDB) {
-            return
+            return .noop
         }
 
-        // 3. Enumerate candidate sibling directories.
         let candidates = findCandidates(in: usersRoot, fileManager: fm)
 
         switch candidates.count {
         case 0:
-            // Fresh install or already-migrated state we can't tell apart
-            // from fresh. Either way: nothing to do.
-            return
+            return .noop
 
         case 1:
             let source = candidates[0]
             do {
-                try migrate(
-                    from: source,
-                    to: anonymousDir,
-                    fileManager: fm
-                )
+                try migrate(from: source, to: anonymousDir, fileManager: fm)
                 defaults.set(true, forKey: completedFlagKey)
                 log(
                     "[legacy-migrate] Successfully migrated \(source.lastPathComponent) "
                         + "-> anonymous/. Original retained as safety net.")
+                return .migrated(sourceName: source.lastPathComponent)
             } catch {
-                // Don't mark the flag — let the user retry on next launch.
-                // Better to see no conversations than a half-copied DB.
                 logError(
                     "[legacy-migrate] FAILED to copy \(source.lastPathComponent) to "
                         + "anonymous/. Manual recovery: copy the contents of "
                         + "\(source.path) into \(anonymousDir.path) and set "
                         + "UserDefaults key '\(completedFlagKey)' to true.",
                     error: error)
+                return .failed(reason: error.localizedDescription)
             }
 
         default:
-            // Multiple candidates — refuse to guess. Set a flag so we don't
-            // re-log on every launch.
-            let names = candidates.map { $0.lastPathComponent }.sorted().joined(separator: ", ")
+            let names = candidates.map { $0.lastPathComponent }.sorted()
+            let joined = names.joined(separator: ", ")
             log(
                 "[legacy-migrate] Skipping migration: multiple candidate user dirs found "
-                    + "(\(names)). Refusing to guess. Set "
+                    + "(\(joined)). Refusing to guess. Set "
                     + "UserDefaults key '\(completedFlagKey)' to true to suppress this "
                     + "and migrate manually.")
             defaults.set(true, forKey: multipleCandidatesFlagKey)
+            return .skippedMultipleCandidates(names: names)
         }
     }
 
     // MARK: - Helpers
 
-    /// `omi.db` at `path` is considered empty if it doesn't exist or is 0 bytes.
     private static func isEmptyDB(at url: URL) -> Bool {
         let fm = FileManager.default
         guard fm.fileExists(atPath: url.path) else { return true }
-        let size = fileSize(at: url)
-        return size == 0
+        return fileSize(at: url) == 0
     }
 
-    /// Returns the file size in bytes, or 0 if it can't be determined.
     private static func fileSize(at url: URL) -> Int64 {
-        guard let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
-              let n = attrs[.size] as? NSNumber
-        else { return 0 }
-        return n.int64Value
+        do {
+            let attrs = try FileManager.default.attributesOfItem(atPath: url.path)
+            guard let n = attrs[.size] as? NSNumber else { return 0 }
+            return n.int64Value
+        } catch {
+            logError("[legacy-migrate] could not stat \(url.path)", error: error)
+            return 0
+        }
     }
 
-    /// Finds sibling user dirs under `usersRoot` that look like real legacy
-    /// data we should consider migrating. Skips:
-    ///   - `anonymous` itself
-    ///   - hidden dirs (start with `.`)
-    ///   - backup/bak names
-    ///   - dirs without an `omi.db` file
-    ///   - dirs whose `omi.db` is 0 bytes
     private static func findCandidates(
         in usersRoot: URL, fileManager fm: FileManager
     ) -> [URL] {
@@ -154,13 +140,26 @@ enum LegacyUserDirMigrator {
             guard isDirectory(url, fileManager: fm) else { return false }
             let name = url.lastPathComponent
             if name == "anonymous" { return false }
-            if name.hasPrefix(".") { return false }
-            let lower = name.lowercased()
-            if lower.contains(".bak") || lower.contains("backup") { return false }
+            if isBackupName(name) { return false }
             let dbURL = url.appendingPathComponent("omi.db")
             guard fm.fileExists(atPath: dbURL.path) else { return false }
             return fileSize(at: dbURL) > 0
         }
+    }
+
+    /// Anchored backup-name match: literal `.bak` suffix, timestamped `.bak.<digits>`
+    /// suffix (matches our own `anonymous.empty.bak.<ts>`), or a `backup` prefix.
+    /// A real legacy uid containing the substring "backup" is NOT filtered out.
+    static func isBackupName(_ name: String) -> Bool {
+        let lower = name.lowercased()
+        if lower.hasSuffix(".bak") { return true }
+        if lower.hasPrefix("backup") { return true }
+        if let range = lower.range(of: #"\.bak\.\d+$"#, options: .regularExpression),
+           range.upperBound == lower.endIndex
+        {
+            return true
+        }
+        return false
     }
 
     private static func isDirectory(_ url: URL, fileManager fm: FileManager) -> Bool {
@@ -169,9 +168,10 @@ enum LegacyUserDirMigrator {
         return isDir.boolValue
     }
 
-    /// Copy `source` to `destination`. If `destination` already exists (an
-    /// empty `users/anonymous/` created earlier in launch by the new build),
-    /// rename it aside first so `copyItem` can succeed.
+    /// Atomic copy: stage into `.anonymous.tmp.<pid>.<ts>/`, only then move
+    /// any pre-existing `anonymous/` aside, then rename tmp -> final. Same-volume
+    /// rename is atomic, so a power loss at any point leaves the legacy source
+    /// intact and `anonymous/` either pristine-old or pristine-new.
     private static func migrate(
         from source: URL,
         to destination: URL,
@@ -182,16 +182,156 @@ enum LegacyUserDirMigrator {
             "[legacy-migrate] Migrating user dir: source=\(source.lastPathComponent) "
                 + "omi.db size=\(dbSize) bytes")
 
-        // If the empty anonymous dir exists, move it aside first.
-        if fm.fileExists(atPath: destination.path) {
-            let ts = Int(Date().timeIntervalSince1970)
-            let backup = destination.deletingLastPathComponent()
-                .appendingPathComponent("anonymous.empty.bak.\(ts)", isDirectory: true)
-            try fm.moveItem(at: destination, to: backup)
-            log("[legacy-migrate] Moved pre-existing empty anonymous/ to \(backup.lastPathComponent)")
+        let parent = destination.deletingLastPathComponent()
+        let pid = ProcessInfo.processInfo.processIdentifier
+        let ts = Int(Date().timeIntervalSince1970)
+        let tmpDir = parent.appendingPathComponent(
+            ".anonymous.tmp.\(pid).\(ts)", isDirectory: true)
+
+        do {
+            try fm.copyItem(at: source, to: tmpDir)
+        } catch {
+            try? fm.removeItem(at: tmpDir)
+            throw error
         }
 
-        // Copy (not move) — keep the original intact as a safety net.
-        try fm.copyItem(at: source, to: destination)
+        if fm.fileExists(atPath: destination.path) {
+            logExistingAnonymousContents(destination, fileManager: fm)
+            let backup = parent.appendingPathComponent(
+                "anonymous.empty.bak.\(ts)", isDirectory: true)
+            do {
+                try fm.moveItem(at: destination, to: backup)
+                log("[legacy-migrate] Moved pre-existing anonymous/ to \(backup.lastPathComponent)")
+            } catch {
+                try? fm.removeItem(at: tmpDir)
+                throw error
+            }
+        }
+
+        do {
+            try fm.moveItem(at: tmpDir, to: destination)
+        } catch {
+            try? fm.removeItem(at: tmpDir)
+            throw error
+        }
+    }
+
+    /// Forensics breadcrumb: log the top-level contents (filenames + sizes,
+    /// capped at 50) of an `anonymous/` we're about to move aside, so a user
+    /// who later asks "where did my data go" can find it in the logs.
+    private static func logExistingAnonymousContents(
+        _ destination: URL, fileManager fm: FileManager
+    ) {
+        let cap = 50
+        do {
+            let entries = try fm.contentsOfDirectory(
+                at: destination,
+                includingPropertiesForKeys: [.fileSizeKey, .isDirectoryKey],
+                options: [])
+            let total = entries.count
+            let described = entries.prefix(cap).map { url -> String in
+                let name = url.lastPathComponent
+                let size = fileSize(at: url)
+                return "\(name)(\(size))"
+            }.joined(separator: ", ")
+            let suffix = total > cap ? " ...and \(total - cap) more" : ""
+            log("[legacy-migrate] Pre-existing anonymous/ contents: [\(described)]\(suffix)")
+        } catch {
+            logError("[legacy-migrate] Could not list pre-existing anonymous/", error: error)
+        }
+    }
+
+    /// Sweep `users/.anonymous.tmp.*` left behind by a previous interrupted run.
+    /// Anything matching is incomplete by definition.
+    private static func cleanupOrphanedTempDirs(in usersRoot: URL, fileManager fm: FileManager) {
+        guard fm.fileExists(atPath: usersRoot.path) else { return }
+        let entries: [URL]
+        do {
+            entries = try fm.contentsOfDirectory(
+                at: usersRoot,
+                includingPropertiesForKeys: nil,
+                options: [])
+        } catch {
+            return
+        }
+        for url in entries where url.lastPathComponent.hasPrefix(".anonymous.tmp.") {
+            log("[legacy-migrate] Removing orphaned tmp dir: \(url.lastPathComponent)")
+            try? fm.removeItem(at: url)
+        }
+    }
+}
+
+/// UI surface for the migrator. The launch sequence holds the main window's
+/// content gated on `isReady` so the FS copy can run on a background thread
+/// without tripping the macOS launch watchdog. `pendingMultiCandidateNames`
+/// drives a one-time alert that nags every launch until the user resolves.
+@MainActor
+final class LegacyMigrationGate: ObservableObject {
+    static let shared = LegacyMigrationGate()
+
+    @Published var isReady: Bool = false
+    @Published var pendingMultiCandidateNames: [String] = []
+
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+
+    private init() {}
+
+    func markReady(outcome: LegacyUserDirMigrator.MigrationOutcome) {
+        switch outcome {
+        case .skippedMultipleCandidates(let names) where !names.isEmpty:
+            pendingMultiCandidateNames = names
+        default:
+            break
+        }
+        isReady = true
+        let pending = continuations
+        continuations.removeAll()
+        for c in pending { c.resume() }
+    }
+
+    /// Suspend until migration completes. Cheap no-op once `isReady`.
+    func waitUntilReady() async {
+        if isReady { return }
+        await withCheckedContinuation { continuation in
+            if isReady {
+                continuation.resume()
+            } else {
+                continuations.append(continuation)
+            }
+        }
+    }
+
+    /// On launch, surface the alert if a previous run skipped on multi-candidate.
+    /// Reads UserDefaults directly so the prompt persists across launches even
+    /// when the migrator short-circuits at the gate without enumerating.
+    func checkPersistedMultiCandidateFlag(defaults: UserDefaults = .standard) {
+        guard !defaults.bool(forKey: LegacyUserDirMigrator.completedFlagKey),
+              defaults.bool(forKey: LegacyUserDirMigrator.multipleCandidatesFlagKey)
+        else { return }
+        if pendingMultiCandidateNames.isEmpty {
+            pendingMultiCandidateNames = ["(see app log for paths)"]
+        }
+    }
+
+    func presentAlertIfNeeded(defaults: UserDefaults = .standard) {
+        guard !pendingMultiCandidateNames.isEmpty else { return }
+        let names = pendingMultiCandidateNames
+        let alert = NSAlert()
+        alert.messageText = "Multiple legacy data folders found"
+        alert.informativeText =
+            "Infinite Recall found multiple legacy data folders and didn't pick one "
+            + "automatically:\n\n  \(names.joined(separator: "\n  "))\n\n"
+            + "Open the user data folder, keep only the one you want as 'anonymous', "
+            + "then click Retry migration."
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Retry migration")
+        alert.addButton(withTitle: "Dismiss")
+        let response = alert.runModal()
+        if response == .alertFirstButtonReturn {
+            defaults.removeObject(forKey: LegacyUserDirMigrator.completedFlagKey)
+            defaults.removeObject(forKey: LegacyUserDirMigrator.multipleCandidatesFlagKey)
+            pendingMultiCandidateNames = []
+            log("[legacy-migrate] User clicked Retry — flags cleared, will re-run on next launch")
+        }
     }
 }

--- a/Desktop/Sources/OmiApp.swift
+++ b/Desktop/Sources/OmiApp.swift
@@ -298,6 +298,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     _ = UpdaterViewModel.shared
     UpdaterViewModel.shared.checkForUpdatesImmediatelyAfterLaunchIfNeeded()
 
+    // Infinite Recall fork: one-time migration of legacy per-user data.
+    // The auth strip hardcoded the user id to "anonymous", which stranded
+    // existing users' data in `users/<old-firebase-uid>/`. This copies it
+    // into `users/anonymous/` on first launch after upgrade. Filesystem-only
+    // (no SQL); must run BEFORE any GRDB connection is opened against
+    // `users/anonymous/omi.db` (the static currentUserId is set ~75 lines
+    // below this, and DB init follows).
+    LegacyUserDirMigrator.runIfNeeded()
+
     // Infinite Recall fork: force anonymous local-only mode on every launch.
     // This unconditionally bypasses the Apple/Google/Firebase sign-in gate so
     // the app boots straight into the main UI. Auto-completes onboarding too,

--- a/Desktop/Sources/OmiApp.swift
+++ b/Desktop/Sources/OmiApp.swift
@@ -299,21 +299,22 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     UpdaterViewModel.shared.checkForUpdatesImmediatelyAfterLaunchIfNeeded()
 
     // Infinite Recall fork: one-time migration of legacy per-user data.
-    // The auth strip hardcoded the user id to "anonymous", which stranded
-    // existing users' data in `users/<old-firebase-uid>/`. This copies it
-    // into `users/anonymous/` on first launch after upgrade. Filesystem-only
-    // (no SQL); must run BEFORE any GRDB connection is opened against
-    // `users/anonymous/omi.db` (the static currentUserId is set ~75 lines
-    // below this, and DB init follows).
-    LegacyUserDirMigrator.runIfNeeded()
+    // Runs on a background executor so a multi-GB copy doesn't trip the macOS
+    // launch watchdog. Sign-in + DB init wait on `LegacyMigrationGate.isReady`
+    // so GRDB never opens `users/anonymous/omi.db` mid-copy.
+    LegacyMigrationGate.shared.checkPersistedMultiCandidateFlag()
+    Task { @MainActor in
+      let outcome = await LegacyUserDirMigrator.runIfNeeded()
+      LegacyMigrationGate.shared.markReady(outcome: outcome)
 
-    // Infinite Recall fork: force anonymous local-only mode on every launch.
-    // This unconditionally bypasses the Apple/Google/Firebase sign-in gate so
-    // the app boots straight into the main UI. Auto-completes onboarding too,
-    // so screen-recording / mic / accessibility permissions are requested on
-    // first use rather than gated behind an onboarding wizard.
-    AuthService.shared.signInAnonymously()
-    UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
+      AuthService.shared.signInAnonymously()
+      UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
+
+      let userId = UserDefaults.standard.string(forKey: "auth_userId")
+      RewindDatabase.currentUserId = (userId?.isEmpty == false) ? userId : "anonymous"
+
+      LegacyMigrationGate.shared.presentAlertIfNeeded()
+    }
 
     // Initialize analytics (MixPanel + PostHog)
     AnalyticsManager.shared.initialize()
@@ -328,6 +329,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     // Skips active recordings (status='recording' newer than 30s) to avoid
     // racing capture before the first segment lands.
     Task {
+      await LegacyMigrationGate.shared.waitUntilReady()
       do {
         let purged = try await TranscriptionStorage.shared.purgeEmptySessions()
         if purged > 0 {
@@ -383,10 +385,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
     AnalyticsManager.shared.trackFirstLaunchIfNeeded()
 
-    // Set per-user database path before any async tasks can trigger DB initialization.
-    // This is synchronous and must happen before TierManager / TranscriptionRetryService.
-    let userId = UserDefaults.standard.string(forKey: "auth_userId")
-    RewindDatabase.currentUserId = (userId?.isEmpty == false) ? userId : "anonymous"
+    // Note: `RewindDatabase.currentUserId` is set inside the migration Task
+    // above so GRDB only opens `users/anonymous/omi.db` after the copy lands.
 
     // Start resource monitoring (memory, CPU, disk)
     ResourceMonitor.shared.start()
@@ -399,6 +399,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     // One-time KG backfill: enqueues an .extractKG job for every existing
     // memory that hasn't been processed yet. Idempotent via migration_status.
     Task {
+      await LegacyMigrationGate.shared.waitUntilReady()
       await KGBackfillService.shared.runIfNeeded()
     }
 
@@ -427,6 +428,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
     // Recover any pending/failed transcription sessions from previous runs
     Task {
+      await LegacyMigrationGate.shared.waitUntilReady()
       await TranscriptionRetryService.shared.recoverPendingTranscriptions()
       TranscriptionRetryService.shared.start()
     }

--- a/Desktop/Tests/LegacyUserDirMigratorTests.swift
+++ b/Desktop/Tests/LegacyUserDirMigratorTests.swift
@@ -1,0 +1,212 @@
+import XCTest
+@testable import Omi_Computer
+
+/// Tests for `LegacyUserDirMigrator`, the one-time auth-strip migration that
+/// copies the user's pre-strip Firebase-UID directory into
+/// `users/anonymous/` on launch.
+///
+/// All tests inject a temp dir as the support root and an isolated
+/// UserDefaults suite so nothing touches `~/Library` or the real defaults.
+final class LegacyUserDirMigratorTests: XCTestCase {
+
+    private var tempDir: URL!
+    private var defaults: UserDefaults!
+    private var defaultsSuiteName: String!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("legacy-migrate-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+
+        defaultsSuiteName = "legacy-migrate-tests-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: defaultsSuiteName)
+        XCTAssertNotNil(defaults)
+    }
+
+    override func tearDownWithError() throws {
+        if let tempDir, FileManager.default.fileExists(atPath: tempDir.path) {
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+        if let defaults, let suite = defaultsSuiteName {
+            defaults.removePersistentDomain(forName: suite)
+        }
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Helpers
+
+    /// Create a `users/<name>/omi.db` file with the given size in bytes.
+    @discardableResult
+    private func makeUserDir(_ name: String, dbSize: Int) throws -> URL {
+        let dir = tempDir.appendingPathComponent(name, isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let dbURL = dir.appendingPathComponent("omi.db")
+        let bytes = Data(count: dbSize)
+        try bytes.write(to: dbURL)
+        return dir
+    }
+
+    /// Same as makeUserDir but does NOT create an omi.db file.
+    @discardableResult
+    private func makeEmptyUserDir(_ name: String) throws -> URL {
+        let dir = tempDir.appendingPathComponent(name, isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func dbSize(at url: URL) -> Int64 {
+        guard let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
+              let n = attrs[.size] as? NSNumber
+        else { return -1 }
+        return n.int64Value
+    }
+
+    // MARK: - Tests
+
+    /// Zero candidates → no-op, no flag set.
+    func testNoCandidates_NoOp() throws {
+        // Empty users root.
+        LegacyUserDirMigrator.runIfNeeded(usersRoot: tempDir, defaults: defaults)
+
+        XCTAssertFalse(
+            defaults.bool(forKey: LegacyUserDirMigrator.completedFlagKey),
+            "Completion flag must NOT be set when there's nothing to migrate")
+        XCTAssertFalse(
+            defaults.bool(forKey: LegacyUserDirMigrator.multipleCandidatesFlagKey))
+
+        let anonDB = tempDir.appendingPathComponent("anonymous/omi.db")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: anonDB.path))
+    }
+
+    /// One legacy candidate with non-empty omi.db → copied, flag set, anon
+    /// has non-zero db.
+    func testOneCandidate_Migrates() throws {
+        let legacyName = "mpwtlyQCq9h4XWwpgVPRGOyNEgh1"
+        let legacy = try makeUserDir(legacyName, dbSize: 4096)
+        // Also seed a sibling file inside legacy/ to verify recursive copy.
+        let videosDir = legacy.appendingPathComponent("Videos", isDirectory: true)
+        try FileManager.default.createDirectory(at: videosDir, withIntermediateDirectories: true)
+        try Data([1, 2, 3]).write(to: videosDir.appendingPathComponent("clip.bin"))
+
+        LegacyUserDirMigrator.runIfNeeded(usersRoot: tempDir, defaults: defaults)
+
+        let anonDB = tempDir.appendingPathComponent("anonymous/omi.db")
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: anonDB.path),
+            "anonymous/omi.db should exist after migration")
+        XCTAssertEqual(
+            dbSize(at: anonDB), 4096,
+            "anonymous/omi.db size should match the legacy db size")
+
+        let copiedClip = tempDir.appendingPathComponent("anonymous/Videos/clip.bin")
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: copiedClip.path),
+            "Subdir contents should be copied recursively")
+
+        // Original retained as safety net.
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: legacy.appendingPathComponent("omi.db").path),
+            "Legacy dir must be retained as safety net (copy not move)")
+
+        XCTAssertTrue(
+            defaults.bool(forKey: LegacyUserDirMigrator.completedFlagKey),
+            "Completion flag must be set after a successful migration")
+    }
+
+    /// One legacy candidate but anonymous already has non-empty omi.db → no-op.
+    /// The file-emptiness gate fires before candidate enumeration.
+    func testAnonymousAlreadyPopulated_NoOp() throws {
+        try makeUserDir("anonymous", dbSize: 8192)
+        try makeUserDir("oldFirebaseUid", dbSize: 4096)
+
+        LegacyUserDirMigrator.runIfNeeded(usersRoot: tempDir, defaults: defaults)
+
+        let anonDB = tempDir.appendingPathComponent("anonymous/omi.db")
+        XCTAssertEqual(
+            dbSize(at: anonDB), 8192,
+            "anonymous/omi.db must be untouched when it's already non-empty")
+
+        XCTAssertFalse(
+            defaults.bool(forKey: LegacyUserDirMigrator.completedFlagKey),
+            "Flag should not be set — we did nothing")
+    }
+
+    /// Two legacy candidates → no-op, multipleCandidates flag set, anon stays empty.
+    func testMultipleCandidates_RefusesAndFlags() throws {
+        try makeUserDir("uidA", dbSize: 4096)
+        try makeUserDir("uidB", dbSize: 4096)
+
+        LegacyUserDirMigrator.runIfNeeded(usersRoot: tempDir, defaults: defaults)
+
+        let anonDB = tempDir.appendingPathComponent("anonymous/omi.db")
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: anonDB.path),
+            "Must NOT copy when multiple candidates exist — we refuse to guess")
+
+        XCTAssertFalse(
+            defaults.bool(forKey: LegacyUserDirMigrator.completedFlagKey))
+        XCTAssertTrue(
+            defaults.bool(forKey: LegacyUserDirMigrator.multipleCandidatesFlagKey),
+            "Multiple-candidate skip flag must be set so we don't re-log every launch")
+    }
+
+    /// Flag already completed → no-op even when conditions would otherwise match.
+    func testFlagAlreadyCompleted_NoOp() throws {
+        try makeUserDir("oldFirebaseUid", dbSize: 4096)
+        defaults.set(true, forKey: LegacyUserDirMigrator.completedFlagKey)
+
+        LegacyUserDirMigrator.runIfNeeded(usersRoot: tempDir, defaults: defaults)
+
+        let anonDB = tempDir.appendingPathComponent("anonymous/omi.db")
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: anonDB.path),
+            "Flag gate must short-circuit migration even when a candidate exists")
+    }
+
+    // MARK: - Filter coverage
+
+    /// Backup dirs and zero-byte dbs must NOT count as candidates. Combined
+    /// with one real legacy dir, this still ends up as the single-candidate
+    /// happy path.
+    func testIgnoresBackupAndEmptyDBDirs() throws {
+        try makeUserDir("realUid", dbSize: 4096)
+        try makeUserDir("realUid.bak.123", dbSize: 4096)  // backup name -> skip
+        try makeUserDir("backup-2024", dbSize: 4096)  // contains "backup" -> skip
+        try makeUserDir("zeroByteUid", dbSize: 0)  // 0-byte db -> skip
+        try makeEmptyUserDir("noDbAtAll")  // missing db -> skip
+
+        LegacyUserDirMigrator.runIfNeeded(usersRoot: tempDir, defaults: defaults)
+
+        let anonDB = tempDir.appendingPathComponent("anonymous/omi.db")
+        XCTAssertEqual(
+            dbSize(at: anonDB), 4096,
+            "Should have migrated the single real candidate, ignoring decoys")
+        XCTAssertTrue(
+            defaults.bool(forKey: LegacyUserDirMigrator.completedFlagKey))
+    }
+
+    /// If `users/anonymous/` already exists empty (e.g. created earlier in
+    /// launch) it must be moved aside so copyItem can succeed.
+    func testEmptyAnonymousIsMovedAsideBeforeCopy() throws {
+        try makeEmptyUserDir("anonymous")  // exists, but no omi.db
+        try makeUserDir("oldUid", dbSize: 4096)
+
+        LegacyUserDirMigrator.runIfNeeded(usersRoot: tempDir, defaults: defaults)
+
+        let anonDB = tempDir.appendingPathComponent("anonymous/omi.db")
+        XCTAssertEqual(
+            dbSize(at: anonDB), 4096,
+            "anonymous/omi.db must exist post-migration")
+        XCTAssertTrue(
+            defaults.bool(forKey: LegacyUserDirMigrator.completedFlagKey))
+
+        // A backup of the empty dir should exist as anonymous.empty.bak.<ts>
+        let entries =
+            (try? FileManager.default.contentsOfDirectory(atPath: tempDir.path)) ?? []
+        let backups = entries.filter { $0.hasPrefix("anonymous.empty.bak.") }
+        XCTAssertEqual(
+            backups.count, 1,
+            "Pre-existing empty anonymous/ should be renamed aside, found: \(entries)")
+    }
+}

--- a/Desktop/Tests/LegacyUserDirMigratorTests.swift
+++ b/Desktop/Tests/LegacyUserDirMigratorTests.swift
@@ -1,12 +1,9 @@
 import XCTest
 @testable import Omi_Computer
 
-/// Tests for `LegacyUserDirMigrator`, the one-time auth-strip migration that
-/// copies the user's pre-strip Firebase-UID directory into
-/// `users/anonymous/` on launch.
-///
-/// All tests inject a temp dir as the support root and an isolated
-/// UserDefaults suite so nothing touches `~/Library` or the real defaults.
+/// Tests for `LegacyUserDirMigrator`. All tests inject a temp dir as the
+/// support root and an isolated UserDefaults suite so nothing touches
+/// `~/Library` or the real defaults.
 final class LegacyUserDirMigratorTests: XCTestCase {
 
     private var tempDir: URL!
@@ -36,7 +33,6 @@ final class LegacyUserDirMigratorTests: XCTestCase {
 
     // MARK: - Helpers
 
-    /// Create a `users/<name>/omi.db` file with the given size in bytes.
     @discardableResult
     private func makeUserDir(_ name: String, dbSize: Int) throws -> URL {
         let dir = tempDir.appendingPathComponent(name, isDirectory: true)
@@ -47,7 +43,6 @@ final class LegacyUserDirMigratorTests: XCTestCase {
         return dir
     }
 
-    /// Same as makeUserDir but does NOT create an omi.db file.
     @discardableResult
     private func makeEmptyUserDir(_ name: String) throws -> URL {
         let dir = tempDir.appendingPathComponent(name, isDirectory: true)
@@ -62,151 +57,284 @@ final class LegacyUserDirMigratorTests: XCTestCase {
         return n.int64Value
     }
 
+    private func runMigration() async -> LegacyUserDirMigrator.MigrationOutcome {
+        await LegacyUserDirMigrator.runIfNeeded(usersRoot: tempDir, defaults: defaults)
+    }
+
     // MARK: - Tests
 
-    /// Zero candidates → no-op, no flag set.
-    func testNoCandidates_NoOp() throws {
-        // Empty users root.
-        LegacyUserDirMigrator.runIfNeeded(usersRoot: tempDir, defaults: defaults)
+    func testNoCandidates_NoOp() async throws {
+        let outcome = await runMigration()
 
-        XCTAssertFalse(
-            defaults.bool(forKey: LegacyUserDirMigrator.completedFlagKey),
-            "Completion flag must NOT be set when there's nothing to migrate")
-        XCTAssertFalse(
-            defaults.bool(forKey: LegacyUserDirMigrator.multipleCandidatesFlagKey))
+        XCTAssertEqual(outcome, .noop)
+        XCTAssertFalse(defaults.bool(forKey: LegacyUserDirMigrator.completedFlagKey))
+        XCTAssertFalse(defaults.bool(forKey: LegacyUserDirMigrator.multipleCandidatesFlagKey))
 
         let anonDB = tempDir.appendingPathComponent("anonymous/omi.db")
         XCTAssertFalse(FileManager.default.fileExists(atPath: anonDB.path))
     }
 
-    /// One legacy candidate with non-empty omi.db → copied, flag set, anon
-    /// has non-zero db.
-    func testOneCandidate_Migrates() throws {
+    func testOneCandidate_Migrates() async throws {
         let legacyName = "mpwtlyQCq9h4XWwpgVPRGOyNEgh1"
         let legacy = try makeUserDir(legacyName, dbSize: 4096)
-        // Also seed a sibling file inside legacy/ to verify recursive copy.
         let videosDir = legacy.appendingPathComponent("Videos", isDirectory: true)
         try FileManager.default.createDirectory(at: videosDir, withIntermediateDirectories: true)
         try Data([1, 2, 3]).write(to: videosDir.appendingPathComponent("clip.bin"))
 
-        LegacyUserDirMigrator.runIfNeeded(usersRoot: tempDir, defaults: defaults)
+        let outcome = await runMigration()
+        XCTAssertEqual(outcome, .migrated(sourceName: legacyName))
 
         let anonDB = tempDir.appendingPathComponent("anonymous/omi.db")
-        XCTAssertTrue(
-            FileManager.default.fileExists(atPath: anonDB.path),
-            "anonymous/omi.db should exist after migration")
-        XCTAssertEqual(
-            dbSize(at: anonDB), 4096,
-            "anonymous/omi.db size should match the legacy db size")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: anonDB.path))
+        XCTAssertEqual(dbSize(at: anonDB), 4096)
 
         let copiedClip = tempDir.appendingPathComponent("anonymous/Videos/clip.bin")
-        XCTAssertTrue(
-            FileManager.default.fileExists(atPath: copiedClip.path),
-            "Subdir contents should be copied recursively")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: copiedClip.path))
 
-        // Original retained as safety net.
         XCTAssertTrue(
             FileManager.default.fileExists(atPath: legacy.appendingPathComponent("omi.db").path),
             "Legacy dir must be retained as safety net (copy not move)")
 
-        XCTAssertTrue(
-            defaults.bool(forKey: LegacyUserDirMigrator.completedFlagKey),
-            "Completion flag must be set after a successful migration")
+        XCTAssertTrue(defaults.bool(forKey: LegacyUserDirMigrator.completedFlagKey))
     }
 
-    /// One legacy candidate but anonymous already has non-empty omi.db → no-op.
-    /// The file-emptiness gate fires before candidate enumeration.
-    func testAnonymousAlreadyPopulated_NoOp() throws {
+    func testAnonymousAlreadyPopulated_NoOp() async throws {
         try makeUserDir("anonymous", dbSize: 8192)
         try makeUserDir("oldFirebaseUid", dbSize: 4096)
 
-        LegacyUserDirMigrator.runIfNeeded(usersRoot: tempDir, defaults: defaults)
+        let outcome = await runMigration()
+        XCTAssertEqual(outcome, .noop)
 
         let anonDB = tempDir.appendingPathComponent("anonymous/omi.db")
-        XCTAssertEqual(
-            dbSize(at: anonDB), 8192,
-            "anonymous/omi.db must be untouched when it's already non-empty")
-
-        XCTAssertFalse(
-            defaults.bool(forKey: LegacyUserDirMigrator.completedFlagKey),
-            "Flag should not be set — we did nothing")
+        XCTAssertEqual(dbSize(at: anonDB), 8192)
+        XCTAssertFalse(defaults.bool(forKey: LegacyUserDirMigrator.completedFlagKey))
     }
 
-    /// Two legacy candidates → no-op, multipleCandidates flag set, anon stays empty.
-    func testMultipleCandidates_RefusesAndFlags() throws {
+    func testMultipleCandidates_RefusesAndFlags() async throws {
         try makeUserDir("uidA", dbSize: 4096)
         try makeUserDir("uidB", dbSize: 4096)
 
-        LegacyUserDirMigrator.runIfNeeded(usersRoot: tempDir, defaults: defaults)
+        let outcome = await runMigration()
+        if case .skippedMultipleCandidates(let names) = outcome {
+            XCTAssertEqual(names.sorted(), ["uidA", "uidB"])
+        } else {
+            XCTFail("Expected skippedMultipleCandidates, got \(outcome)")
+        }
 
         let anonDB = tempDir.appendingPathComponent("anonymous/omi.db")
-        XCTAssertFalse(
-            FileManager.default.fileExists(atPath: anonDB.path),
-            "Must NOT copy when multiple candidates exist — we refuse to guess")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: anonDB.path))
 
-        XCTAssertFalse(
-            defaults.bool(forKey: LegacyUserDirMigrator.completedFlagKey))
-        XCTAssertTrue(
-            defaults.bool(forKey: LegacyUserDirMigrator.multipleCandidatesFlagKey),
-            "Multiple-candidate skip flag must be set so we don't re-log every launch")
+        XCTAssertFalse(defaults.bool(forKey: LegacyUserDirMigrator.completedFlagKey))
+        XCTAssertTrue(defaults.bool(forKey: LegacyUserDirMigrator.multipleCandidatesFlagKey))
     }
 
-    /// Flag already completed → no-op even when conditions would otherwise match.
-    func testFlagAlreadyCompleted_NoOp() throws {
+    func testFlagAlreadyCompleted_NoOp() async throws {
         try makeUserDir("oldFirebaseUid", dbSize: 4096)
         defaults.set(true, forKey: LegacyUserDirMigrator.completedFlagKey)
 
-        LegacyUserDirMigrator.runIfNeeded(usersRoot: tempDir, defaults: defaults)
+        let outcome = await runMigration()
+        XCTAssertEqual(outcome, .noop)
 
         let anonDB = tempDir.appendingPathComponent("anonymous/omi.db")
-        XCTAssertFalse(
-            FileManager.default.fileExists(atPath: anonDB.path),
-            "Flag gate must short-circuit migration even when a candidate exists")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: anonDB.path))
     }
 
     // MARK: - Filter coverage
 
-    /// Backup dirs and zero-byte dbs must NOT count as candidates. Combined
-    /// with one real legacy dir, this still ends up as the single-candidate
-    /// happy path.
-    func testIgnoresBackupAndEmptyDBDirs() throws {
+    func testIgnoresBackupAndEmptyDBDirs() async throws {
         try makeUserDir("realUid", dbSize: 4096)
-        try makeUserDir("realUid.bak.123", dbSize: 4096)  // backup name -> skip
-        try makeUserDir("backup-2024", dbSize: 4096)  // contains "backup" -> skip
-        try makeUserDir("zeroByteUid", dbSize: 0)  // 0-byte db -> skip
-        try makeEmptyUserDir("noDbAtAll")  // missing db -> skip
+        try makeUserDir("realUid.bak", dbSize: 4096)
+        try makeUserDir("backup-2024", dbSize: 4096)
+        try makeUserDir("zeroByteUid", dbSize: 0)
+        try makeEmptyUserDir("noDbAtAll")
 
-        LegacyUserDirMigrator.runIfNeeded(usersRoot: tempDir, defaults: defaults)
+        let outcome = await runMigration()
+        XCTAssertEqual(outcome, .migrated(sourceName: "realUid"))
 
         let anonDB = tempDir.appendingPathComponent("anonymous/omi.db")
-        XCTAssertEqual(
-            dbSize(at: anonDB), 4096,
-            "Should have migrated the single real candidate, ignoring decoys")
-        XCTAssertTrue(
-            defaults.bool(forKey: LegacyUserDirMigrator.completedFlagKey))
+        XCTAssertEqual(dbSize(at: anonDB), 4096)
+        XCTAssertTrue(defaults.bool(forKey: LegacyUserDirMigrator.completedFlagKey))
     }
 
-    /// If `users/anonymous/` already exists empty (e.g. created earlier in
-    /// launch) it must be moved aside so copyItem can succeed.
-    func testEmptyAnonymousIsMovedAsideBeforeCopy() throws {
-        try makeEmptyUserDir("anonymous")  // exists, but no omi.db
+    func testEmptyAnonymousIsMovedAsideBeforeCopy() async throws {
+        try makeEmptyUserDir("anonymous")
         try makeUserDir("oldUid", dbSize: 4096)
 
-        LegacyUserDirMigrator.runIfNeeded(usersRoot: tempDir, defaults: defaults)
+        let outcome = await runMigration()
+        XCTAssertEqual(outcome, .migrated(sourceName: "oldUid"))
 
         let anonDB = tempDir.appendingPathComponent("anonymous/omi.db")
-        XCTAssertEqual(
-            dbSize(at: anonDB), 4096,
-            "anonymous/omi.db must exist post-migration")
-        XCTAssertTrue(
-            defaults.bool(forKey: LegacyUserDirMigrator.completedFlagKey))
+        XCTAssertEqual(dbSize(at: anonDB), 4096)
+        XCTAssertTrue(defaults.bool(forKey: LegacyUserDirMigrator.completedFlagKey))
 
-        // A backup of the empty dir should exist as anonymous.empty.bak.<ts>
         let entries =
             (try? FileManager.default.contentsOfDirectory(atPath: tempDir.path)) ?? []
         let backups = entries.filter { $0.hasPrefix("anonymous.empty.bak.") }
-        XCTAssertEqual(
-            backups.count, 1,
-            "Pre-existing empty anonymous/ should be renamed aside, found: \(entries)")
+        XCTAssertEqual(backups.count, 1, "found: \(entries)")
+    }
+
+    // MARK: - Round-2 fixes
+
+    /// `users/anonymous/omi.db` exists but is 0 bytes (matches actual prod
+    /// state when GRDB pre-creates the file before migrations run).
+    func testEmptyAnonymousDBFile_TriggersMigration() async throws {
+        try makeUserDir("anonymous", dbSize: 0)
+        try makeUserDir("oldUid", dbSize: 4096)
+
+        let outcome = await runMigration()
+        XCTAssertEqual(outcome, .migrated(sourceName: "oldUid"))
+
+        let anonDB = tempDir.appendingPathComponent("anonymous/omi.db")
+        XCTAssertEqual(dbSize(at: anonDB), 4096)
+    }
+
+    /// Inject a copy failure by chmod'ing the users root to read-only so the
+    /// staging-tmp copy throws. Verify rollback: completion flag stays unset,
+    /// source dir intact, no leftover tmp staging dirs.
+    func testCopyFailureLeavesFlagUnset() async throws {
+        let legacy = try makeUserDir("oldUid", dbSize: 4096)
+
+        // Chmod usersRoot to read-only so writes throw EACCES.
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o555], ofItemAtPath: tempDir.path)
+        defer {
+            // Restore so tearDown can rm -rf cleanly.
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: 0o755], ofItemAtPath: tempDir.path)
+        }
+
+        let outcome = await runMigration()
+        if case .failed = outcome {
+            // expected
+        } else {
+            XCTFail("Expected .failed outcome, got \(outcome)")
+        }
+
+        XCTAssertFalse(defaults.bool(forKey: LegacyUserDirMigrator.completedFlagKey))
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: legacy.appendingPathComponent("omi.db").path),
+            "Source legacy dir must remain intact after a failed migration")
+
+        // Tmp staging dir must have been cleaned up.
+        try? FileManager.default.setAttributes(
+            [.posixPermissions: 0o755], ofItemAtPath: tempDir.path)
+        let entries =
+            (try? FileManager.default.contentsOfDirectory(atPath: tempDir.path)) ?? []
+        let leftoverTmp = entries.filter { $0.hasPrefix(".anonymous.tmp.") }
+        XCTAssertEqual(leftoverTmp, [], "tmp dirs must be cleaned on failure")
+    }
+
+    /// Calling `runIfNeeded` twice on the same fixture: the second call must
+    /// short-circuit at the completion flag without re-enumerating.
+    func testIdempotentReRunAfterSuccess() async throws {
+        try makeUserDir("oldUid", dbSize: 4096)
+
+        let first = await runMigration()
+        XCTAssertEqual(first, .migrated(sourceName: "oldUid"))
+
+        // Sanity: flag is set.
+        XCTAssertTrue(defaults.bool(forKey: LegacyUserDirMigrator.completedFlagKey))
+
+        // Add a *second* candidate. If the migrator re-enumerated, it would
+        // now see two candidates (the one we just migrated and a new one) and
+        // either set the multi-candidate flag or pick one. A true no-op leaves
+        // both flags untouched and returns .noop.
+        try makeUserDir("anotherOldUid", dbSize: 4096)
+
+        let second = await runMigration()
+        XCTAssertEqual(second, .noop)
+        XCTAssertFalse(
+            defaults.bool(forKey: LegacyUserDirMigrator.multipleCandidatesFlagKey),
+            "Second call must not re-enumerate")
+    }
+
+    /// `multipleCandidatesFlagKey` set on a prior launch must short-circuit
+    /// the gate without re-enumerating.
+    func testMultipleCandidatesFlagSuppressesSecondCall() async throws {
+        try makeUserDir("uidA", dbSize: 4096)
+        try makeUserDir("uidB", dbSize: 4096)
+        defaults.set(true, forKey: LegacyUserDirMigrator.multipleCandidatesFlagKey)
+
+        let outcome = await runMigration()
+        if case .skippedMultipleCandidates(let names) = outcome {
+            XCTAssertEqual(names, [], "Should short-circuit without re-enumerating")
+        } else {
+            XCTFail("Expected skippedMultipleCandidates, got \(outcome)")
+        }
+
+        let anonDB = tempDir.appendingPathComponent("anonymous/omi.db")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: anonDB.path))
+    }
+
+    /// The migrator's own backup naming `anonymous.empty.bak.<ts>` must be
+    /// filtered out of candidates (anchored regex match).
+    func testDecoyFilter_anonymousEmptyBakTimestamp() async throws {
+        try makeUserDir("realUid", dbSize: 4096)
+        try makeUserDir("anonymous.empty.bak.1777000000", dbSize: 4096)
+
+        let outcome = await runMigration()
+        XCTAssertEqual(outcome, .migrated(sourceName: "realUid"))
+    }
+
+    /// A real legacy uid that contains the literal substring "backup" must
+    /// NOT be filtered (pins behavior of fix #6 anchored matching).
+    func testDecoyFilter_realUidContainingBackupText() async throws {
+        try makeUserDir("abc123backup456", dbSize: 4096)
+
+        let outcome = await runMigration()
+        XCTAssertEqual(outcome, .migrated(sourceName: "abc123backup456"))
+    }
+
+    /// Pre-existing non-empty `anonymous/` (no omi.db, but with other content)
+    /// is moved aside and its top-level contents are logged before the move.
+    func testNonEmptyNonDBContentLoggedBeforeMove() async throws {
+        let anonDir = try makeEmptyUserDir("anonymous")
+        let videosDir = anonDir.appendingPathComponent("Videos", isDirectory: true)
+        try FileManager.default.createDirectory(at: videosDir, withIntermediateDirectories: true)
+        try Data([1, 2, 3]).write(to: videosDir.appendingPathComponent("clip.bin"))
+        try makeUserDir("oldUid", dbSize: 4096)
+
+        let outcome = await runMigration()
+        XCTAssertEqual(outcome, .migrated(sourceName: "oldUid"))
+
+        // Backup dir must contain the pre-existing contents (forensics).
+        let entries =
+            (try? FileManager.default.contentsOfDirectory(atPath: tempDir.path)) ?? []
+        let backupName = entries.first { $0.hasPrefix("anonymous.empty.bak.") }
+        XCTAssertNotNil(backupName, "Pre-existing anonymous/ should be moved aside")
+        if let backupName {
+            let backupVideos = tempDir.appendingPathComponent(backupName)
+                .appendingPathComponent("Videos/clip.bin")
+            XCTAssertTrue(
+                FileManager.default.fileExists(atPath: backupVideos.path),
+                "Pre-existing contents must be preserved in backup")
+        }
+    }
+
+    /// An orphaned `.anonymous.tmp.*` from a previous interrupted run must be
+    /// cleaned up at launch.
+    func testInterruptedTempDirCleanedUp() async throws {
+        let orphan = tempDir.appendingPathComponent(".anonymous.tmp.999.999", isDirectory: true)
+        try FileManager.default.createDirectory(at: orphan, withIntermediateDirectories: true)
+        try Data("junk".utf8).write(to: orphan.appendingPathComponent("garbage"))
+
+        _ = await runMigration()
+
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: orphan.path),
+            "Orphaned tmp dir from prior run must be cleaned up")
+    }
+
+    // MARK: - Decoy filter unit coverage
+
+    func testIsBackupName_anchoredMatching() {
+        XCTAssertTrue(LegacyUserDirMigrator.isBackupName("foo.bak"))
+        XCTAssertTrue(LegacyUserDirMigrator.isBackupName("anonymous.empty.bak.1777000000"))
+        XCTAssertTrue(LegacyUserDirMigrator.isBackupName("backup-2024"))
+        XCTAssertTrue(LegacyUserDirMigrator.isBackupName("backupOldUid"))
+
+        XCTAssertFalse(LegacyUserDirMigrator.isBackupName("abc123backup456"))
+        XCTAssertFalse(LegacyUserDirMigrator.isBackupName("foo.bakery"))
+        XCTAssertFalse(LegacyUserDirMigrator.isBackupName("realUid"))
     }
 }


### PR DESCRIPTION
## Problem

Two recent commits stripped the auth flow and hardcoded the userId to the literal string `anonymous`:

- `daef675 merge: strip auth flow (anonymous local user)`
- `1a35f94 feat(auth): always launch as anonymous local user, bypass sign-in flow`

User data lives under `~/Library/Application Support/Omi/users/<userId>/`. Pre-strip, `<userId>` was a Firebase UID like `mpwtlyQCq9h4XWwpgVPRGOyNEgh1`. Post-strip it's `anonymous`. So an existing user upgrades, the new build looks at `users/anonymous/` (empty, freshly created), shows zero conversations, and the historical data sits orphaned in `users/<old-uid>/`.

## Fix

Add `LegacyUserDirMigrator` and call `runIfNeeded()` early in `OmiApp.applicationDidFinishLaunching`, **before** `signInAnonymously()` and before `RewindDatabase.currentUserId` is set. Filesystem-only — no SQL, no GRDB, no schema knowledge. GRDB still runs its own pending migrations on first DB open.

**Behavior:**

1. Short-circuit if `legacyAnonymousMigrationCompleted` UserDefaults flag is already set.
2. Empty-check `users/anonymous/omi.db` via filesystem (missing dir, missing file, or 0 bytes).
3. Enumerate sibling dirs; skip `anonymous`, hidden, `*.bak*`, `*backup*`, missing `omi.db`, or 0-byte `omi.db`.
4. Zero candidates -> no-op. One candidate -> migrate. More than one -> refuse to guess, set `legacyMigrationSkipped_multipleCandidates` so we don't re-log every launch.
5. Migration uses `FileManager.copyItem` (NOT move) so the original stays intact as a safety net. If `users/anonymous/` already exists empty, rename to `anonymous.empty.bak.<ts>/` first.
6. On `copyItem` failure: log a manually-recoverable diagnostic and **don't** set the completion flag — better the user sees no conversations than a half-copied DB.

## Edge cases handled

- Multiple legacy candidate dirs (we refuse to guess)
- Empty `users/anonymous/` already exists from a prior launch (moved aside)
- Backup, zero-byte, and `omi.db`-less dirs filtered out of candidate set
- Copy failures leave the gate open for retry on next launch
- Flag completed but legacy dir still present (e.g., re-installed after wipe) -> no-op

## Test coverage

`Desktop/Tests/LegacyUserDirMigratorTests.swift` (7 tests, all green):

- `testNoCandidates_NoOp`
- `testOneCandidate_Migrates` (verifies recursive subdir copy + original retained)
- `testAnonymousAlreadyPopulated_NoOp`
- `testMultipleCandidates_RefusesAndFlags`
- `testFlagAlreadyCompleted_NoOp`
- `testIgnoresBackupAndEmptyDBDirs`
- `testEmptyAnonymousIsMovedAsideBeforeCopy`

The migrator accepts `usersRoot: URL` and `defaults: UserDefaults` parameters with production defaults so tests inject a temp dir + isolated UserDefaults suite.

## Manual test plan

- [ ] On a machine with a pre-strip Firebase-UID user dir (e.g. `users/mpwtlyQCq9h4XWwpgVPRGOyNEgh1/`) and an empty/missing `users/anonymous/`, launch the new build and confirm conversations appear from the migrated DB. Original dir should remain on disk.

## CI run locally

- `xcrun swift build -c debug --package-path Desktop` -> Build complete
- `xcrun swift test --package-path Desktop` -> 398 tests pass
- `cargo test --locked -p infinite-recall-api` -> pass
- `cargo test --locked -p infinite-recall-api --features activity_test_wiring` -> pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * One-time legacy user-data migration at app launch with a UI gate and retry/dismiss alert.

* **Bug Fixes**
  * Atomic, idempotent migration with safeguards to avoid data loss (handles empty DBs, multiple candidates, backups, and cleanup of interrupted attempts).
  * Launch tasks now wait for migration to complete before proceeding.

* **Tests**
  * New test suite covering migration outcomes, flags, backups, error cases, and idempotency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->