### PR TITLE
fix(activity): align scheduler/menu-bar/Activity counts; clarify AC-wait copy

### DIFF
--- a/Backend-Rust/api/src/activity/contract.md
+++ b/Backend-Rust/api/src/activity/contract.md
@@ -142,7 +142,7 @@ and a stringly-typed `waiting_for`.
 
 | Field | Allowed values |
 |---|---|
-| `KindRow.kind` / `WorkKind` | `transcribe`, `ocr`, `summarize`, `extract_memory`, `extract_action_items` |
+| `KindRow.kind` / `WorkKind` | `transcribe`, `ocr`, `summarize`, `extract_memory`, `extract_action_items`, `extract_kg` |
 | `CaptureRow.kind` / `CaptureKind` | `audio`, `screen` |
 | `PauseRequest.target` / `ResumeRequest.target` / `PauseTargetId` | `kind`, `capture` (with typed `id` payload — see below) |
 | `ResourceSample.thermal_state` / `ThermalState` | `nominal`, `fair`, `serious`, `critical` |

--- a/Backend-Rust/api/src/activity/types.rs
+++ b/Backend-Rust/api/src/activity/types.rs
@@ -18,6 +18,13 @@ pub enum WorkKind {
     Summarize,
     ExtractMemory,
     ExtractActionItems,
+    /// Brain-map / knowledge-graph extraction. Issue #105: previously
+    /// scheduler-only (Swift `PendingWork.Kind.extractKG`), so its queue
+    /// depth was counted by the menu-bar badge but absent from the
+    /// Activity snapshot's per-kind table — making the two surfaces
+    /// disagree. Promoted to a wire kind so both surfaces aggregate the
+    /// same set of `pending_work` rows.
+    ExtractKg,
 }
 
 /// Live capture surfaces (separate from deferred work).
@@ -67,6 +74,7 @@ impl WorkKind {
             WorkKind::Summarize => "summarize",
             WorkKind::ExtractMemory => "extract_memory",
             WorkKind::ExtractActionItems => "extract_action_items",
+            WorkKind::ExtractKg => "extract_kg",
         }
     }
 }
@@ -345,6 +353,7 @@ mod tests {
             WorkKind::Summarize,
             WorkKind::ExtractMemory,
             WorkKind::ExtractActionItems,
+            WorkKind::ExtractKg,
         ] {
             assert_eq!(
                 serde_json::to_value(k).unwrap(),

--- a/Backend-Rust/api/src/routes/activity.rs
+++ b/Backend-Rust/api/src/routes/activity.rs
@@ -32,12 +32,18 @@ use crate::state::{AppState, PauseChange};
 /// All `WorkKind`s, in display order. Used to assemble the `kinds` array
 /// in the snapshot — every kind gets a row even if there's no in-flight
 /// item or pause, so the UI can render a stable table.
-const ALL_KINDS: [WorkKind; 5] = [
+const ALL_KINDS: [WorkKind; 6] = [
     WorkKind::Transcribe,
     WorkKind::Ocr,
     WorkKind::Summarize,
     WorkKind::ExtractMemory,
     WorkKind::ExtractActionItems,
+    // Issue #105: keep the Activity snapshot's queue accounting in sync
+    // with `PendingWorkStorage.pendingCount()` (which the menu-bar badge
+    // reads). Pre-#105, `extractKG` rows were counted by the badge but
+    // absent here, producing the "8 items waiting (battery)" / "0 queued"
+    // disagreement reported in the bug.
+    WorkKind::ExtractKg,
 ];
 
 const ALL_CAPTURES: [CaptureKind; 2] = [CaptureKind::Audio, CaptureKind::Screen];
@@ -139,6 +145,9 @@ fn workkind_swift_raw_value(k: WorkKind) -> &'static str {
         WorkKind::Summarize => "summarize",
         WorkKind::ExtractMemory => "extractMemory",
         WorkKind::ExtractActionItems => "extractActionItems",
+        // Swift's `PendingWork.Kind.extractKG` rawValue is camelCase
+        // ("extractKG"), matching the other camelCase entries above.
+        WorkKind::ExtractKg => "extractKG",
     }
 }
 

--- a/Backend-Rust/api/tests/activity_endpoints.rs
+++ b/Backend-Rust/api/tests/activity_endpoints.rs
@@ -806,6 +806,103 @@ async fn queue_depth_snapshot_includes_extract_kg() {
     assert_eq!(extract_kg["failed"], json!(1));
 }
 
+/// Issue #105 invariant: the Activity snapshot's per-kind `queued` sum must
+/// match `PendingWorkStorage.pendingCount()` (the menu-bar badge). The bug
+/// was a wire-shape drift — `extractKG` rows were counted by the
+/// `pendingCount()` query (`status='queued' AND workType=*`) but the
+/// snapshot's `ALL_KINDS` array dropped them, so the two surfaces
+/// disagreed (8 vs 0). This test seeds at least one `queued` row for every
+/// kind including `extractKG`, hits `/snapshot`, and asserts
+/// `sum(kinds[*].queued) == pendingCount()`. Future drift in
+/// `workkind_swift_raw_value` (or in `ALL_KINDS`) would regress here.
+#[tokio::test]
+async fn activity_snapshot_extract_kg_count_matches_pending_work_total() {
+    // One `queued` row per Swift `PendingWork.Kind.rawValue`. Counts vary
+    // by kind so an off-by-one in the assembly path would be detectable.
+    // Plus a `claimed` row (excluded from `pendingCount`) and a `failed`
+    // row (excluded from the queued sum but included in the kind's
+    // `failed` field) to confirm the assertion targets `queued` only.
+    let seed: &[(&str, &str)] = &[
+        ("queued", "transcribe"),
+        ("queued", "transcribe"),
+        ("queued", "ocr"),
+        ("queued", "summarize"),
+        ("queued", "summarize"),
+        ("queued", "summarize"),
+        ("queued", "extractMemory"),
+        ("queued", "extractActionItems"),
+        ("queued", "extractActionItems"),
+        ("queued", "extractKG"),
+        ("queued", "extractKG"),
+        ("queued", "extractKG"),
+        ("queued", "extractKG"),
+        // Non-queued rows must NOT count toward the sum.
+        ("claimed", "transcribe"),
+        ("failed", "ocr"),
+        ("dead", "summarize"),
+    ];
+    let state = make_state(
+        Arc::new(MemPauseStore::new()),
+        Arc::new(MemInflight::new()),
+        Arc::new(FakeSampler),
+        Arc::new(FakeGate::allow()),
+    );
+    seed_pending_work(&state.pool, seed).await;
+
+    // Mirror the `PendingWorkStorage.pendingCount()` query Swift uses for
+    // the menu-bar badge: `status = 'queued'` across every workType.
+    // Computed from the same seed list so any kind we add tomorrow auto-
+    // appears on both sides.
+    let pending_count: u32 = seed
+        .iter()
+        .filter(|(status, _)| *status == "queued")
+        .count()
+        .try_into()
+        .unwrap();
+    assert_eq!(
+        pending_count, 13,
+        "sanity: seed must produce 13 queued rows across all six kinds (incl. extractKG)"
+    );
+
+    let app = routes::router(state);
+    let (k, v) = auth_header();
+    let snap_req = Request::builder()
+        .method(Method::GET)
+        .uri("/v1/activity/snapshot")
+        .header(k, v)
+        .body(Body::empty())
+        .unwrap();
+    let snap = json_body(app.oneshot(snap_req).await.unwrap()).await;
+    let kinds = snap["kinds"].as_array().expect("kinds is an array");
+
+    let snapshot_queued_sum: u32 = kinds
+        .iter()
+        .map(|row| {
+            row["queued"]
+                .as_u64()
+                .expect("queued is a non-negative integer") as u32
+        })
+        .sum();
+
+    assert_eq!(
+        snapshot_queued_sum, pending_count,
+        "Activity snapshot's per-kind queued sum ({snapshot_queued_sum}) must equal \
+         pendingCount() ({pending_count}) — the menu-bar badge and Activity table \
+         disagree if this drifts (issue #105)."
+    );
+
+    // Defense-in-depth: the extract_kg row specifically must contribute its
+    // four queued rows to the sum. A regression in `workkind_swift_raw_value`
+    // (e.g. mapping `ExtractKg` to `"extract_kg"` instead of `"extractKG"`)
+    // would silently drop these from the snapshot but keep them in
+    // pendingCount, surfacing as a sum mismatch above.
+    let extract_kg = kinds
+        .iter()
+        .find(|r| r["kind"] == "extract_kg")
+        .expect("snapshot must include an `extract_kg` row");
+    assert_eq!(extract_kg["queued"], json!(4));
+}
+
 /// Fresh installs may not have run the Swift `pending_work` migration yet.
 /// Snapshot should still be 200 with every queue/failure count at zero.
 #[tokio::test]

--- a/Backend-Rust/api/tests/activity_endpoints.rs
+++ b/Backend-Rust/api/tests/activity_endpoints.rs
@@ -759,6 +759,51 @@ async fn queue_depth_snapshot_reads_pending_work_not_loopback_cache() {
     assert_eq!(row_for("extract_memory")["failed"], json!(1));
     assert_eq!(row_for("extract_action_items")["queued"], json!(0));
     assert_eq!(row_for("extract_action_items")["failed"], json!(2));
+    // Issue #105: extractKG must be present in the snapshot's `kinds` so the
+    // Activity view's per-kind sum matches `BatteryAwareScheduler.pendingWorkCount`
+    // (which the menu-bar badge reads). Default is zero/zero when no rows exist.
+    assert_eq!(row_for("extract_kg")["queued"], json!(0));
+    assert_eq!(row_for("extract_kg")["failed"], json!(0));
+}
+
+/// Issue #105 regression: queued `extractKG` rows must surface in the
+/// Activity snapshot. Pre-#105 this kind was scheduler-internal only, so
+/// the menu-bar badge counted it but the Activity per-kind table didn't,
+/// producing the "8 items waiting (battery)" / "0 queued" disagreement.
+#[tokio::test]
+async fn queue_depth_snapshot_includes_extract_kg() {
+    let state = make_state(
+        Arc::new(MemPauseStore::new()),
+        Arc::new(MemInflight::new()),
+        Arc::new(FakeSampler),
+        Arc::new(FakeGate::allow()),
+    );
+    seed_pending_work(
+        &state.pool,
+        &[
+            ("queued", "extractKG"),
+            ("queued", "extractKG"),
+            ("queued", "extractKG"),
+            ("failed", "extractKG"),
+        ],
+    )
+    .await;
+    let app = routes::router(state);
+    let (k, v) = auth_header();
+    let snap_req = Request::builder()
+        .method(Method::GET)
+        .uri("/v1/activity/snapshot")
+        .header(k, v)
+        .body(Body::empty())
+        .unwrap();
+    let snap = json_body(app.oneshot(snap_req).await.unwrap()).await;
+    let kinds = snap["kinds"].as_array().expect("kinds is an array");
+    let extract_kg = kinds
+        .iter()
+        .find(|r| r["kind"] == "extract_kg")
+        .expect("snapshot must include an `extract_kg` row (issue #105)");
+    assert_eq!(extract_kg["queued"], json!(3));
+    assert_eq!(extract_kg["failed"], json!(1));
 }
 
 /// Fresh installs may not have run the Swift `pending_work` migration yet.
@@ -830,6 +875,7 @@ async fn enum_round_trip_via_wire() {
         (t::WorkKind::Summarize, "summarize"),
         (t::WorkKind::ExtractMemory, "extract_memory"),
         (t::WorkKind::ExtractActionItems, "extract_action_items"),
+        (t::WorkKind::ExtractKg, "extract_kg"),
     ] {
         let s = serde_json::to_string(&kind).unwrap();
         assert_eq!(s, format!("\"{wire}\""));
@@ -870,6 +916,7 @@ async fn enum_round_trip_via_wire() {
         t::WorkKind::Summarize,
         t::WorkKind::ExtractMemory,
         t::WorkKind::ExtractActionItems,
+        t::WorkKind::ExtractKg,
     ] {
         let pt = t::PauseTargetId::Kind(kind);
         let s = serde_json::to_string(&pt).unwrap();
@@ -901,6 +948,7 @@ async fn pause_kind_round_trip_for_every_variant() {
         "summarize",
         "extract_memory",
         "extract_action_items",
+        "extract_kg",
     ] {
         let body = json!({"target":"kind","id":kind_str,"minutes":1});
         let req = Request::builder()

--- a/Desktop/Sources/Activity/ActivityModels.swift
+++ b/Desktop/Sources/Activity/ActivityModels.swift
@@ -18,6 +18,13 @@ public enum WorkKind: String, Codable, CaseIterable, Hashable {
     case summarize
     case extractMemory = "extract_memory"
     case extractActionItems = "extract_action_items"
+    /// Issue #105: brain-map / knowledge-graph extraction. Mirrored on the
+    /// wire so the Activity snapshot's per-kind table accounts for the same
+    /// `pending_work` rows that `BatteryAwareScheduler.pendingWorkCount`
+    /// (which feeds the menu-bar badge) already counts. Pre-#105 this
+    /// kind was scheduler-internal only, producing the count mismatch
+    /// reported in the bug.
+    case extractKG = "extract_kg"
 }
 
 public enum CaptureKind: String, Codable, CaseIterable, Hashable {

--- a/Desktop/Sources/Activity/ActivityMonitorService.swift
+++ b/Desktop/Sources/Activity/ActivityMonitorService.swift
@@ -292,6 +292,7 @@ public final class ActivityMonitorService: ObservableObject {
         case .summarize: return PendingWork.Kind.summarize.rawValue
         case .extractMemory: return PendingWork.Kind.extractMemory.rawValue
         case .extractActionItems: return PendingWork.Kind.extractActionItems.rawValue
+        case .extractKG: return PendingWork.Kind.extractKG.rawValue
         }
     }
 

--- a/Desktop/Sources/Activity/ActivityPage.swift
+++ b/Desktop/Sources/Activity/ActivityPage.swift
@@ -82,18 +82,31 @@ func activityCorrectedGate(
         return .blocked(reason: .onBattery, since: snapshotGate.since, waitingFor: .acPower)
     }
     // Issue #105: discard a stale `Blocked(.onBattery)` from the daemon
-    // snapshot when the live `ResourceSample` says we're actually on AC
-    // and not in Low Power Mode. Without this, the user can see
-    // "Waiting for AC power" while plugged in — the snapshot poll runs at
-    // 1 Hz and the gate-state reporter de-dupes posts, so a brief
-    // disagreement at the AC/battery transition window can otherwise stick
-    // until the next gate-state diff is observed.
+    // snapshot when the same snapshot's resource sample says we're actually
+    // on AC and not in Low Power Mode. Both `snapshotGate` and `resources`
+    // ride the same 1Hz Rust poll, but the gate-state reporter de-dupes
+    // posts — so the cached gate can lag the resource sample at the
+    // AC/battery transition window. Without this, the user sees
+    // "Waiting for AC power" while plugged in until the next gate-state
+    // diff is observed.
     if case .blocked(.onBattery, _, _) = snapshotGate,
        !resources.onBattery, !resources.lowPower {
+        activityCorrectedGateLog.debug(
+            "Downgrading stale .onBattery gate (since=\(snapshotGate.since.timeIntervalSince1970, privacy: .public)) to .allowed — resources report on-AC, not low-power."
+        )
         return .allowed(since: snapshotGate.since)
     }
     return snapshotGate
 }
+
+/// Subsystem-wide logger for the Activity-page gate-correction predicate.
+/// Pulled out so a user reporting "Activity says allowed but nothing runs"
+/// (or vice-versa) leaves a breadcrumb when the Issue #105 stale-gate
+/// downgrade fires.
+private let activityCorrectedGateLog = Logger(
+    subsystem: "me.omi.desktop",
+    category: "ActivityCorrectedGate"
+)
 
 func activityShouldShowRunNowButton(
     snapshotGate: GateState?,
@@ -420,14 +433,16 @@ struct ActivityPage: View {
                     color: OmiColors.warning
                 )
             }
-            // Issue #105: prefix the wait condition so the subtitle reads as
-            // "Resumes when on AC power" rather than the bare "AC power" the
-            // user reasonably mistook for a current-state assertion. Mirrors
-            // the `.deviceActive` copy convention right above.
+            // Issue #105: read as "Resumes when on AC power" rather than the
+            // bare "AC power" the user reasonably mistook for a current-state
+            // assertion. Hardcoded — for `.onBattery`, `waitingFor` is always
+            // `.acPower` (see `BatteryAwareScheduler`), but `WaitCondition`
+            // also includes `.manual` which would read "Resumes when on manual
+            // resume — or run now." Hardcoding avoids the awkward case.
             return BannerInfo(
                 icon: "battery.25",
                 title: "Waiting for AC power — \(queued) item\(queued == 1 ? "" : "s") queued",
-                detail: "Resumes when on \(detail) — or run now.",
+                detail: "Resumes when on AC power — or run now.",
                 color: OmiColors.warning
             )
         case .thermal:

--- a/Desktop/Sources/Activity/ActivityPage.swift
+++ b/Desktop/Sources/Activity/ActivityPage.swift
@@ -81,6 +81,17 @@ func activityCorrectedGate(
     if activityPowerBlock(resources: resources, queued: queued) != nil {
         return .blocked(reason: .onBattery, since: snapshotGate.since, waitingFor: .acPower)
     }
+    // Issue #105: discard a stale `Blocked(.onBattery)` from the daemon
+    // snapshot when the live `ResourceSample` says we're actually on AC
+    // and not in Low Power Mode. Without this, the user can see
+    // "Waiting for AC power" while plugged in — the snapshot poll runs at
+    // 1 Hz and the gate-state reporter de-dupes posts, so a brief
+    // disagreement at the AC/battery transition window can otherwise stick
+    // until the next gate-state diff is observed.
+    if case .blocked(.onBattery, _, _) = snapshotGate,
+       !resources.onBattery, !resources.lowPower {
+        return .allowed(since: snapshotGate.since)
+    }
     return snapshotGate
 }
 
@@ -409,10 +420,14 @@ struct ActivityPage: View {
                     color: OmiColors.warning
                 )
             }
+            // Issue #105: prefix the wait condition so the subtitle reads as
+            // "Resumes when on AC power" rather than the bare "AC power" the
+            // user reasonably mistook for a current-state assertion. Mirrors
+            // the `.deviceActive` copy convention right above.
             return BannerInfo(
                 icon: "battery.25",
                 title: "Waiting for AC power — \(queued) item\(queued == 1 ? "" : "s") queued",
-                detail: detail,
+                detail: "Resumes when on \(detail) — or run now.",
                 color: OmiColors.warning
             )
         case .thermal:
@@ -918,6 +933,7 @@ struct ActivityPage: View {
         case .summarize: return "text.append"
         case .extractMemory: return "brain"
         case .extractActionItems: return "checklist"
+        case .extractKG: return "point.3.connected.trianglepath.dotted"
         }
     }
 
@@ -928,6 +944,7 @@ struct ActivityPage: View {
         case .summarize: return "Summarize"
         case .extractMemory: return "Extract memories"
         case .extractActionItems: return "Find action items"
+        case .extractKG: return "Build brain map"
         }
     }
 

--- a/Desktop/Sources/Power/BatteryAwareScheduler.swift
+++ b/Desktop/Sources/Power/BatteryAwareScheduler.swift
@@ -612,7 +612,9 @@ public final class BatteryAwareScheduler: ObservableObject {
     case .summarize: return .summarize
     case .extractMemory: return .extractMemory
     case .extractActionItems: return .extractActionItems
-    case .extractKG: return nil  // not represented in the daemon's WorkKind wire enum
+    // Issue #105: extractKG is now a first-class wire kind so the Activity
+    // snapshot's per-kind table sees the same rows the menu-bar badge does.
+    case .extractKG: return .extractKG
     }
   }
 

--- a/Desktop/Tests/ActivityPagePowerGateTests.swift
+++ b/Desktop/Tests/ActivityPagePowerGateTests.swift
@@ -211,5 +211,99 @@ final class ActivityPagePowerGateTests: XCTestCase {
             corrected.isAllowed,
             "Stale snapshot .onBattery must be downgraded to .allowed when resources report on-AC and not low-power."
         )
+        // The downgrade preserves the original `since` so the UI's
+        // "blocked-for" timer doesn't reset across the transition.
+        XCTAssertEqual(
+            corrected.since,
+            staleSnapshotGate.since,
+            "Downgrade must preserve the snapshot's `since` so the elapsed-state timer is continuous."
+        )
+    }
+
+    /// Issue #105 negative case: snapshot gate is `.onBattery` AND
+    /// resources confirm Low Power Mode is on. The downgrade predicate
+    /// must NOT fire — the user still needs to know LPM is the blocker.
+    func test_correctedGateDoesNotDowngradeWhenLowPowerMode() {
+        let res = resources(onBattery: false, lowPower: true)
+        let snapshotGate = GateState.blocked(
+            reason: .onBattery,
+            since: now,
+            waitingFor: .acPower
+        )
+
+        let corrected = activityCorrectedGate(
+            snapshotGate: snapshotGate,
+            resources: res,
+            queued: 4,
+            thermalState: .nominal,
+            isRunOnceActive: false,
+            runOnceStartedAt: nil,
+            now: now
+        )
+
+        XCTAssertEqual(
+            corrected.blockReason,
+            .onBattery,
+            "Low Power Mode must keep the .onBattery block; the downgrade only fires for AC + non-LPM."
+        )
+    }
+
+    /// Issue #105 negative case: snapshot gate is `.onBattery` and resources
+    /// agree we're genuinely on battery. The downgrade must NOT fire — the
+    /// snapshot is correct, not stale.
+    func test_correctedGateDoesNotDowngradeWhenGenuinelyOnBattery() {
+        let res = resources(onBattery: true, lowPower: false)
+        let snapshotGate = GateState.blocked(
+            reason: .onBattery,
+            since: now,
+            waitingFor: .acPower
+        )
+
+        let corrected = activityCorrectedGate(
+            snapshotGate: snapshotGate,
+            resources: res,
+            queued: 4,
+            thermalState: .nominal,
+            isRunOnceActive: false,
+            runOnceStartedAt: nil,
+            now: now
+        )
+
+        XCTAssertEqual(
+            corrected.blockReason,
+            .onBattery,
+            "Genuine on-battery state must keep the .onBattery block; the downgrade only fires when resources contradict the snapshot."
+        )
+    }
+
+    /// Issue #105 guard: the downgrade `if case` matches `.onBattery`
+    /// exclusively. Other block reasons (e.g. `.thermal`) must pass through
+    /// unchanged even when resources report on-AC and not low-power.
+    /// Guards against accidentally widening the predicate later.
+    func test_correctedGateLeavesNonOnBatteryBlocksAlone() {
+        let res = resources(onBattery: false, lowPower: false)
+        let snapshotGate = GateState.blocked(
+            reason: .thermal,
+            since: now,
+            waitingFor: .thermalCooldown
+        )
+
+        let corrected = activityCorrectedGate(
+            snapshotGate: snapshotGate,
+            resources: res,
+            queued: 4,
+            // Thermal-state arg is `.nominal` so the early-return thermal
+            // override doesn't fire — we want to exercise the late branches.
+            thermalState: .nominal,
+            isRunOnceActive: false,
+            runOnceStartedAt: nil,
+            now: now
+        )
+
+        XCTAssertEqual(
+            corrected.blockReason,
+            .thermal,
+            "Non-onBattery snapshot blocks must pass through unchanged regardless of resources."
+        )
     }
 }

--- a/Desktop/Tests/ActivityPagePowerGateTests.swift
+++ b/Desktop/Tests/ActivityPagePowerGateTests.swift
@@ -183,4 +183,33 @@ final class ActivityPagePowerGateTests: XCTestCase {
             isRunOnceActive: false
         ), "Run now must hide for .thermal via disablesRunNowOverride alone, independent of the isThermalBlocked flag.")
     }
+
+    /// Issue #105: A snapshot gate of `.blocked(.onBattery, …)` can be stale
+    /// (e.g. cached from before the user plugged in). When `resources` reports
+    /// the device is on AC and not in low-power, the corrected gate must
+    /// downgrade to `.allowed` so the Activity banner doesn't read
+    /// "Waiting for AC power" while the user is already on AC.
+    func test_correctedGateDowngradesStaleOnBatteryWhenResourcesSayOnAC() {
+        let res = resources(onBattery: false, lowPower: false)
+        let staleSnapshotGate = GateState.blocked(
+            reason: .onBattery,
+            since: now,
+            waitingFor: .acPower
+        )
+
+        let corrected = activityCorrectedGate(
+            snapshotGate: staleSnapshotGate,
+            resources: res,
+            queued: 5,
+            thermalState: .nominal,
+            isRunOnceActive: false,
+            runOnceStartedAt: nil,
+            now: now
+        )
+
+        XCTAssertTrue(
+            corrected.isAllowed,
+            "Stale snapshot .onBattery must be downgraded to .allowed when resources report on-AC and not low-power."
+        )
+    }
 }


### PR DESCRIPTION
Closes #105

## Summary
- Promotes `extract_kg` to a first-class `WorkKind` on the Rust+Swift wire so the Activity snapshot per-kind counts match `PendingWorkStorage.pendingCount()` (the menu-bar source). Pre-fix, menu-bar counted KG rows but the snapshot's `ALL_KINDS` array dropped them — root cause of "8 items waiting" vs "0 items queued".
- Reworks the gate-banner subtitle from a bare `"AC power"` (which read as an asserted state) to `"Resumes when on AC power — or run now."`, mirroring the `.deviceActive` case copy. Hardcoded to avoid the awkward `.manual` `WaitCondition` rendering.
- Adds a stale-gate downgrade in `activityCorrectedGate`: when the daemon snapshot still reports `.blocked(.onBattery)` but the snapshot's resource sample shows we're on AC and not in Low Power Mode, the corrected gate is downgraded to `.allowed`. Eliminates the "Waiting for AC power" banner that lingered through the AC/battery transition because the 1Hz snapshot poll and the de-duped gate-state reporter could disagree briefly. Logs a debug breadcrumb when it fires.

## Review-feedback follow-ups (this PR)
- Three negative tests for `activityCorrectedGate` cover LPM, genuine on-battery, and non-`.onBattery` blocks; positive test strengthened to assert `since` preservation.
- Rust integration test `activity_snapshot_extract_kg_count_matches_pending_work_total` enforces the real #105 invariant: `sum(snapshot.kinds[*].queued) == pendingCount()` across all six kinds including `extractKG`. Catches future drift in `workkind_swift_raw_value`.
- Banner copy hardcoded; `activityCorrectedGate` comment reworded; debug log added.

## Known follow-up (out-of-scope)
- #110 — `WorkKind` decode lacks forward-compat fallback for unknown wire kinds. Raised by silent-failure-hunter; tracked separately to keep #109 focused on #105.

## Test plan
- [x] `xcrun swift build -c debug --package-path Desktop` — green
- [x] `xcrun swift test --package-path Desktop` — 411/411 pass
- [x] `cargo test --locked -p infinite-recall-api` — 73/73 + 4/4 pass
- [x] `cargo test --locked -p infinite-recall-api --features activity_test_wiring` — 23/23 pass (incl. new `activity_snapshot_extract_kg_count_matches_pending_work_total`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new "Build brain map" work kind in activity monitoring with proper queue-depth tracking and UI/daemon coverage.

* **Bug Fixes**
  * Activity status UI no longer remains stuck on "Waiting for AC power" when the device is on AC; resume messaging clarified.

* **Tests**
  * End-to-end and unit tests added to validate snapshot counts, queue/reporting behavior, and power-gate corrections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->