### PR TITLE
Implement Descript-style speaker identification

### DIFF
--- a/Desktop/Sources/AppState.swift
+++ b/Desktop/Sources/AppState.swift
@@ -1343,6 +1343,7 @@ class AppState: ObservableObject {
       liveSpeakerPersonMap = [:]
       LiveTranscriptMonitor.shared.clear()
       recordingStartTime = Date()
+      let audioCaptureStartedAt = recordingStartTime ?? Date()
       AudioLevelMonitor.shared.reset()
       RecordingTimer.shared.start()
 
@@ -1356,13 +1357,19 @@ class AppState: ObservableObject {
           self?.handleDiarizationTurn(turn)
         }
       }
-
       log(
         "Transcription: Using source: \(effectiveSource.rawValue), device: \(recordingInputDeviceName ?? "Unknown")"
       )
 
-      // Create crash-safe DB session for persistence
+      // Create crash-safe DB session for persistence. The audio persistence start
+      // is sequenced before session attachment so a delayed start(nil) cannot
+      // overwrite a real session id.
       Task {
+        await AudioPersistenceService.shared.start(
+          source: "mixed",
+          transcriptionSessionId: nil,
+          captureStartedAt: audioCaptureStartedAt
+        )
         do {
           let sessionId = try await TranscriptionStorage.shared.startSession(
             source: currentConversationSource.rawValue,
@@ -1380,6 +1387,9 @@ class AppState: ObservableObject {
               sessionId,
               startedAt: self.recordingStartTime
             )
+            Task {
+              await AudioPersistenceService.shared.setTranscriptionSessionId(sessionId)
+            }
           }
           log("Transcription: Created DB session \(sessionId)")
         } catch {
@@ -1449,6 +1459,9 @@ class AppState: ObservableObject {
     audioMixer?.start { [weak self] monoMixed in
       self?.transcriptionService?.sendAudio(monoMixed)
       SpeakerDiarizationService.shared.appendAudio(monoMixed)
+      Task {
+        await AudioPersistenceService.shared.append(monoMixed)
+      }
     }
 
     do {
@@ -1713,6 +1726,7 @@ class AppState: ObservableObject {
     // (backend will process it; memory_created event may arrive on the new session's WebSocket)
     if let sessionId = currentSessionId {
       do {
+        await AudioPersistenceService.shared.flush()
         let segmentCount = try await TranscriptionStorage.shared.getSegmentCount(sessionId: sessionId)
         let chunkCount = try await TranscriptionStorage.shared.getAudioChunkCount(sessionId: sessionId)
         let elapsed: Double = recordingStartTime.map { Date().timeIntervalSince($0) } ?? 0
@@ -1744,6 +1758,7 @@ class AppState: ObservableObject {
     // must not be persisted against the finished session. They'll be buffered in memory until
     // the new session ID is set in the Task below.
     currentSessionId = nil
+    await AudioPersistenceService.shared.setTranscriptionSessionId(nil)
 
     // Clear segments for the next conversation but keep recording active
     speakerSegments = []
@@ -1826,6 +1841,9 @@ class AppState: ObservableObject {
               self?.handleDiarizationTurn(turn)
             }
           }
+          Task {
+            await AudioPersistenceService.shared.setTranscriptionSessionId(sessionId)
+          }
         }
         log("Transcription: Created new DB session \(sessionId) for next conversation")
       } catch {
@@ -1871,6 +1889,9 @@ class AppState: ObservableObject {
     // Stop audio mixer
     audioMixer?.stop()
     audioMixer = nil
+    Task {
+      await AudioPersistenceService.shared.stop()
+    }
 
     // Infinite Recall fork: stop on-device diarization (flushes any in-flight turn).
     SpeakerDiarizationService.shared.stop()
@@ -1903,6 +1924,7 @@ class AppState: ObservableObject {
       }()
       Task {
         do {
+          await AudioPersistenceService.shared.stop()
           let segmentCount = try await TranscriptionStorage.shared.getSegmentCount(sessionId: sessionId)
           let chunkCount = try await TranscriptionStorage.shared.getAudioChunkCount(sessionId: sessionId)
           if segmentCount == 0 && chunkCount == 0 && elapsedSeconds < 5 {
@@ -2353,6 +2375,14 @@ class AppState: ObservableObject {
     let backendIds = split.backendIds
     let fallbackOrders = split.fallbackOrders
 
+    guard let sessionId = await TranscriptionStorage.shared.sessionIdForBackendId(conversationId) else {
+      logError(
+        "People: Failed to resolve transcription session for conversation \(conversationId)",
+        error: NSError(domain: "PeopleStore", code: -2)
+      )
+      return false
+    }
+
     // Update in-memory conversations list so the prop is fresh on next open.
     if let idx = conversations.firstIndex(where: { $0.id == conversationId }) {
       if !backendIds.isEmpty {
@@ -2412,15 +2442,23 @@ class AppState: ObservableObject {
       )
     } catch {
       logError("People: Failed to update local segment cache", error: error)
+      return false
     }
-    if let sessionId = await TranscriptionStorage.shared.sessionIdForBackendId(conversationId) {
-      _ = await PeopleStore.shared.assignSegments(
-        sessionId: sessionId,
-        segmentIds: segmentIds,
-        personId: personId,
-        isUser: isUser
+
+    let assigned = await PeopleStore.shared.assignSegments(
+      sessionId: sessionId,
+      segmentIds: segmentIds,
+      personId: personId,
+      isUser: isUser
+    )
+    guard assigned else {
+      logError(
+        "People: Failed to assign segments/backfill embeddings",
+        error: NSError(domain: "PeopleStore", code: -3)
       )
+      return false
     }
+
     log("People: Assigned \(segmentIds.count) segments in conversation \(conversationId)")
     return true
   }
@@ -2600,12 +2638,19 @@ class AppState: ObservableObject {
       // Refresh conversations list
       Task {
         await loadConversations()
+        if memoryId != "?", !memoryId.isEmpty {
+          NotificationCenter.default.post(
+            name: .completedConversationMayNeedSpeakerReview,
+            object: nil,
+            userInfo: ["conversationId": memoryId]
+          )
+        }
       }
 
       // Local integrations: enqueue webhook/filesystem dispatches for this
       // memory. This only writes outbox rows; the drain service does the
       // actual sending in the background.
-      if memoryId != "?" {
+      if memoryId != "?", !memoryId.isEmpty {
         Task {
           await LocalIntegrationDispatcher.shared.enqueueDispatch(conversationId: memoryId)
         }
@@ -3202,6 +3247,9 @@ extension Notification.Name {
   /// Posted when conversation rows are mutated under the UI (e.g. backfill
   /// service rewrites title/overview). Listeners should refetch.
   static let conversationsListNeedsRefresh = Notification.Name("conversationsListNeedsRefresh")
+  /// Posted after a completed conversation has refreshed into the list and may need speaker review.
+  static let completedConversationMayNeedSpeakerReview = Notification.Name(
+    "completedConversationMayNeedSpeakerReview")
   /// Posted when action_items rows are mutated under the UI (e.g. the
   /// `.extractActionItems` handler inserts conversation-derived tasks).
   /// Listeners should refetch (e.g. `TasksStore.loadTasks()`).

--- a/Desktop/Sources/AppState.swift
+++ b/Desktop/Sources/AppState.swift
@@ -1281,23 +1281,26 @@ class AppState: ObservableObject {
         // Initialize audio capture service
         audioCaptureService = AudioCaptureService()
 
-        // Initialize audio mixer for combining mic and system audio
-        audioMixer = AudioMixer()
-
         // Initialize system audio capture if supported (macOS 14.4+)
         // Can be disabled via: defaults write com.omi.desktop-dev disableSystemAudioCapture -bool true
         //                  or: defaults write com.omi.computer-macos disableSystemAudioCapture -bool true
         let systemAudioDisabled = UserDefaults.standard.bool(forKey: "disableSystemAudioCapture")
+        var systemAudioAvailable = false
         if systemAudioDisabled {
           log(
             "Transcription: System audio capture DISABLED by user preference (disableSystemAudioCapture)"
           )
         } else if #available(macOS 14.4, *) {
           systemAudioCaptureService = SystemAudioCaptureService()
+          systemAudioAvailable = true
           log("Transcription: System audio capture initialized (macOS 14.4+)")
         } else {
           log("Transcription: System audio capture not available (requires macOS 14.4+)")
         }
+
+        // Initialize audio mixer after source availability is known. When system
+        // capture is available, the mixer waits briefly for both sides before padding.
+        audioMixer = AudioMixer(systemAudioAvailable: systemAudioAvailable)
       }
       // For BLE device, BleAudioService will be used in startAudioCapture
 
@@ -1364,18 +1367,22 @@ class AppState: ObservableObject {
       // Create crash-safe DB session for persistence. The audio persistence start
       // is sequenced before session attachment so a delayed start(nil) cannot
       // overwrite a real session id.
+      AudioPersistenceService.shared.enqueueStart(
+        source: effectiveSource == .bleDevice ? "ble_device" : "mixed",
+        transcriptionSessionId: nil,
+        captureStartedAt: audioCaptureStartedAt
+      )
       Task {
-        await AudioPersistenceService.shared.start(
-          source: "mixed",
-          transcriptionSessionId: nil,
-          captureStartedAt: audioCaptureStartedAt
-        )
         do {
           let sessionId = try await TranscriptionStorage.shared.startSession(
             source: currentConversationSource.rawValue,
             language: effectiveLanguage,
             timezone: TimeZone.current.identifier,
             inputDeviceName: recordingInputDeviceName
+          )
+          await alignTranscriptionSessionStartTime(
+            sessionId: sessionId,
+            startedAt: audioCaptureStartedAt
           )
           await MainActor.run {
             self.currentSessionId = sessionId
@@ -1387,9 +1394,7 @@ class AppState: ObservableObject {
               sessionId,
               startedAt: self.recordingStartTime
             )
-            Task {
-              await AudioPersistenceService.shared.setTranscriptionSessionId(sessionId)
-            }
+            AudioPersistenceService.shared.enqueueSetTranscriptionSessionId(sessionId)
           }
           log("Transcription: Created DB session \(sessionId)")
         } catch {
@@ -1459,9 +1464,7 @@ class AppState: ObservableObject {
     audioMixer?.start { [weak self] monoMixed in
       self?.transcriptionService?.sendAudio(monoMixed)
       SpeakerDiarizationService.shared.appendAudio(monoMixed)
-      Task {
-        await AudioPersistenceService.shared.append(monoMixed)
-      }
+      AudioPersistenceService.shared.enqueueAppend(monoMixed)
     }
 
     do {
@@ -1498,6 +1501,7 @@ class AppState: ObservableObject {
           } catch {
             // System audio is optional — continue with mic only (mixer will just
             // emit mic samples summed with zero system samples).
+            self.audioMixer?.setSystemAudioAvailable(false)
             logError(
               "Transcription: System audio capture failed (continuing with mic only)", error: error)
           }
@@ -1553,7 +1557,11 @@ class AppState: ObservableObject {
     await BleAudioService.shared.startProcessing(
       from: connection,
       transcriptionService: transcriptionService,
-      audioDataHandler: { _ in
+      audioDataHandler: { pcmData in
+        if !pcmData.isEmpty && pcmData.count.isMultiple(of: 2) {
+          SpeakerDiarizationService.shared.appendAudio(pcmData)
+          AudioPersistenceService.shared.enqueueAppend(pcmData)
+        }
         // Audio level is updated by BleAudioService
         Task { @MainActor in
           AudioLevelMonitor.shared.updateMicrophoneLevel(BleAudioService.shared.audioLevel)
@@ -1680,6 +1688,32 @@ class AppState: ObservableObject {
     }
   }
 
+  private func notifyLocalConversationMayNeedSpeakerReview(
+    sessionId: Int64,
+    segmentCount: Int,
+    chunkCount: Int
+  ) {
+    let conversationId = "local-\(sessionId)"
+    let userInfo: [String: Any] = [
+      "conversationId": conversationId,
+      "sessionId": sessionId,
+    ]
+
+    if segmentCount > 0 {
+      NotificationCenter.default.post(
+        name: .completedConversationMayNeedSpeakerReview,
+        object: nil,
+        userInfo: userInfo
+      )
+    } else if chunkCount > 0 {
+      NotificationCenter.default.post(
+        name: .localConversationAwaitingSpeakerReviewTranscriptSegments,
+        object: nil,
+        userInfo: userInfo
+      )
+    }
+  }
+
   /// Reconcile a local session by checking if a matching conversation exists on the backend.
   /// If found, marks the session as completed. Otherwise leaves it as pendingUpload for retry.
   private func reconcileSession(sessionId: Int64, startTime: Date) async {
@@ -1707,6 +1741,24 @@ class AppState: ObservableObject {
     }
   }
 
+  /// Keep the durable session anchor aligned with the first sample timeline.
+  /// Review audio slices use transcription_sessions.startedAt as audio zero.
+  private func alignTranscriptionSessionStartTime(sessionId: Int64, startedAt: Date?) async {
+    guard let startedAt else { return }
+    guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else { return }
+    do {
+      try await dbQueue.write { db in
+        try db.execute(
+          sql: "UPDATE transcription_sessions SET startedAt = ?, updatedAt = ? WHERE id = ?",
+          arguments: [startedAt, Date(), sessionId]
+        )
+      }
+    } catch {
+      logError("Transcription: Failed to align session audio anchor", error: error)
+      await RewindDatabase.shared.reportQueryError(error)
+    }
+  }
+
   /// Finish the current conversation and keep recording for a new one.
   /// Disconnects the WebSocket (triggers backend conversation processing) then reconnects.
   func finishConversation() async -> FinishConversationResult {
@@ -1726,7 +1778,8 @@ class AppState: ObservableObject {
     // (backend will process it; memory_created event may arrive on the new session's WebSocket)
     if let sessionId = currentSessionId {
       do {
-        await AudioPersistenceService.shared.flush()
+        await AudioPersistenceService.shared.flushQueued()
+        AudioPersistenceService.shared.enqueueSetTranscriptionSessionId(nil)
         let segmentCount = try await TranscriptionStorage.shared.getSegmentCount(sessionId: sessionId)
         let chunkCount = try await TranscriptionStorage.shared.getAudioChunkCount(sessionId: sessionId)
         let elapsed: Double = recordingStartTime.map { Date().timeIntervalSince($0) } ?? 0
@@ -1736,6 +1789,13 @@ class AppState: ObservableObject {
         } else {
           try await TranscriptionStorage.shared.finishSession(id: sessionId)
           log("Transcription: Finished DB session \(sessionId) before reconnect")
+          await MainActor.run {
+            self.notifyLocalConversationMayNeedSpeakerReview(
+              sessionId: sessionId,
+              segmentCount: segmentCount,
+              chunkCount: chunkCount
+            )
+          }
           Task(priority: .background) {
             await ConversationSummaryBackfillService.shared.summarizeSessionIfNeeded(
               sessionId, reason: "finishConversation")
@@ -1758,7 +1818,7 @@ class AppState: ObservableObject {
     // must not be persisted against the finished session. They'll be buffered in memory until
     // the new session ID is set in the Task below.
     currentSessionId = nil
-    await AudioPersistenceService.shared.setTranscriptionSessionId(nil)
+    AudioPersistenceService.shared.enqueueSetTranscriptionSessionId(nil)
 
     // Clear segments for the next conversation but keep recording active
     speakerSegments = []
@@ -1821,6 +1881,7 @@ class AppState: ObservableObject {
 
     // Start a new DB session for the next conversation
     let lang = AssistantSettings.shared.effectiveTranscriptionLanguage
+    let nextRecordingStartTime = recordingStartTime
     Task {
       do {
         let sessionId = try await TranscriptionStorage.shared.startSession(
@@ -1828,6 +1889,10 @@ class AppState: ObservableObject {
           language: lang,
           timezone: TimeZone.current.identifier,
           inputDeviceName: recordingInputDeviceName
+        )
+        await alignTranscriptionSessionStartTime(
+          sessionId: sessionId,
+          startedAt: nextRecordingStartTime
         )
         await MainActor.run {
           self.currentSessionId = sessionId
@@ -1841,9 +1906,7 @@ class AppState: ObservableObject {
               self?.handleDiarizationTurn(turn)
             }
           }
-          Task {
-            await AudioPersistenceService.shared.setTranscriptionSessionId(sessionId)
-          }
+          AudioPersistenceService.shared.enqueueSetTranscriptionSessionId(sessionId)
         }
         log("Transcription: Created new DB session \(sessionId) for next conversation")
       } catch {
@@ -1889,9 +1952,7 @@ class AppState: ObservableObject {
     // Stop audio mixer
     audioMixer?.stop()
     audioMixer = nil
-    Task {
-      await AudioPersistenceService.shared.stop()
-    }
+    AudioPersistenceService.shared.enqueueStop()
 
     // Infinite Recall fork: stop on-device diarization (flushes any in-flight turn).
     SpeakerDiarizationService.shared.stop()
@@ -1924,7 +1985,7 @@ class AppState: ObservableObject {
       }()
       Task {
         do {
-          await AudioPersistenceService.shared.stop()
+          await AudioPersistenceService.shared.stopQueued()
           let segmentCount = try await TranscriptionStorage.shared.getSegmentCount(sessionId: sessionId)
           let chunkCount = try await TranscriptionStorage.shared.getAudioChunkCount(sessionId: sessionId)
           if segmentCount == 0 && chunkCount == 0 && elapsedSeconds < 5 {
@@ -1933,6 +1994,13 @@ class AppState: ObservableObject {
           } else {
             try await TranscriptionStorage.shared.finishSession(id: sessionId)
             log("Transcription: Finished DB session \(sessionId)")
+            await MainActor.run {
+              self.notifyLocalConversationMayNeedSpeakerReview(
+                sessionId: sessionId,
+                segmentCount: segmentCount,
+                chunkCount: chunkCount
+              )
+            }
             Task(priority: .background) {
               await ConversationSummaryBackfillService.shared.summarizeSessionIfNeeded(
                 sessionId, reason: "stopTranscription")
@@ -2383,7 +2451,22 @@ class AppState: ObservableObject {
       return false
     }
 
-    // Update in-memory conversations list so the prop is fresh on next open.
+    let assigned = await PeopleStore.shared.assignSegments(
+      sessionId: sessionId,
+      segmentIds: segmentIds,
+      personId: personId,
+      isUser: isUser
+    )
+    guard assigned else {
+      logError(
+        "People: Failed to assign segments/backfill embeddings",
+        error: NSError(domain: "PeopleStore", code: -3)
+      )
+      return false
+    }
+
+    // Update in-memory conversations list only after the local segment rows and
+    // embedding backfill have committed.
     if let idx = conversations.firstIndex(where: { $0.id == conversationId }) {
       if !backendIds.isEmpty {
         let backendSet = Set(backendIds)
@@ -2429,34 +2512,6 @@ class AppState: ObservableObject {
           )
         }
       }
-    }
-
-    // Persist to local SQLite (transcription_segments).
-    do {
-      try await TranscriptionStorage.shared.updateSpeakerAssignmentByBackendId(
-        conversationId,
-        segmentIds: backendIds,
-        fallbackSegmentOrders: fallbackOrders,
-        isUser: isUser,
-        personId: isUser ? nil : personId
-      )
-    } catch {
-      logError("People: Failed to update local segment cache", error: error)
-      return false
-    }
-
-    let assigned = await PeopleStore.shared.assignSegments(
-      sessionId: sessionId,
-      segmentIds: segmentIds,
-      personId: personId,
-      isUser: isUser
-    )
-    guard assigned else {
-      logError(
-        "People: Failed to assign segments/backfill embeddings",
-        error: NSError(domain: "PeopleStore", code: -3)
-      )
-      return false
     }
 
     log("People: Assigned \(segmentIds.count) segments in conversation \(conversationId)")
@@ -3250,6 +3305,10 @@ extension Notification.Name {
   /// Posted after a completed conversation has refreshed into the list and may need speaker review.
   static let completedConversationMayNeedSpeakerReview = Notification.Name(
     "completedConversationMayNeedSpeakerReview")
+  /// Posted for a just-finished local conversation whose transcript must arrive via backfill
+  /// before speaker review can be considered.
+  static let localConversationAwaitingSpeakerReviewTranscriptSegments = Notification.Name(
+    "localConversationAwaitingSpeakerReviewTranscriptSegments")
   /// Posted when action_items rows are mutated under the UI (e.g. the
   /// `.extractActionItems` handler inserts conversation-derived tasks).
   /// Listeners should refetch (e.g. `TasksStore.loadTasks()`).

--- a/Desktop/Sources/AudioMixer.swift
+++ b/Desktop/Sources/AudioMixer.swift
@@ -121,11 +121,15 @@ class AudioMixer {
             // When flushing, process whatever is available
             bytesToProcess = max(micBuffer.count, systemBuffer.count)
         } else {
-            // Normal operation: process when both have data
+            // Normal operation: process once audio is available. If one side is
+            // absent (system capture disabled/failed, or mic-only recording), pad
+            // that side with silence instead of stalling the stream.
             let minAvailable = min(micBuffer.count, systemBuffer.count)
-            guard minAvailable >= minBufferBytes else { return }
+            let maxAvailable = max(micBuffer.count, systemBuffer.count)
+            guard maxAvailable >= minBufferBytes else { return }
             // Align to sample boundary (2 bytes per Int16 sample)
-            bytesToProcess = (minAvailable / 2) * 2
+            let availableToProcess = minAvailable > 0 ? minAvailable : maxAvailable
+            bytesToProcess = (availableToProcess / 2) * 2
         }
 
         guard bytesToProcess >= 2 else { return }

--- a/Desktop/Sources/AudioMixer.swift
+++ b/Desktop/Sources/AudioMixer.swift
@@ -22,16 +22,29 @@ class AudioMixer {
     // MARK: - Properties
 
     private let outputMode: OutputMode
+    private let counterpartWaitTimeout: TimeInterval
     private var onMixedChunk: AudioChunkHandler?
     private var isRunning = false
+    private var micAudioAvailable: Bool
+    private var systemAudioAvailable: Bool
 
-    init(outputMode: OutputMode = .mono) {
+    init(
+        outputMode: OutputMode = .mono,
+        micAudioAvailable: Bool = true,
+        systemAudioAvailable: Bool = true,
+        counterpartWaitTimeout: TimeInterval = 0.25
+    ) {
         self.outputMode = outputMode
+        self.micAudioAvailable = micAudioAvailable
+        self.systemAudioAvailable = systemAudioAvailable
+        self.counterpartWaitTimeout = counterpartWaitTimeout
     }
 
     // Audio buffers (16kHz mono Int16 PCM)
     private var micBuffer = Data()
     private var systemBuffer = Data()
+    private var micBufferFirstSampleAt: Date?
+    private var systemBufferFirstSampleAt: Date?
     private let bufferLock = NSLock()
 
     // Minimum samples before producing output (100ms at 16kHz = 1600 samples = 3200 bytes)
@@ -51,6 +64,8 @@ class AudioMixer {
         self.isRunning = true
         micBuffer = Data()
         systemBuffer = Data()
+        micBufferFirstSampleAt = nil
+        systemBufferFirstSampleAt = nil
         bufferLock.unlock()
         log("AudioMixer: Started (mode=\(outputMode == .mono ? "mono" : "stereo"))")
     }
@@ -63,9 +78,33 @@ class AudioMixer {
         processBuffers(flush: true)
         micBuffer = Data()
         systemBuffer = Data()
+        micBufferFirstSampleAt = nil
+        systemBufferFirstSampleAt = nil
         onMixedChunk = nil
         bufferLock.unlock()
         log("AudioMixer: Stopped")
+    }
+
+    func setMicAudioAvailable(_ available: Bool) {
+        bufferLock.lock()
+        defer { bufferLock.unlock() }
+        micAudioAvailable = available
+        if !available {
+            micBuffer = Data()
+            micBufferFirstSampleAt = nil
+        }
+        processBuffers()
+    }
+
+    func setSystemAudioAvailable(_ available: Bool) {
+        bufferLock.lock()
+        defer { bufferLock.unlock() }
+        systemAudioAvailable = available
+        if !available {
+            systemBuffer = Data()
+            systemBufferFirstSampleAt = nil
+        }
+        processBuffers()
     }
 
     /// Add microphone audio (16kHz mono Int16 PCM)
@@ -75,12 +114,13 @@ class AudioMixer {
 
         guard isRunning else { return }
 
-        micBuffer.append(data)
+        append(data, to: &micBuffer, firstSampleAt: &micBufferFirstSampleAt)
 
         // Prevent unbounded buffer growth
         if micBuffer.count > maxBufferBytes {
             let excess = micBuffer.count - maxBufferBytes
             micBuffer.removeFirst(excess)
+            micBufferFirstSampleAt = Date()
         }
 
         processBuffers()
@@ -93,12 +133,13 @@ class AudioMixer {
 
         guard isRunning else { return }
 
-        systemBuffer.append(data)
+        append(data, to: &systemBuffer, firstSampleAt: &systemBufferFirstSampleAt)
 
         // Prevent unbounded buffer growth
         if systemBuffer.count > maxBufferBytes {
             let excess = systemBuffer.count - maxBufferBytes
             systemBuffer.removeFirst(excess)
+            systemBufferFirstSampleAt = Date()
         }
 
         processBuffers()
@@ -111,26 +152,10 @@ class AudioMixer {
     private func processBuffers(flush: Bool = false) {
         guard isRunning || flush else { return }
 
-        // Check if we have enough data (or flushing)
         let minRequired = flush ? 2 : minBufferBytes  // At least 1 sample (2 bytes) when flushing
         guard micBuffer.count >= minRequired || systemBuffer.count >= minRequired else { return }
 
-        // Determine how many bytes to process (match the shorter buffer, aligned to sample boundary)
-        let bytesToProcess: Int
-        if flush {
-            // When flushing, process whatever is available
-            bytesToProcess = max(micBuffer.count, systemBuffer.count)
-        } else {
-            // Normal operation: process once audio is available. If one side is
-            // absent (system capture disabled/failed, or mic-only recording), pad
-            // that side with silence instead of stalling the stream.
-            let minAvailable = min(micBuffer.count, systemBuffer.count)
-            let maxAvailable = max(micBuffer.count, systemBuffer.count)
-            guard maxAvailable >= minBufferBytes else { return }
-            // Align to sample boundary (2 bytes per Int16 sample)
-            let availableToProcess = minAvailable > 0 ? minAvailable : maxAvailable
-            bytesToProcess = (availableToProcess / 2) * 2
-        }
+        guard let bytesToProcess = bytesToProcess(flush: flush) else { return }
 
         guard bytesToProcess >= 2 else { return }
 
@@ -145,6 +170,7 @@ class AudioMixer {
             // Pad mic buffer with silence
             micData = micBuffer + Data(repeating: 0, count: bytesToProcess - micBuffer.count)
             micBuffer = Data()
+            micBufferFirstSampleAt = nil
         }
 
         if systemBuffer.count >= bytesToProcess {
@@ -154,7 +180,9 @@ class AudioMixer {
             // Pad system buffer with silence
             sysData = systemBuffer + Data(repeating: 0, count: bytesToProcess - systemBuffer.count)
             systemBuffer = Data()
+            systemBufferFirstSampleAt = nil
         }
+        updateFirstSampleMarkersAfterRemoval()
 
         // Produce mixed output in the configured mode
         let mixed: Data
@@ -167,6 +195,71 @@ class AudioMixer {
 
         // Send to callback
         onMixedChunk?(mixed)
+    }
+
+    private func append(_ data: Data, to buffer: inout Data, firstSampleAt: inout Date?) {
+        if buffer.isEmpty {
+            firstSampleAt = Date()
+        }
+        buffer.append(data)
+    }
+
+    private func bytesToProcess(flush: Bool) -> Int? {
+        if flush {
+            return (max(micBuffer.count, systemBuffer.count) / 2) * 2
+        }
+
+        let micCount = micAudioAvailable ? micBuffer.count : 0
+        let systemCount = systemAudioAvailable ? systemBuffer.count : 0
+        let maxAvailable = max(micCount, systemCount)
+        guard maxAvailable >= minBufferBytes else { return nil }
+
+        if micAudioAvailable && systemAudioAvailable {
+            let minAvailable = min(micBuffer.count, systemBuffer.count)
+            if minAvailable >= minBufferBytes {
+                return (minAvailable / 2) * 2
+            }
+            guard hasWaitedForCounterpartLongEnough() else { return nil }
+            return (maxAvailable / 2) * 2
+        }
+
+        if micAudioAvailable {
+            return (micBuffer.count / 2) * 2
+        }
+        if systemAudioAvailable {
+            return (systemBuffer.count / 2) * 2
+        }
+        return nil
+    }
+
+    private func hasWaitedForCounterpartLongEnough(now: Date = Date()) -> Bool {
+        let oldestBufferedAt: Date?
+        switch (micBufferFirstSampleAt, systemBufferFirstSampleAt) {
+        case let (micStarted?, systemStarted?):
+            oldestBufferedAt = min(micStarted, systemStarted)
+        case let (micStarted?, nil):
+            oldestBufferedAt = micStarted
+        case let (nil, systemStarted?):
+            oldestBufferedAt = systemStarted
+        case (nil, nil):
+            oldestBufferedAt = nil
+        }
+        guard let oldestBufferedAt else { return false }
+        return now.timeIntervalSince(oldestBufferedAt) >= counterpartWaitTimeout
+    }
+
+    private func updateFirstSampleMarkersAfterRemoval() {
+        if micBuffer.isEmpty {
+            micBufferFirstSampleAt = nil
+        } else {
+            micBufferFirstSampleAt = Date()
+        }
+
+        if systemBuffer.isEmpty {
+            systemBufferFirstSampleAt = nil
+        } else {
+            systemBufferFirstSampleAt = Date()
+        }
     }
 
     /// Sum two mono Int16 streams into a single mono Int16 stream.

--- a/Desktop/Sources/AudioPersistenceService.swift
+++ b/Desktop/Sources/AudioPersistenceService.swift
@@ -373,14 +373,9 @@ actor AudioPersistenceService {
 
     private nonisolated func performQueued(_ operation: @escaping @Sendable () async -> Void) async {
         await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-            Self.operationQueue.async {
-                let semaphore = DispatchSemaphore(value: 0)
-                Task {
-                    await operation()
-                    semaphore.signal()
-                    continuation.resume()
-                }
-                semaphore.wait()
+            enqueue {
+                await operation()
+                continuation.resume()
             }
         }
     }

--- a/Desktop/Sources/AudioPersistenceService.swift
+++ b/Desktop/Sources/AudioPersistenceService.swift
@@ -9,17 +9,25 @@ import GRDB
 /// Format: 16kHz mono Int16 PCM (matches what `AudioMixer` emits for the mono mode).
 actor AudioPersistenceService {
     static let shared = AudioPersistenceService()
+    static let retentionDaysKey = "audioChunksRetentionDays"
+    static let defaultRetentionDays = 7
 
     /// 30 seconds @ 16kHz mono Int16 = 16000 * 2 * 30 = 960_000 bytes.
     private let chunkDurationSeconds: Double = 30.0
     private let sampleRate: Int = 16000
     private let bytesPerSample: Int = 2
     private var targetChunkBytes: Int { Int(chunkDurationSeconds) * sampleRate * bytesPerSample }
+    private static let retentionCleanupIntervalNanoseconds: UInt64 = 60 * 60 * 1_000_000_000
 
     private var buffer = Data()
     private var bufferStartedAt: Date?
+    private var captureStartedAt: Date?
+    private var linkWindowStartedAt: Date?
+    private var nextChunkStartedAt: Date?
     private var sessionId: Int64?
     private var source: String = "mixed"
+    private var lastPurgeAt: Date?
+    private var retentionCleanupTask: Task<Void, Never>?
 
     private init() {}
 
@@ -27,10 +35,19 @@ actor AudioPersistenceService {
 
     /// Begin a new always-on capture window. Safe to call repeatedly — flushes any
     /// in-flight buffer first.
-    func start(source: String = "mixed", transcriptionSessionId: Int64? = nil) async {
+    func start(
+        source: String = "mixed",
+        transcriptionSessionId: Int64? = nil,
+        captureStartedAt: Date = Date()
+    ) async {
         await flush()
+        await purgeExpiredChunksIfNeeded()
+        ensureRetentionCleanupTask()
         self.buffer = Data()
         self.bufferStartedAt = nil
+        self.captureStartedAt = captureStartedAt
+        self.linkWindowStartedAt = captureStartedAt
+        self.nextChunkStartedAt = captureStartedAt
         self.source = source
         self.sessionId = transcriptionSessionId
         log("AudioPersistenceService: Started (source=\(source), session=\(transcriptionSessionId.map(String.init) ?? "nil"))")
@@ -38,8 +55,13 @@ actor AudioPersistenceService {
 
     /// Update the transcription session id mid-capture (e.g. when a session is created
     /// after Whisper finally loads).
-    func setTranscriptionSessionId(_ id: Int64?) {
+    func setTranscriptionSessionId(_ id: Int64?) async {
         self.sessionId = id
+        guard let id else {
+            linkWindowStartedAt = nextChunkStartedAt ?? Date()
+            return
+        }
+        await linkOrphanedChunks(to: id)
     }
 
     /// Append mixed mono Int16 PCM bytes. Flushes a chunk to SQLite when ~30s of
@@ -47,7 +69,7 @@ actor AudioPersistenceService {
     func append(_ data: Data) async {
         guard !data.isEmpty else { return }
         if buffer.isEmpty {
-            bufferStartedAt = Date()
+            bufferStartedAt = nextChunkStartedAt ?? captureStartedAt ?? Date()
         }
         buffer.append(data)
 
@@ -65,6 +87,7 @@ actor AudioPersistenceService {
 
         let durationSec = Double(chunk.count / bytesPerSample) / Double(sampleRate)
         let endedAt = startedAt.addingTimeInterval(durationSec)
+        nextChunkStartedAt = endedAt
 
         do {
             guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
@@ -107,5 +130,233 @@ actor AudioPersistenceService {
         await flush()
         sessionId = nil
         log("AudioPersistenceService: Stopped")
+    }
+
+    // MARK: - Playback
+
+    func reviewAudioWAV(conversationId: String, startTime: Double, endTime: Double) async -> Data? {
+        guard endTime > startTime else { return nil }
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else { return nil }
+
+        struct ChunkRow {
+            let startedAt: Date
+            let endedAt: Date
+            let sampleRate: Int
+            let channels: Int
+            let pcm: Data
+        }
+
+        do {
+            let payload: (audioStartedAt: Date, rows: [ChunkRow])? = try await dbQueue.read { db in
+                guard let session = try Row.fetchOne(
+                    db,
+                    sql: "SELECT id, startedAt FROM transcription_sessions WHERE backendId = ?",
+                    arguments: [conversationId]
+                ) else { return nil }
+
+                let sessionId: Int64 = session["id"]
+                let sessionStartedAt: Date = session["startedAt"]
+                let audioStartedAt = try Date.fetchOne(
+                    db,
+                    sql: "SELECT MIN(startedAt) FROM audio_chunks WHERE transcriptionSessionId = ?",
+                    arguments: [sessionId]
+                ) ?? sessionStartedAt
+                let requestedStart = audioStartedAt.addingTimeInterval(startTime)
+                let requestedEnd = audioStartedAt.addingTimeInterval(endTime)
+                let rows = try Row.fetchAll(
+                    db,
+                    sql: """
+                        SELECT startedAt, endedAt, sampleRate, channels, pcm
+                        FROM audio_chunks
+                        WHERE transcriptionSessionId = ?
+                          AND startedAt < ?
+                          AND endedAt > ?
+                        ORDER BY startedAt ASC
+                        """,
+                    arguments: [sessionId, requestedEnd, requestedStart]
+                ).map { row in
+                    ChunkRow(
+                        startedAt: row["startedAt"],
+                        endedAt: row["endedAt"],
+                        sampleRate: row["sampleRate"] ?? 16000,
+                        channels: row["channels"] ?? 1,
+                        pcm: row["pcm"] ?? Data()
+                    )
+                }
+                return (audioStartedAt, rows)
+            }
+            guard let payload, !payload.rows.isEmpty else { return nil }
+
+            let requestedStart = payload.audioStartedAt.addingTimeInterval(startTime)
+            let requestedEnd = payload.audioStartedAt.addingTimeInterval(endTime)
+            var pcm = Data()
+            var detectedSampleRate = sampleRate
+            var detectedChannels = 1
+
+            for row in payload.rows {
+                guard row.sampleRate > 0, row.channels > 0, !row.pcm.isEmpty else { continue }
+                detectedSampleRate = row.sampleRate
+                detectedChannels = row.channels
+                let bytesPerFrame = bytesPerSample * row.channels
+                let overlapStart = max(row.startedAt, requestedStart)
+                let overlapEnd = min(row.endedAt, requestedEnd)
+                guard overlapEnd > overlapStart else { continue }
+
+                let startFrame = max(0, Int(overlapStart.timeIntervalSince(row.startedAt) * Double(row.sampleRate)))
+                let endFrame = max(startFrame, Int(overlapEnd.timeIntervalSince(row.startedAt) * Double(row.sampleRate)))
+                let startByte = min(row.pcm.count, startFrame * bytesPerFrame)
+                let endByte = min(row.pcm.count, endFrame * bytesPerFrame)
+                guard endByte > startByte else { continue }
+                pcm.append(row.pcm[startByte..<endByte])
+            }
+
+            guard !pcm.isEmpty else { return nil }
+            return Self.wavData(
+                pcm: pcm,
+                sampleRate: detectedSampleRate,
+                channels: detectedChannels,
+                bitsPerSample: 16
+            )
+        } catch {
+            logError("AudioPersistenceService: Failed to fetch review audio", error: error)
+            await RewindDatabase.shared.reportQueryError(error)
+            return nil
+        }
+    }
+
+    // MARK: - Retention
+
+    static var retentionDays: Int {
+        get {
+            let stored = UserDefaults.standard.object(forKey: retentionDaysKey) as? Int
+            return max(1, stored ?? defaultRetentionDays)
+        }
+        set {
+            UserDefaults.standard.set(max(1, newValue), forKey: retentionDaysKey)
+        }
+    }
+
+    @discardableResult
+    func purgeExpiredChunks(now: Date = Date()) async -> Int {
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else { return 0 }
+        let cutoff = now.addingTimeInterval(-Double(Self.retentionDays) * 24 * 60 * 60)
+        do {
+            let deleted = try await dbQueue.write { db -> Int in
+                try db.execute(
+                    sql: "DELETE FROM audio_chunks WHERE endedAt < ?",
+                    arguments: [cutoff]
+                )
+                return db.changesCount
+            }
+            lastPurgeAt = now
+            if deleted > 0 {
+                log("AudioPersistenceService: Purged \(deleted) expired audio chunk(s)")
+            }
+            return deleted
+        } catch {
+            logError("AudioPersistenceService: Failed to purge expired chunks", error: error)
+            await RewindDatabase.shared.reportQueryError(error)
+            return 0
+        }
+    }
+
+    @discardableResult
+    func purgeExpiredChunksIfNeeded(now: Date = Date()) async -> Int {
+        if let lastPurgeAt, now.timeIntervalSince(lastPurgeAt) < 60 * 60 {
+            return 0
+        }
+        return await purgeExpiredChunks(now: now)
+    }
+
+    func resetStateForTests() async {
+        await stop()
+        retentionCleanupTask?.cancel()
+        retentionCleanupTask = nil
+        lastPurgeAt = nil
+        captureStartedAt = nil
+        linkWindowStartedAt = nil
+        nextChunkStartedAt = nil
+    }
+
+    private func linkOrphanedChunks(to id: Int64) async {
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else { return }
+        let windowStart = linkWindowStartedAt ?? captureStartedAt ?? .distantPast
+        let src = source
+        do {
+            let updated = try await dbQueue.write { db -> Int in
+                try db.execute(
+                    sql: """
+                        UPDATE audio_chunks
+                           SET transcriptionSessionId = ?
+                         WHERE transcriptionSessionId IS NULL
+                           AND source = ?
+                           AND endedAt > ?
+                        """,
+                    arguments: [id, src, windowStart]
+                )
+                return db.changesCount
+            }
+            if updated > 0 {
+                log("AudioPersistenceService: Linked \(updated) orphaned chunk(s) to session \(id)")
+            }
+        } catch {
+            logError("AudioPersistenceService: Failed to link orphaned chunks", error: error)
+            await RewindDatabase.shared.reportQueryError(error)
+        }
+    }
+
+    private func ensureRetentionCleanupTask() {
+        guard retentionCleanupTask == nil else { return }
+        retentionCleanupTask = Task { [weak self] in
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(nanoseconds: Self.retentionCleanupIntervalNanoseconds)
+                } catch {
+                    break
+                }
+                await self?.purgeExpiredChunksIfNeeded()
+            }
+        }
+    }
+
+    private static func wavData(
+        pcm: Data,
+        sampleRate: Int,
+        channels: Int,
+        bitsPerSample: Int
+    ) -> Data {
+        var data = Data()
+        let byteRate = sampleRate * channels * bitsPerSample / 8
+        let blockAlign = channels * bitsPerSample / 8
+        let subchunk2Size = UInt32(pcm.count)
+        let chunkSize = UInt32(36 + pcm.count)
+
+        data.append(contentsOf: Array("RIFF".utf8))
+        data.appendLittleEndian(chunkSize)
+        data.append(contentsOf: Array("WAVE".utf8))
+        data.append(contentsOf: Array("fmt ".utf8))
+        data.appendLittleEndian(UInt32(16))
+        data.appendLittleEndian(UInt16(1))
+        data.appendLittleEndian(UInt16(channels))
+        data.appendLittleEndian(UInt32(sampleRate))
+        data.appendLittleEndian(UInt32(byteRate))
+        data.appendLittleEndian(UInt16(blockAlign))
+        data.appendLittleEndian(UInt16(bitsPerSample))
+        data.append(contentsOf: Array("data".utf8))
+        data.appendLittleEndian(subchunk2Size)
+        data.append(pcm)
+        return data
+    }
+}
+
+private extension Data {
+    mutating func appendLittleEndian(_ value: UInt16) {
+        var little = value.littleEndian
+        append(Data(bytes: &little, count: MemoryLayout<UInt16>.size))
+    }
+
+    mutating func appendLittleEndian(_ value: UInt32) {
+        var little = value.littleEndian
+        append(Data(bytes: &little, count: MemoryLayout<UInt32>.size))
     }
 }

--- a/Desktop/Sources/AudioPersistenceService.swift
+++ b/Desktop/Sources/AudioPersistenceService.swift
@@ -28,10 +28,56 @@ actor AudioPersistenceService {
     private var source: String = "mixed"
     private var lastPurgeAt: Date?
     private var retentionCleanupTask: Task<Void, Never>?
+    private static let operationQueue = DispatchQueue(label: "com.omi.audioPersistence.operations")
 
     private init() {}
 
     // MARK: - Lifecycle
+
+    nonisolated func enqueueStart(
+        source: String = "mixed",
+        transcriptionSessionId: Int64? = nil,
+        captureStartedAt: Date = Date()
+    ) {
+        enqueue {
+            await self.start(
+                source: source,
+                transcriptionSessionId: transcriptionSessionId,
+                captureStartedAt: captureStartedAt
+            )
+        }
+    }
+
+    nonisolated func enqueueAppend(_ data: Data) {
+        guard !data.isEmpty else { return }
+        enqueue {
+            await self.append(data)
+        }
+    }
+
+    nonisolated func enqueueSetTranscriptionSessionId(_ id: Int64?) {
+        enqueue {
+            await self.setTranscriptionSessionId(id)
+        }
+    }
+
+    nonisolated func flushQueued() async {
+        await performQueued {
+            await self.flush()
+        }
+    }
+
+    nonisolated func enqueueStop() {
+        enqueue {
+            await self.stop()
+        }
+    }
+
+    nonisolated func stopQueued() async {
+        await performQueued {
+            await self.stop()
+        }
+    }
 
     /// Begin a new always-on capture window. Safe to call repeatedly — flushes any
     /// in-flight buffer first.
@@ -155,12 +201,7 @@ actor AudioPersistenceService {
                 ) else { return nil }
 
                 let sessionId: Int64 = session["id"]
-                let sessionStartedAt: Date = session["startedAt"]
-                let audioStartedAt = try Date.fetchOne(
-                    db,
-                    sql: "SELECT MIN(startedAt) FROM audio_chunks WHERE transcriptionSessionId = ?",
-                    arguments: [sessionId]
-                ) ?? sessionStartedAt
+                let audioStartedAt: Date = session["startedAt"]
                 let requestedStart = audioStartedAt.addingTimeInterval(startTime)
                 let requestedEnd = audioStartedAt.addingTimeInterval(endTime)
                 let rows = try Row.fetchAll(
@@ -315,6 +356,31 @@ actor AudioPersistenceService {
                     break
                 }
                 await self?.purgeExpiredChunksIfNeeded()
+            }
+        }
+    }
+
+    private nonisolated func enqueue(_ operation: @escaping @Sendable () async -> Void) {
+        Self.operationQueue.async {
+            let semaphore = DispatchSemaphore(value: 0)
+            Task {
+                await operation()
+                semaphore.signal()
+            }
+            semaphore.wait()
+        }
+    }
+
+    private nonisolated func performQueued(_ operation: @escaping @Sendable () async -> Void) async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            Self.operationQueue.async {
+                let semaphore = DispatchSemaphore(value: 0)
+                Task {
+                    await operation()
+                    semaphore.signal()
+                    continuation.resume()
+                }
+                semaphore.wait()
             }
         }
     }

--- a/Desktop/Sources/Diarization/PeopleStore.swift
+++ b/Desktop/Sources/Diarization/PeopleStore.swift
@@ -46,6 +46,29 @@ actor PeopleStore {
         return (backendIds, fallbackOrders)
     }
 
+    private static func canUseSegmentForVoiceTraining(text: String, start: Double, end: Double) -> Bool {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        guard end - start >= SpeakerEmbeddingStore.minimumMatchDuration else { return false }
+        return !isNoiseOnly(trimmed)
+    }
+
+    private static func isNoiseOnly(_ text: String) -> Bool {
+        let lowered = text
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "()[]{}"))
+            .lowercased()
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !lowered.isEmpty else { return true }
+
+        let noiseWords = [
+            "music", "gentle music", "background music", "noise", "silence",
+            "applause", "laughter", "inaudible", "static", "beep", "tone"
+        ]
+        if noiseWords.contains(lowered) { return true }
+        return noiseWords.contains { lowered == "[\($0)]" || lowered == "(\($0))" }
+    }
+
     // MARK: - Read
 
     /// Fetch all known people, ordered by display name.
@@ -159,12 +182,7 @@ actor PeopleStore {
                         arguments: [resolvedPerson, resolvedIsUser, sessionId, encodedOrders]
                     )
                 }
-            }
 
-            // Backfill embeddings only for the time windows represented by the
-            // selected segments. This avoids contaminating a whole session-local
-            // speaker cluster when the user tags just one/few segments.
-            let rows: [Row] = try await dbQueue.read { db in
                 var clauses: [String] = []
                 var args: [DatabaseValueConvertible] = [sessionId]
                 if !backendIds.isEmpty {
@@ -177,29 +195,42 @@ actor PeopleStore {
                     clauses.append("segmentOrder IN (\(placeholders))")
                     args.append(contentsOf: fallbackOrders)
                 }
-                guard !clauses.isEmpty else { return [] }
+                guard !clauses.isEmpty else { return }
                 let sql = """
-                    SELECT speaker, startTime, endTime
+                    SELECT speaker, text, startTime, endTime
                     FROM transcription_segments
                     WHERE sessionId = ? AND (\(clauses.joined(separator: " OR ")))
                     """
-                return try Row.fetchAll(db, sql: sql, arguments: StatementArguments(args))
+                let rows = try Row.fetchAll(db, sql: sql, arguments: StatementArguments(args))
+                var bySpeaker: [Int: [SpeakerEmbeddingStore.AssignmentRange]] = [:]
+                for row in rows {
+                    let speaker: Int = row["speaker"]
+                    let text: String = row["text"] ?? ""
+                    let start: Double = row["startTime"]
+                    let end: Double = row["endTime"]
+                    bySpeaker[speaker, default: []].append(
+                        SpeakerEmbeddingStore.AssignmentRange(
+                            start: start,
+                            end: end,
+                            allowsTraining: Self.canUseSegmentForVoiceTraining(
+                                text: text,
+                                start: start,
+                                end: end
+                            )
+                        )
+                    )
+                }
+                for (sid, ranges) in bySpeaker {
+                    try SpeakerEmbeddingStore.assignPersonToEmbeddings(
+                        in: db,
+                        sessionId: sessionId,
+                        speakerId: sid,
+                        personId: resolvedPerson,
+                        overlapping: ranges
+                    )
+                }
             }
-            var bySpeaker: [Int: [(start: Double, end: Double)]] = [:]
-            for row in rows {
-                let speaker: Int = row["speaker"]
-                let start: Double = row["startTime"]
-                let end: Double = row["endTime"]
-                bySpeaker[speaker, default: []].append((start, end))
-            }
-            for (sid, ranges) in bySpeaker {
-                await SpeakerEmbeddingStore.shared.assignPersonToEmbeddings(
-                    sessionId: sessionId,
-                    speakerId: sid,
-                    personId: resolvedPerson,
-                    overlapping: ranges
-                )
-            }
+            await SpeakerEmbeddingStore.shared.reset()
             return true
         } catch {
             logError("PeopleStore: assignSegments failed", error: error)

--- a/Desktop/Sources/Diarization/PeopleStore.swift
+++ b/Desktop/Sources/Diarization/PeopleStore.swift
@@ -50,23 +50,7 @@ actor PeopleStore {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return false }
         guard end - start >= SpeakerEmbeddingStore.minimumMatchDuration else { return false }
-        return !isNoiseOnly(trimmed)
-    }
-
-    private static func isNoiseOnly(_ text: String) -> Bool {
-        let lowered = text
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .trimmingCharacters(in: CharacterSet(charactersIn: "()[]{}"))
-            .lowercased()
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !lowered.isEmpty else { return true }
-
-        let noiseWords = [
-            "music", "gentle music", "background music", "noise", "silence",
-            "applause", "laughter", "inaudible", "static", "beep", "tone"
-        ]
-        if noiseWords.contains(lowered) { return true }
-        return noiseWords.contains { lowered == "[\($0)]" || lowered == "(\($0))" }
+        return !SpeakerContentFilter.isNoiseOnly(trimmed)
     }
 
     // MARK: - Read

--- a/Desktop/Sources/Diarization/SpeakerContentFilter.swift
+++ b/Desktop/Sources/Diarization/SpeakerContentFilter.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+enum SpeakerContentFilter {
+    private static let noiseWords: Set<String> = [
+        "music", "gentle music", "background music", "noise", "silence",
+        "applause", "laughter", "inaudible", "static", "beep", "tone"
+    ]
+
+    static func isNoiseOnly(_ text: String) -> Bool {
+        let lowered = text
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "()[]{}"))
+            .lowercased()
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !lowered.isEmpty else { return true }
+        return noiseWords.contains(lowered)
+    }
+}

--- a/Desktop/Sources/Diarization/SpeakerEmbeddingStore.swift
+++ b/Desktop/Sources/Diarization/SpeakerEmbeddingStore.swift
@@ -76,6 +76,10 @@ enum VoiceMatchDecision: Equatable {
     }
 }
 
+enum SpeakerEmbeddingStoreError: Error {
+    case databaseUnavailable
+}
+
 /// Actor that owns DB I/O for speaker embeddings + the in-memory match index.
 actor SpeakerEmbeddingStore {
     static let shared = SpeakerEmbeddingStore()
@@ -94,6 +98,18 @@ actor SpeakerEmbeddingStore {
         var centroid: [Float]
         var sampleCount: Int
         var totalDuration: Double
+    }
+
+    struct AssignmentRange {
+        let start: Double
+        let end: Double
+        let allowsTraining: Bool
+
+        init(start: Double, end: Double, allowsTraining: Bool = true) {
+            self.start = start
+            self.end = end
+            self.allowsTraining = allowsTraining
+        }
     }
 
     /// Cached centroid embedding per person (mean of their stored embeddings).
@@ -184,122 +200,185 @@ actor SpeakerEmbeddingStore {
 
     /// Backfill `personId` on previously-recorded embeddings (e.g. when the
     /// user names "Speaker 1" mid-conversation).
+    @discardableResult
     func assignPersonToEmbeddings(
         sessionId: Int64,
         speakerId: Int,
         personId: String?
-    ) async {
-        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else { return }
+    ) async throws -> Int {
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+            throw SpeakerEmbeddingStoreError.databaseUnavailable
+        }
         do {
-            try await dbQueue.write { db in
-                try db.execute(
-                    sql: """
-                        UPDATE speaker_embeddings
-                        SET personId = ?,
-                            assignmentSource = ?,
-                            matchConfidence = NULL,
-                            isTrainingSample = CASE
-                                WHEN ? IS NULL THEN 0
-                                WHEN embeddingModel = ?
-                                  AND embeddingVersion = ?
-                                  AND (endTime - startTime) >= ? THEN 1
-                                ELSE 0
-                            END
-                        WHERE sessionId = ? AND speakerId = ?
-                        """,
-                    arguments: [
-                        personId,
-                        personId == nil ? nil : VoiceProfileAssignmentSource.manual.rawValue,
-                        personId,
-                        SpeakerEmbeddingStore.defaultEmbeddingModel,
-                        SpeakerEmbeddingStore.defaultEmbeddingVersion,
-                        SpeakerEmbeddingStore.minimumMatchDuration,
-                        sessionId,
-                        speakerId
-                    ]
+            let updated = try await dbQueue.write { db in
+                try Self.assignPersonToEmbeddings(
+                    in: db,
+                    sessionId: sessionId,
+                    speakerId: speakerId,
+                    personId: personId
                 )
             }
             // Invalidate cached centroid so next match call rebuilds it.
             if let pid = personId { personProfiles.removeValue(forKey: pid) }
             centroidsLoaded = false
+            return updated
         } catch {
             logError("SpeakerEmbeddingStore: backfill failed", error: error)
             await RewindDatabase.shared.reportQueryError(error)
+            throw error
         }
     }
 
     /// Assign a person only for embeddings overlapping the provided time ranges.
     /// Used to avoid contaminating an entire session-local speaker cluster when
     /// the user tags only a subset of segments.
+    @discardableResult
     func assignPersonToEmbeddings(
         sessionId: Int64,
         speakerId: Int,
         personId: String?,
         overlapping ranges: [(start: Double, end: Double)]
-    ) async {
-        guard !ranges.isEmpty else { return }
-        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else { return }
+    ) async throws -> Int {
+        guard !ranges.isEmpty else { return 0 }
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+            throw SpeakerEmbeddingStoreError.databaseUnavailable
+        }
         do {
-            try await dbQueue.write { db in
-                for r in ranges {
-                    // Overlap test: [startTime, endTime] intersects [r.start, r.end].
-                    try db.execute(
-                        sql: """
-                            UPDATE speaker_embeddings
-                            SET personId = ?,
-                                assignmentSource = ?,
-                                matchConfidence = NULL,
-                                isTrainingSample = 0
-                            WHERE sessionId = ?
-                              AND speakerId = ?
-                              AND NOT (endTime <= ? OR startTime >= ?)
-                            """,
-                        arguments: [
-                            personId,
-                            personId == nil ? nil : VoiceProfileAssignmentSource.manual.rawValue,
-                            sessionId,
-                            speakerId,
-                            r.start,
-                            r.end
-                        ]
-                    )
-                }
-                if personId != nil {
-                    for r in ranges {
-                        try db.execute(
-                            sql: """
-                                UPDATE speaker_embeddings
-                                SET isTrainingSample = 1
-                                WHERE sessionId = ?
-                                  AND speakerId = ?
-                                  AND personId = ?
-                                  AND embeddingModel = ?
-                                  AND embeddingVersion = ?
-                                  AND NOT (endTime <= ? OR startTime >= ?)
-                                  AND (MIN(endTime, ?) - MAX(startTime, ?)) >= ?
-                                """,
-                            arguments: [
-                                sessionId,
-                                speakerId,
-                                personId,
-                                SpeakerEmbeddingStore.defaultEmbeddingModel,
-                                SpeakerEmbeddingStore.defaultEmbeddingVersion,
-                                r.start,
-                                r.end,
-                                r.end,
-                                r.start,
-                                SpeakerEmbeddingStore.minimumMatchDuration
-                            ]
-                        )
-                    }
-                }
+            let assignmentRanges = ranges.map {
+                AssignmentRange(start: $0.start, end: $0.end)
+            }
+            let updated = try await dbQueue.write { db in
+                try Self.assignPersonToEmbeddings(
+                    in: db,
+                    sessionId: sessionId,
+                    speakerId: speakerId,
+                    personId: personId,
+                    overlapping: assignmentRanges
+                )
             }
             if let pid = personId { personProfiles.removeValue(forKey: pid) }
             centroidsLoaded = false
+            return updated
         } catch {
             logError("SpeakerEmbeddingStore: ranged backfill failed", error: error)
             await RewindDatabase.shared.reportQueryError(error)
+            throw error
         }
+    }
+
+    @discardableResult
+    static func assignPersonToEmbeddings(
+        in db: Database,
+        sessionId: Int64,
+        speakerId: Int,
+        personId: String?,
+        overlapping ranges: [AssignmentRange]? = nil
+    ) throws -> Int {
+        if let ranges {
+            guard !ranges.isEmpty else { return 0 }
+            return try assignPersonToEmbeddingsInRanges(
+                in: db,
+                sessionId: sessionId,
+                speakerId: speakerId,
+                personId: personId,
+                ranges: ranges
+            )
+        }
+
+        try db.execute(
+            sql: """
+                UPDATE speaker_embeddings
+                SET personId = ?,
+                    assignmentSource = ?,
+                    matchConfidence = NULL,
+                    isTrainingSample = CASE
+                        WHEN ? IS NULL THEN 0
+                        WHEN embeddingModel = ?
+                          AND embeddingVersion = ?
+                          AND (endTime - startTime) >= ? THEN 1
+                        ELSE 0
+                    END
+                WHERE sessionId = ? AND speakerId = ?
+                """,
+            arguments: [
+                personId,
+                personId == nil ? nil : VoiceProfileAssignmentSource.manual.rawValue,
+                personId,
+                SpeakerEmbeddingStore.defaultEmbeddingModel,
+                SpeakerEmbeddingStore.defaultEmbeddingVersion,
+                SpeakerEmbeddingStore.minimumMatchDuration,
+                sessionId,
+                speakerId
+            ]
+        )
+        return db.changesCount
+    }
+
+    private static func assignPersonToEmbeddingsInRanges(
+        in db: Database,
+        sessionId: Int64,
+        speakerId: Int,
+        personId: String?,
+        ranges: [AssignmentRange]
+    ) throws -> Int {
+        var updatedRows = 0
+        for range in ranges {
+            // Overlap test: [startTime, endTime] intersects [range.start, range.end].
+            try db.execute(
+                sql: """
+                    UPDATE speaker_embeddings
+                    SET personId = ?,
+                        assignmentSource = ?,
+                        matchConfidence = NULL,
+                        isTrainingSample = 0
+                    WHERE sessionId = ?
+                      AND speakerId = ?
+                      AND NOT (endTime <= ? OR startTime >= ?)
+                    """,
+                arguments: [
+                    personId,
+                    personId == nil ? nil : VoiceProfileAssignmentSource.manual.rawValue,
+                    sessionId,
+                    speakerId,
+                    range.start,
+                    range.end
+                ]
+            )
+            updatedRows += db.changesCount
+        }
+
+        guard personId != nil else { return updatedRows }
+
+        for range in ranges where range.allowsTraining {
+            try db.execute(
+                sql: """
+                    UPDATE speaker_embeddings
+                    SET isTrainingSample = 1
+                    WHERE sessionId = ?
+                      AND speakerId = ?
+                      AND personId = ?
+                      AND embeddingModel = ?
+                      AND embeddingVersion = ?
+                      AND NOT (endTime <= ? OR startTime >= ?)
+                      AND (MIN(endTime, ?) - MAX(startTime, ?)) >= ?
+                    """,
+                arguments: [
+                    sessionId,
+                    speakerId,
+                    personId,
+                    SpeakerEmbeddingStore.defaultEmbeddingModel,
+                    SpeakerEmbeddingStore.defaultEmbeddingVersion,
+                    range.start,
+                    range.end,
+                    range.end,
+                    range.start,
+                    SpeakerEmbeddingStore.minimumMatchDuration
+                ]
+            )
+            updatedRows += db.changesCount
+        }
+
+        return updatedRows
     }
 
     // MARK: - Matching

--- a/Desktop/Sources/LocalIntegrations/LocalIntegrationDrainService.swift
+++ b/Desktop/Sources/LocalIntegrations/LocalIntegrationDrainService.swift
@@ -19,6 +19,9 @@ final class LocalIntegrationDrainService: LocalIntegrationOutboxDelegate {
   static let shared = LocalIntegrationDrainService()
   private init() {}
 
+  /// If false, kick() is a no-op. Used in tests to prevent background races.
+  var isEnabled = true
+
   /// Posted on the main thread after every per-row outcome is applied
   /// (success/retry/permanentFailure). UI surfaces (e.g. `MyAppsSection`)
   /// listen so pending-count badges and `lastError` reflect drain progress
@@ -70,6 +73,8 @@ final class LocalIntegrationDrainService: LocalIntegrationOutboxDelegate {
   /// Manual / post-enqueue trigger. Cheap, idempotent, safe to call from
   /// any `@MainActor` context. Coalesces concurrent calls.
   func kick() {
+    guard isEnabled else { return }
+
     // Cancel any pending sleep — we want to drain now.
     pendingWakeTask?.cancel()
     pendingWakeTask = nil

--- a/Desktop/Sources/MainWindow/Components/NameSpeakerSheet.swift
+++ b/Desktop/Sources/MainWindow/Components/NameSpeakerSheet.swift
@@ -1,5 +1,28 @@
 import SwiftUI
 
+enum SpeakerAssignmentTarget: Equatable {
+    case you
+    case person(String)
+
+    var personId: String? {
+        switch self {
+        case .you:
+            return nil
+        case .person(let id):
+            return id
+        }
+    }
+
+    var isUser: Bool {
+        switch self {
+        case .you:
+            return true
+        case .person:
+            return false
+        }
+    }
+}
+
 /// Modal sheet for naming a speaker in a transcript
 struct NameSpeakerSheet: View {
     let segment: TranscriptSegment
@@ -9,7 +32,7 @@ struct NameSpeakerSheet: View {
     let onCreatePerson: (_ name: String) async -> Person?
     let onDismiss: () -> Void
 
-    @State private var selectedPersonId: String? = nil
+    @State private var selectedTarget: SpeakerAssignmentTarget? = nil
     @State private var isAddingNewPerson: Bool = false
     @State private var newPersonName: String = ""
     @State private var duplicateWarning: String? = nil
@@ -19,13 +42,13 @@ struct NameSpeakerSheet: View {
 
     /// Segments from the same speaker in this conversation
     private var sameSpeakerSegments: [TranscriptSegment] {
-        allSegments.filter { $0.speaker == segment.speaker && !$0.isUser }
+        allSegments.filter { $0.speaker == segment.speaker }
     }
 
     /// Segment indices (positional index in allSegments) for the same speaker
     private var sameSpeakerIndices: [Int] {
         allSegments.enumerated().compactMap { index, seg in
-            seg.speaker == segment.speaker && !seg.isUser ? index : nil
+            seg.speaker == segment.speaker ? index : nil
         }
     }
 
@@ -129,7 +152,7 @@ struct NameSpeakerSheet: View {
                             .scaledFont(size: 12, weight: .semibold)
                             .foregroundColor(OmiColors.textPrimary)
                     )
-                Text("Speaker \(segment.speakerId)")
+                Text(segment.isUser ? "You" : "Speaker \(segment.speakerId)")
                     .scaledFont(size: 14, weight: .medium)
                     .foregroundColor(OmiColors.textPrimary)
             }
@@ -157,10 +180,17 @@ struct NameSpeakerSheet: View {
                 .foregroundColor(OmiColors.textSecondary)
 
             FlowLayout(spacing: 8) {
+                personChip(label: "You", isSelected: selectedTarget == .you) {
+                    selectedTarget = .you
+                    isAddingNewPerson = false
+                    newPersonName = ""
+                    duplicateWarning = nil
+                }
+
                 // Existing people chips
                 ForEach(people) { person in
-                    personChip(label: person.name, isSelected: selectedPersonId == person.id) {
-                        selectedPersonId = person.id
+                    personChip(label: person.name, isSelected: selectedTarget == .person(person.id)) {
+                        selectedTarget = .person(person.id)
                         isAddingNewPerson = false
                         newPersonName = ""
                         duplicateWarning = nil
@@ -170,7 +200,7 @@ struct NameSpeakerSheet: View {
                 // "+ Add Person" chip
                 personChip(label: "+ Add Person", isSelected: isAddingNewPerson, isAction: true) {
                     isAddingNewPerson = true
-                    selectedPersonId = nil
+                    selectedTarget = nil
                     duplicateWarning = nil
                 }
             }
@@ -249,7 +279,7 @@ struct NameSpeakerSheet: View {
     // MARK: - Helpers
 
     private var canSave: Bool {
-        selectedPersonId != nil
+        selectedTarget != nil
     }
 
     private var canCreate: Bool {
@@ -272,7 +302,7 @@ struct NameSpeakerSheet: View {
 
         isCreating = true
         if let person = await onCreatePerson(trimmed) {
-            selectedPersonId = person.id
+            selectedTarget = .person(person.id)
             isAddingNewPerson = false
             newPersonName = ""
         }
@@ -280,9 +310,10 @@ struct NameSpeakerSheet: View {
     }
 
     private func save() {
+        guard let target = selectedTarget else { return }
         isSaving = true
         let segmentIndices = tagAllFromSpeaker ? sameSpeakerIndices : [tappedSegmentIndex]
-        onSave(selectedPersonId, false, segmentIndices)
+        onSave(target.personId, target.isUser, segmentIndices)
     }
 
     private func personChip(label: String, isSelected: Bool, isAction: Bool = false, action: @escaping () -> Void) -> some View {

--- a/Desktop/Sources/MainWindow/Components/NameSpeakerSheet.swift
+++ b/Desktop/Sources/MainWindow/Components/NameSpeakerSheet.swift
@@ -174,95 +174,18 @@ struct NameSpeakerSheet: View {
     // MARK: - People Selection
 
     private var peopleSelectionSection: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Text("Who is this?")
-                .scaledFont(size: 13, weight: .medium)
-                .foregroundColor(OmiColors.textSecondary)
-
-            FlowLayout(spacing: 8) {
-                personChip(label: "You", isSelected: selectedTarget == .you) {
-                    selectedTarget = .you
-                    isAddingNewPerson = false
-                    newPersonName = ""
-                    duplicateWarning = nil
-                }
-
-                // Existing people chips
-                ForEach(people) { person in
-                    personChip(label: person.name, isSelected: selectedTarget == .person(person.id)) {
-                        selectedTarget = .person(person.id)
-                        isAddingNewPerson = false
-                        newPersonName = ""
-                        duplicateWarning = nil
-                    }
-                }
-
-                // "+ Add Person" chip
-                personChip(label: "+ Add Person", isSelected: isAddingNewPerson, isAction: true) {
-                    isAddingNewPerson = true
-                    selectedTarget = nil
-                    duplicateWarning = nil
-                }
-            }
-
-            // Inline text field for new person name
-            if isAddingNewPerson {
-                VStack(alignment: .leading, spacing: 6) {
-                    HStack(spacing: 8) {
-                        TextField("Person name", text: $newPersonName)
-                            .textFieldStyle(.plain)
-                            .scaledFont(size: 13)
-                            .foregroundColor(OmiColors.textPrimary)
-                            .padding(.horizontal, 10)
-                            .padding(.vertical, 8)
-                            .background(
-                                RoundedRectangle(cornerRadius: 8)
-                                    .fill(OmiColors.backgroundSecondary)
-                            )
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 8)
-                                    .stroke(duplicateWarning != nil ? OmiColors.error : OmiColors.border, lineWidth: 1)
-                            )
-                            .onChange(of: newPersonName) { _, newValue in
-                                validateName(newValue)
-                            }
-                            .onSubmit {
-                                if !newPersonName.trimmingCharacters(in: .whitespaces).isEmpty && duplicateWarning == nil {
-                                    Task { await createAndSelect() }
-                                }
-                            }
-
-                        Button(action: {
-                            Task { await createAndSelect() }
-                        }) {
-                            if isCreating {
-                                ProgressView()
-                                    .scaleEffect(0.5)
-                                    .frame(width: 14, height: 14)
-                            } else {
-                                Text("Add")
-                                    .scaledFont(size: 12, weight: .medium)
-                            }
-                        }
-                        .buttonStyle(.plain)
-                        .foregroundColor(canCreate ? .black : OmiColors.textTertiary)
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 6)
-                        .background(
-                            Capsule()
-                                .fill(canCreate ? Color.white : OmiColors.backgroundTertiary)
-                        )
-                        .disabled(!canCreate || isCreating)
-                    }
-
-                    if let warning = duplicateWarning {
-                        Text(warning)
-                            .scaledFont(size: 11)
-                            .foregroundColor(OmiColors.error)
-                    }
-                }
-            }
-        }
+        SpeakerPeopleSelectionSection(
+            people: people,
+            selectedTarget: $selectedTarget,
+            isAddingNewPerson: $isAddingNewPerson,
+            newPersonName: $newPersonName,
+            duplicateWarning: $duplicateWarning,
+            canCreate: canCreate,
+            isCreating: isCreating,
+            showsCreationProgress: true,
+            onNameChange: validateName,
+            onCreate: { Task { await createAndSelect() } }
+        )
     }
 
     // MARK: - Tag Other Segments Toggle
@@ -316,22 +239,4 @@ struct NameSpeakerSheet: View {
         onSave(target.personId, target.isUser, segmentIndices)
     }
 
-    private func personChip(label: String, isSelected: Bool, isAction: Bool = false, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            Text(label)
-                .scaledFont(size: 13, weight: isSelected ? .semibold : .regular)
-                .foregroundColor(isSelected ? .black : (isAction ? OmiColors.purplePrimary : OmiColors.textPrimary))
-                .padding(.horizontal, 14)
-                .padding(.vertical, 8)
-                .background(
-                    Capsule()
-                        .fill(isSelected ? Color.white : OmiColors.backgroundTertiary)
-                )
-                .overlay(
-                    Capsule()
-                        .stroke(isSelected ? OmiColors.border : (isAction ? OmiColors.purplePrimary.opacity(0.3) : Color.clear), lineWidth: 1)
-                )
-        }
-        .buttonStyle(.plain)
-    }
 }

--- a/Desktop/Sources/MainWindow/Components/SpeakerBubbleView.swift
+++ b/Desktop/Sources/MainWindow/Components/SpeakerBubbleView.swift
@@ -46,20 +46,20 @@ struct SpeakerBubbleView: View {
             }
 
             VStack(alignment: isUser ? .trailing : .leading, spacing: 4) {
-                // Speaker label — clickable for non-user speakers
-                if !isUser, let onTap = onSpeakerTapped {
+                // Speaker label
+                if let onTap = onSpeakerTapped {
                     Button(action: onTap) {
                         HStack(spacing: 4) {
                             Text(speakerLabel)
                                 .scaledFont(size: 12, weight: .medium)
-                            if personName == nil {
+                            if personName == nil && !isUser {
                                 Image(systemName: "pencil")
                                     .scaledFont(size: 10)
                             }
                         }
                         .padding(.vertical, 2)
                         .contentShape(Rectangle())
-                        .foregroundColor(personName != nil ? OmiColors.purplePrimary : OmiColors.textTertiary)
+                        .foregroundColor(personName != nil || isUser ? OmiColors.purplePrimary : OmiColors.textTertiary)
                     }
                     .buttonStyle(.plain)
                     .accessibilityIdentifier("transcript_speaker_button_\(segment.id)")
@@ -123,6 +123,28 @@ struct SpeakerBubbleView: View {
     }
 
     private var avatar: some View {
+        Group {
+            if let onSpeakerTapped {
+                Button(action: onSpeakerTapped) {
+                    avatarCircle
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("transcript_speaker_avatar_\(segment.id)")
+                .accessibilityLabel("Change speaker \(speakerLabel)")
+                .onHover { hovering in
+                    if hovering {
+                        NSCursor.pointingHand.push()
+                    } else {
+                        NSCursor.pop()
+                    }
+                }
+            } else {
+                avatarCircle
+            }
+        }
+    }
+
+    private var avatarCircle: some View {
         Circle()
             .fill(isUser ? OmiColors.purplePrimary : (personName != nil ? OmiColors.purplePrimary.opacity(0.3) : OmiColors.backgroundQuaternary))
             .frame(width: 32, height: 32)

--- a/Desktop/Sources/MainWindow/Components/SpeakerIdentificationReviewSheet.swift
+++ b/Desktop/Sources/MainWindow/Components/SpeakerIdentificationReviewSheet.swift
@@ -83,19 +83,7 @@ enum SpeakerReviewQueueBuilder {
     }
 
     static func isNoiseOnly(_ text: String) -> Bool {
-        let lowered = text
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .trimmingCharacters(in: CharacterSet(charactersIn: "()[]{}"))
-            .lowercased()
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !lowered.isEmpty else { return true }
-
-        let noiseWords = [
-            "music", "gentle music", "background music", "noise", "silence",
-            "applause", "laughter", "inaudible", "static", "beep", "tone"
-        ]
-        if noiseWords.contains(lowered) { return true }
-        return noiseWords.contains { lowered == "[\($0)]" || lowered == "(\($0))" }
+        SpeakerContentFilter.isNoiseOnly(text)
     }
 
     private static func suggestedCandidate(
@@ -308,70 +296,18 @@ struct SpeakerIdentificationReviewSheet: View {
     }
 
     private var peopleSelectionSection: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Text("Who is this?")
-                .scaledFont(size: 13, weight: .medium)
-                .foregroundColor(OmiColors.textSecondary)
-
-            FlowLayout(spacing: 8) {
-                personChip(label: "You", isSelected: selectedTarget == .you) {
-                    selectedTarget = .you
-                    isAddingNewPerson = false
-                    newPersonName = ""
-                    duplicateWarning = nil
-                }
-
-                ForEach(people) { person in
-                    personChip(label: person.name, isSelected: selectedTarget == .person(person.id)) {
-                        selectedTarget = .person(person.id)
-                        isAddingNewPerson = false
-                        newPersonName = ""
-                        duplicateWarning = nil
-                    }
-                }
-
-                personChip(label: "+ Add Person", isSelected: isAddingNewPerson, isAction: true) {
-                    isAddingNewPerson = true
-                    selectedTarget = nil
-                    duplicateWarning = nil
-                }
-            }
-
-            if isAddingNewPerson {
-                HStack(spacing: 8) {
-                    TextField("Person name", text: $newPersonName)
-                        .textFieldStyle(.plain)
-                        .scaledFont(size: 13)
-                        .foregroundColor(OmiColors.textPrimary)
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 8)
-                        .background(RoundedRectangle(cornerRadius: 8).fill(OmiColors.backgroundSecondary))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 8)
-                                .stroke(duplicateWarning != nil ? OmiColors.error : OmiColors.border, lineWidth: 1)
-                        )
-                        .onChange(of: newPersonName) { _, value in validateName(value) }
-                        .onSubmit { Task { await createAndSelect() } }
-
-                    Button(action: { Task { await createAndSelect() } }) {
-                        Text(isCreating ? "Adding" : "Add")
-                            .scaledFont(size: 12, weight: .medium)
-                    }
-                    .buttonStyle(.plain)
-                    .foregroundColor(canCreate ? .black : OmiColors.textTertiary)
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 7)
-                    .background(Capsule().fill(canCreate ? Color.white : OmiColors.backgroundTertiary))
-                    .disabled(!canCreate || isCreating)
-                }
-
-                if let duplicateWarning {
-                    Text(duplicateWarning)
-                        .scaledFont(size: 11)
-                        .foregroundColor(OmiColors.error)
-                }
-            }
-        }
+        SpeakerPeopleSelectionSection(
+            people: people,
+            selectedTarget: $selectedTarget,
+            isAddingNewPerson: $isAddingNewPerson,
+            newPersonName: $newPersonName,
+            duplicateWarning: $duplicateWarning,
+            canCreate: canCreate,
+            isCreating: isCreating,
+            showsCreationProgress: false,
+            onNameChange: validateName,
+            onCreate: { Task { await createAndSelect() } }
+        )
     }
 
     private func footer(_ item: SpeakerReviewQueueItem) -> some View {
@@ -509,19 +445,4 @@ struct SpeakerIdentificationReviewSheet: View {
         }
     }
 
-    private func personChip(label: String, isSelected: Bool, isAction: Bool = false, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            Text(label)
-                .scaledFont(size: 13, weight: isSelected ? .semibold : .regular)
-                .foregroundColor(isSelected ? .black : (isAction ? OmiColors.purplePrimary : OmiColors.textPrimary))
-                .padding(.horizontal, 14)
-                .padding(.vertical, 8)
-                .background(Capsule().fill(isSelected ? Color.white : OmiColors.backgroundTertiary))
-                .overlay(
-                    Capsule()
-                        .stroke(isSelected ? OmiColors.border : (isAction ? OmiColors.purplePrimary.opacity(0.3) : Color.clear), lineWidth: 1)
-                )
-        }
-        .buttonStyle(.plain)
-    }
 }

--- a/Desktop/Sources/MainWindow/Components/SpeakerIdentificationReviewSheet.swift
+++ b/Desktop/Sources/MainWindow/Components/SpeakerIdentificationReviewSheet.swift
@@ -22,7 +22,7 @@ struct SpeakerReviewQueueItem: Identifiable, Equatable {
 }
 
 enum SpeakerReviewQueueBuilder {
-    static let minimumReviewableDuration: Double = 1.2
+    static let minimumReviewableDuration: Double = 3.0
     static let minimumSampleDuration: Double = 3.0
     static let maximumSampleDuration: Double = 8.0
 
@@ -124,14 +124,15 @@ enum SpeakerReviewQueueBuilder {
 
     private static func sample(for segment: TranscriptSegment, index: Int) -> SpeakerReviewSample {
         let duration = max(0, segment.end - segment.start)
-        let targetDuration = min(max(duration, minimumSampleDuration), maximumSampleDuration)
+        let targetDuration = min(duration, maximumSampleDuration)
         let midpoint = (segment.start + segment.end) * 0.5
-        let start = max(0, midpoint - targetDuration * 0.5)
+        let start = max(segment.start, midpoint - targetDuration * 0.5)
+        let end = min(segment.end, start + targetDuration)
         return SpeakerReviewSample(
             id: segment.id,
             segmentIndex: index,
             start: start,
-            end: start + targetDuration,
+            end: end,
             text: segment.text
         )
     }
@@ -155,6 +156,7 @@ struct SpeakerIdentificationReviewSheet: View {
     @State private var isSaving = false
     @State private var isCreating = false
     @State private var isLoadingAudio = false
+    @State private var playbackError: String?
     @State private var audioPlayer: AVAudioPlayer?
 
     init(
@@ -287,6 +289,7 @@ struct SpeakerIdentificationReviewSheet: View {
                 Button("Another Sample") {
                     guard let item = currentItem, item.samples.count > 1 else { return }
                     currentSampleIndex = (currentSampleIndex + 1) % item.samples.count
+                    playbackError = nil
                 }
                 .buttonStyle(.plain)
                 .foregroundColor(OmiColors.textSecondary)
@@ -294,6 +297,12 @@ struct SpeakerIdentificationReviewSheet: View {
                 .padding(.vertical, 7)
                 .background(Capsule().fill(OmiColors.backgroundTertiary))
                 .disabled((currentItem?.samples.count ?? 0) < 2)
+            }
+
+            if let playbackError {
+                Text(playbackError)
+                    .scaledFont(size: 11)
+                    .foregroundColor(OmiColors.error)
             }
         }
     }
@@ -469,10 +478,12 @@ struct SpeakerIdentificationReviewSheet: View {
         isAddingNewPerson = false
         newPersonName = ""
         duplicateWarning = nil
+        playbackError = nil
     }
 
     private func playCurrentSample() async {
         guard let sample = currentSample else { return }
+        playbackError = nil
         isLoadingAudio = true
         let data = await AudioPersistenceService.shared.reviewAudioWAV(
             conversationId: conversationId,
@@ -480,14 +491,21 @@ struct SpeakerIdentificationReviewSheet: View {
             endTime: sample.end
         )
         isLoadingAudio = false
-        guard let data, !data.isEmpty else { return }
+        guard let data, !data.isEmpty else {
+            playbackError = "Review audio is missing or expired for this sample."
+            return
+        }
         do {
             let player = try AVAudioPlayer(data: data)
             audioPlayer = player
             player.prepareToPlay()
-            player.play()
+            guard player.play() else {
+                playbackError = "Couldn't start playback for this sample."
+                return
+            }
         } catch {
             logError("Identify Speakers: failed to play review sample", error: error)
+            playbackError = "Couldn't play this sample."
         }
     }
 

--- a/Desktop/Sources/MainWindow/Components/SpeakerIdentificationReviewSheet.swift
+++ b/Desktop/Sources/MainWindow/Components/SpeakerIdentificationReviewSheet.swift
@@ -1,0 +1,509 @@
+import AVFoundation
+import SwiftUI
+
+struct SpeakerReviewSample: Identifiable, Equatable {
+    let id: String
+    let segmentIndex: Int
+    let start: Double
+    let end: Double
+    let text: String
+}
+
+struct SpeakerReviewQueueItem: Identifiable, Equatable {
+    let id: String
+    let speakerKey: String
+    let speakerId: Int
+    let suggestedPersonId: String?
+    let suggestedSimilarity: Double?
+    let segmentIndices: [Int]
+    let samples: [SpeakerReviewSample]
+
+    var isSuggested: Bool { suggestedPersonId != nil }
+}
+
+enum SpeakerReviewQueueBuilder {
+    static let minimumReviewableDuration: Double = 1.2
+    static let minimumSampleDuration: Double = 3.0
+    static let maximumSampleDuration: Double = 8.0
+
+    static func makeQueue(from segments: [TranscriptSegment]) -> [SpeakerReviewQueueItem] {
+        let assignable = segments.enumerated().filter { _, segment in
+            segment.personId == nil && !segment.isUser
+        }
+        let reviewable = assignable.filter { _, segment in
+            isReviewable(segment)
+        }
+        let assignableBySpeaker = Dictionary(grouping: assignable) { _, segment in
+            speakerKey(for: segment)
+        }
+        let reviewableBySpeaker = Dictionary(grouping: reviewable) { _, segment in
+            speakerKey(for: segment)
+        }
+
+        return reviewableBySpeaker.compactMap { key, reviewableEntries in
+            let allEntries = assignableBySpeaker[key] ?? reviewableEntries
+            let sorted = reviewableEntries.sorted { lhs, rhs in
+                let leftDuration = lhs.element.end - lhs.element.start
+                let rightDuration = rhs.element.end - rhs.element.start
+                if leftDuration == rightDuration {
+                    return lhs.element.start < rhs.element.start
+                }
+                return leftDuration > rightDuration
+            }
+            let samples = sorted.prefix(5).map { index, segment in
+                sample(for: segment, index: index)
+            }
+            guard !samples.isEmpty, let first = allEntries.sorted(by: { $0.offset < $1.offset }).first?.element else {
+                return nil
+            }
+            let suggestion = suggestedCandidate(from: allEntries)
+            return SpeakerReviewQueueItem(
+                id: key,
+                speakerKey: key,
+                speakerId: first.speakerId,
+                suggestedPersonId: suggestion?.suggestedPersonId,
+                suggestedSimilarity: suggestion?.suggestedSimilarity,
+                segmentIndices: allEntries.map(\.offset).sorted(),
+                samples: samples
+            )
+        }
+        .sorted { lhs, rhs in
+            if lhs.isSuggested != rhs.isSuggested {
+                return lhs.isSuggested && !rhs.isSuggested
+            }
+            return lhs.speakerId < rhs.speakerId
+        }
+    }
+
+    static func isReviewable(_ segment: TranscriptSegment) -> Bool {
+        let trimmed = segment.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        guard segment.end - segment.start >= minimumReviewableDuration else { return false }
+        return !isNoiseOnly(trimmed)
+    }
+
+    static func isNoiseOnly(_ text: String) -> Bool {
+        let lowered = text
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "()[]{}"))
+            .lowercased()
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !lowered.isEmpty else { return true }
+
+        let noiseWords = [
+            "music", "gentle music", "background music", "noise", "silence",
+            "applause", "laughter", "inaudible", "static", "beep", "tone"
+        ]
+        if noiseWords.contains(lowered) { return true }
+        return noiseWords.contains { lowered == "[\($0)]" || lowered == "(\($0))" }
+    }
+
+    private static func suggestedCandidate(
+        from entries: [(offset: Int, element: TranscriptSegment)]
+    ) -> TranscriptSegment? {
+        entries
+            .filter { $0.element.suggestedPersonId != nil }
+            .sorted { lhs, rhs in
+                let leftSimilarity = lhs.element.suggestedSimilarity ?? -Double.infinity
+                let rightSimilarity = rhs.element.suggestedSimilarity ?? -Double.infinity
+                if leftSimilarity == rightSimilarity {
+                    return lhs.offset < rhs.offset
+                }
+                return leftSimilarity > rightSimilarity
+            }
+            .first?
+            .element
+    }
+
+    private static func speakerKey(for segment: TranscriptSegment) -> String {
+        if let speaker = segment.speaker, !speaker.isEmpty {
+            return speaker
+        }
+        return String(format: "SPEAKER_%02d", segment.speakerId)
+    }
+
+    private static func sample(for segment: TranscriptSegment, index: Int) -> SpeakerReviewSample {
+        let duration = max(0, segment.end - segment.start)
+        let targetDuration = min(max(duration, minimumSampleDuration), maximumSampleDuration)
+        let midpoint = (segment.start + segment.end) * 0.5
+        let start = max(0, midpoint - targetDuration * 0.5)
+        return SpeakerReviewSample(
+            id: segment.id,
+            segmentIndex: index,
+            start: start,
+            end: start + targetDuration,
+            text: segment.text
+        )
+    }
+}
+
+struct SpeakerIdentificationReviewSheet: View {
+    let conversationId: String
+    let segments: [TranscriptSegment]
+    let people: [Person]
+    let onAssign: (_ segmentIndices: [Int], _ personId: String?, _ isUser: Bool) async -> Bool
+    let onCreatePerson: (_ name: String) async -> Person?
+    let onDismiss: () -> Void
+
+    @State private var queue: [SpeakerReviewQueueItem]
+    @State private var currentIndex = 0
+    @State private var currentSampleIndex = 0
+    @State private var selectedTarget: SpeakerAssignmentTarget?
+    @State private var isAddingNewPerson = false
+    @State private var newPersonName = ""
+    @State private var duplicateWarning: String?
+    @State private var isSaving = false
+    @State private var isCreating = false
+    @State private var isLoadingAudio = false
+    @State private var audioPlayer: AVAudioPlayer?
+
+    init(
+        conversationId: String,
+        segments: [TranscriptSegment],
+        people: [Person],
+        onAssign: @escaping (_ segmentIndices: [Int], _ personId: String?, _ isUser: Bool) async -> Bool,
+        onCreatePerson: @escaping (_ name: String) async -> Person?,
+        onDismiss: @escaping () -> Void
+    ) {
+        self.conversationId = conversationId
+        self.segments = segments
+        self.people = people
+        self.onAssign = onAssign
+        self.onCreatePerson = onCreatePerson
+        self.onDismiss = onDismiss
+        _queue = State(initialValue: SpeakerReviewQueueBuilder.makeQueue(from: segments))
+    }
+
+    private var currentItem: SpeakerReviewQueueItem? {
+        guard queue.indices.contains(currentIndex) else { return nil }
+        return queue[currentIndex]
+    }
+
+    private var currentSample: SpeakerReviewSample? {
+        guard let item = currentItem, item.samples.indices.contains(currentSampleIndex) else { return nil }
+        return item.samples[currentSampleIndex]
+    }
+
+    private var canSave: Bool {
+        selectedTarget != nil && !isSaving
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            Divider().background(OmiColors.border)
+
+            if let item = currentItem {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 18) {
+                        speakerSummary(item)
+                        sampleSection
+                        peopleSelectionSection
+                    }
+                    .padding(20)
+                }
+                footer(item)
+            } else {
+                emptyState
+            }
+        }
+        .frame(width: 460, height: 560)
+        .background(OmiColors.backgroundPrimary)
+        .onAppear(perform: resetSelectionForCurrentSpeaker)
+    }
+
+    private var header: some View {
+        HStack {
+            Text("Identify Speakers")
+                .scaledFont(size: 16, weight: .semibold)
+                .foregroundColor(OmiColors.textPrimary)
+            Spacer()
+            if !queue.isEmpty {
+                Text("\(currentIndex + 1) of \(queue.count)")
+                    .scaledFont(size: 12, weight: .medium)
+                    .foregroundColor(OmiColors.textTertiary)
+            }
+            DismissButton(action: onDismiss)
+        }
+        .padding(.horizontal, 20)
+        .padding(.top, 20)
+        .padding(.bottom, 12)
+    }
+
+    private func speakerSummary(_ item: SpeakerReviewQueueItem) -> some View {
+        HStack(spacing: 10) {
+            Circle()
+                .fill(item.isSuggested ? OmiColors.purplePrimary.opacity(0.28) : OmiColors.backgroundQuaternary)
+                .frame(width: 34, height: 34)
+                .overlay(
+                    Text(String(item.speakerId))
+                        .scaledFont(size: 13, weight: .semibold)
+                        .foregroundColor(OmiColors.textPrimary)
+                )
+            VStack(alignment: .leading, spacing: 3) {
+                Text("Speaker \(item.speakerId)")
+                    .scaledFont(size: 14, weight: .semibold)
+                    .foregroundColor(OmiColors.textPrimary)
+                Text(item.isSuggested ? "Suggested match needs review" : "Unknown speaker")
+                    .scaledFont(size: 12)
+                    .foregroundColor(OmiColors.textSecondary)
+            }
+            Spacer()
+        }
+        .padding(12)
+        .background(RoundedRectangle(cornerRadius: 10).fill(OmiColors.backgroundSecondary))
+    }
+
+    private var sampleSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Sample")
+                .scaledFont(size: 13, weight: .medium)
+                .foregroundColor(OmiColors.textSecondary)
+
+            Text(currentSample?.text ?? "")
+                .scaledFont(size: 13)
+                .foregroundColor(OmiColors.textPrimary)
+                .lineLimit(4)
+                .padding(12)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(RoundedRectangle(cornerRadius: 10).fill(OmiColors.backgroundSecondary))
+
+            HStack(spacing: 8) {
+                Button(action: { Task { await playCurrentSample() } }) {
+                    HStack(spacing: 6) {
+                        Image(systemName: isLoadingAudio ? "hourglass" : "play.fill")
+                            .scaledFont(size: 11, weight: .semibold)
+                        Text("Play")
+                            .scaledFont(size: 12, weight: .medium)
+                    }
+                    .foregroundColor(.black)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 7)
+                    .background(Capsule().fill(Color.white))
+                }
+                .buttonStyle(.plain)
+                .disabled(isLoadingAudio || currentSample == nil)
+
+                Button("Another Sample") {
+                    guard let item = currentItem, item.samples.count > 1 else { return }
+                    currentSampleIndex = (currentSampleIndex + 1) % item.samples.count
+                }
+                .buttonStyle(.plain)
+                .foregroundColor(OmiColors.textSecondary)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 7)
+                .background(Capsule().fill(OmiColors.backgroundTertiary))
+                .disabled((currentItem?.samples.count ?? 0) < 2)
+            }
+        }
+    }
+
+    private var peopleSelectionSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Who is this?")
+                .scaledFont(size: 13, weight: .medium)
+                .foregroundColor(OmiColors.textSecondary)
+
+            FlowLayout(spacing: 8) {
+                personChip(label: "You", isSelected: selectedTarget == .you) {
+                    selectedTarget = .you
+                    isAddingNewPerson = false
+                    newPersonName = ""
+                    duplicateWarning = nil
+                }
+
+                ForEach(people) { person in
+                    personChip(label: person.name, isSelected: selectedTarget == .person(person.id)) {
+                        selectedTarget = .person(person.id)
+                        isAddingNewPerson = false
+                        newPersonName = ""
+                        duplicateWarning = nil
+                    }
+                }
+
+                personChip(label: "+ Add Person", isSelected: isAddingNewPerson, isAction: true) {
+                    isAddingNewPerson = true
+                    selectedTarget = nil
+                    duplicateWarning = nil
+                }
+            }
+
+            if isAddingNewPerson {
+                HStack(spacing: 8) {
+                    TextField("Person name", text: $newPersonName)
+                        .textFieldStyle(.plain)
+                        .scaledFont(size: 13)
+                        .foregroundColor(OmiColors.textPrimary)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 8)
+                        .background(RoundedRectangle(cornerRadius: 8).fill(OmiColors.backgroundSecondary))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(duplicateWarning != nil ? OmiColors.error : OmiColors.border, lineWidth: 1)
+                        )
+                        .onChange(of: newPersonName) { _, value in validateName(value) }
+                        .onSubmit { Task { await createAndSelect() } }
+
+                    Button(action: { Task { await createAndSelect() } }) {
+                        Text(isCreating ? "Adding" : "Add")
+                            .scaledFont(size: 12, weight: .medium)
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundColor(canCreate ? .black : OmiColors.textTertiary)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 7)
+                    .background(Capsule().fill(canCreate ? Color.white : OmiColors.backgroundTertiary))
+                    .disabled(!canCreate || isCreating)
+                }
+
+                if let duplicateWarning {
+                    Text(duplicateWarning)
+                        .scaledFont(size: 11)
+                        .foregroundColor(OmiColors.error)
+                }
+            }
+        }
+    }
+
+    private func footer(_ item: SpeakerReviewQueueItem) -> some View {
+        VStack(spacing: 0) {
+            Divider().background(OmiColors.border)
+            HStack {
+                Button("Skip") {
+                    skipCurrent()
+                }
+                .buttonStyle(.plain)
+                .foregroundColor(OmiColors.textSecondary)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 8)
+
+                Spacer()
+
+                Button(action: { Task { await saveCurrent(item) } }) {
+                    Text(isSaving ? "Saving" : "Confirm")
+                        .scaledFont(size: 12, weight: .medium)
+                }
+                .buttonStyle(.plain)
+                .foregroundColor(canSave ? .black : OmiColors.textTertiary)
+                .padding(.horizontal, 18)
+                .padding(.vertical, 8)
+                .background(Capsule().fill(canSave ? Color.white : OmiColors.backgroundTertiary))
+                .disabled(!canSave)
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 14)
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Spacer()
+            Image(systemName: "person.2.wave.2")
+                .scaledFont(size: 36)
+                .foregroundColor(OmiColors.textTertiary.opacity(0.7))
+            Text("No speakers need review")
+                .scaledFont(size: 14, weight: .medium)
+                .foregroundColor(OmiColors.textSecondary)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var canCreate: Bool {
+        let trimmed = newPersonName.trimmingCharacters(in: .whitespacesAndNewlines)
+        return !trimmed.isEmpty && duplicateWarning == nil
+    }
+
+    private func validateName(_ name: String) {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        duplicateWarning = people.contains { $0.name.lowercased() == trimmed.lowercased() }
+            ? "A person with this name already exists"
+            : nil
+    }
+
+    private func createAndSelect() async {
+        guard canCreate else { return }
+        isCreating = true
+        let trimmed = newPersonName.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let person = await onCreatePerson(trimmed) {
+            selectedTarget = .person(person.id)
+            isAddingNewPerson = false
+            newPersonName = ""
+        }
+        isCreating = false
+    }
+
+    private func saveCurrent(_ item: SpeakerReviewQueueItem) async {
+        guard let target = selectedTarget else { return }
+        isSaving = true
+        let success = await onAssign(item.segmentIndices, target.personId, target.isUser)
+        isSaving = false
+        if success {
+            queue.remove(at: currentIndex)
+            if currentIndex >= queue.count {
+                currentIndex = max(0, queue.count - 1)
+            }
+            resetSelectionForCurrentSpeaker()
+            if queue.isEmpty {
+                onDismiss()
+            }
+        }
+    }
+
+    private func skipCurrent() {
+        guard !queue.isEmpty else { return }
+        queue.remove(at: currentIndex)
+        if currentIndex >= queue.count {
+            currentIndex = max(0, queue.count - 1)
+        }
+        if queue.isEmpty {
+            onDismiss()
+            return
+        }
+        resetSelectionForCurrentSpeaker()
+    }
+
+    private func resetSelectionForCurrentSpeaker() {
+        currentSampleIndex = 0
+        selectedTarget = currentItem?.suggestedPersonId.map { .person($0) }
+        isAddingNewPerson = false
+        newPersonName = ""
+        duplicateWarning = nil
+    }
+
+    private func playCurrentSample() async {
+        guard let sample = currentSample else { return }
+        isLoadingAudio = true
+        let data = await AudioPersistenceService.shared.reviewAudioWAV(
+            conversationId: conversationId,
+            startTime: sample.start,
+            endTime: sample.end
+        )
+        isLoadingAudio = false
+        guard let data, !data.isEmpty else { return }
+        do {
+            let player = try AVAudioPlayer(data: data)
+            audioPlayer = player
+            player.prepareToPlay()
+            player.play()
+        } catch {
+            logError("Identify Speakers: failed to play review sample", error: error)
+        }
+    }
+
+    private func personChip(label: String, isSelected: Bool, isAction: Bool = false, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(label)
+                .scaledFont(size: 13, weight: isSelected ? .semibold : .regular)
+                .foregroundColor(isSelected ? .black : (isAction ? OmiColors.purplePrimary : OmiColors.textPrimary))
+                .padding(.horizontal, 14)
+                .padding(.vertical, 8)
+                .background(Capsule().fill(isSelected ? Color.white : OmiColors.backgroundTertiary))
+                .overlay(
+                    Capsule()
+                        .stroke(isSelected ? OmiColors.border : (isAction ? OmiColors.purplePrimary.opacity(0.3) : Color.clear), lineWidth: 1)
+                )
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/Desktop/Sources/MainWindow/Components/SpeakerPeopleSelectionSection.swift
+++ b/Desktop/Sources/MainWindow/Components/SpeakerPeopleSelectionSection.swift
@@ -1,0 +1,127 @@
+import SwiftUI
+
+struct SpeakerPeopleSelectionSection: View {
+    let people: [Person]
+    @Binding var selectedTarget: SpeakerAssignmentTarget?
+    @Binding var isAddingNewPerson: Bool
+    @Binding var newPersonName: String
+    @Binding var duplicateWarning: String?
+    let canCreate: Bool
+    let isCreating: Bool
+    let showsCreationProgress: Bool
+    let onNameChange: (String) -> Void
+    let onCreate: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Who is this?")
+                .scaledFont(size: 13, weight: .medium)
+                .foregroundColor(OmiColors.textSecondary)
+
+            FlowLayout(spacing: 8) {
+                personChip(label: "You", isSelected: selectedTarget == .you) {
+                    select(.you)
+                }
+
+                ForEach(people) { person in
+                    personChip(label: person.name, isSelected: selectedTarget == .person(person.id)) {
+                        select(.person(person.id))
+                    }
+                }
+
+                personChip(label: "+ Add Person", isSelected: isAddingNewPerson, isAction: true) {
+                    isAddingNewPerson = true
+                    selectedTarget = nil
+                    duplicateWarning = nil
+                }
+            }
+
+            if isAddingNewPerson {
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack(spacing: 8) {
+                        TextField("Person name", text: $newPersonName)
+                            .textFieldStyle(.plain)
+                            .scaledFont(size: 13)
+                            .foregroundColor(OmiColors.textPrimary)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 8)
+                            .background(RoundedRectangle(cornerRadius: 8).fill(OmiColors.backgroundSecondary))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .stroke(duplicateWarning != nil ? OmiColors.error : OmiColors.border, lineWidth: 1)
+                            )
+                            .onChange(of: newPersonName) { _, value in onNameChange(value) }
+                            .onSubmit {
+                                if canCreate {
+                                    onCreate()
+                                }
+                            }
+
+                        Button(action: onCreate) {
+                            if isCreating && showsCreationProgress {
+                                ProgressView()
+                                    .scaleEffect(0.5)
+                                    .frame(width: 14, height: 14)
+                            } else {
+                                Text(isCreating ? "Adding" : "Add")
+                                    .scaledFont(size: 12, weight: .medium)
+                            }
+                        }
+                        .buttonStyle(.plain)
+                        .foregroundColor(canCreate ? .black : OmiColors.textTertiary)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 7)
+                        .background(Capsule().fill(canCreate ? Color.white : OmiColors.backgroundTertiary))
+                        .disabled(!canCreate || isCreating)
+                    }
+
+                    if let duplicateWarning {
+                        Text(duplicateWarning)
+                            .scaledFont(size: 11)
+                            .foregroundColor(OmiColors.error)
+                    }
+                }
+            }
+        }
+    }
+
+    private func select(_ target: SpeakerAssignmentTarget) {
+        selectedTarget = target
+        isAddingNewPerson = false
+        newPersonName = ""
+        duplicateWarning = nil
+    }
+
+    private func personChip(
+        label: String,
+        isSelected: Bool,
+        isAction: Bool = false,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Text(label)
+                .scaledFont(size: 13, weight: isSelected ? .semibold : .regular)
+                .foregroundColor(chipForegroundColor(isSelected: isSelected, isAction: isAction))
+                .padding(.horizontal, 14)
+                .padding(.vertical, 8)
+                .background(Capsule().fill(isSelected ? Color.white : OmiColors.backgroundTertiary))
+                .overlay(
+                    Capsule()
+                        .stroke(chipBorderColor(isSelected: isSelected, isAction: isAction), lineWidth: 1)
+                )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func chipForegroundColor(isSelected: Bool, isAction: Bool) -> Color {
+        if isSelected { return .black }
+        if isAction { return OmiColors.purplePrimary }
+        return OmiColors.textPrimary
+    }
+
+    private func chipBorderColor(isSelected: Bool, isAction: Bool) -> Color {
+        if isSelected { return OmiColors.border }
+        if isAction { return OmiColors.purplePrimary.opacity(0.3) }
+        return .clear
+    }
+}

--- a/Desktop/Sources/MainWindow/Components/TranscriptDetailView.swift
+++ b/Desktop/Sources/MainWindow/Components/TranscriptDetailView.swift
@@ -14,7 +14,7 @@ struct TranscriptDetailView: View {
                         segment: segment,
                         isUser: segment.isUser,
                         personName: segment.personId.flatMap { peopleById[$0]?.name },
-                        onSpeakerTapped: segment.isUser ? nil : (onSpeakerTapped != nil ? { onSpeakerTapped?(segment) } : nil)
+                        onSpeakerTapped: onSpeakerTapped != nil ? { onSpeakerTapped?(segment) } : nil
                     )
                 }
             }

--- a/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -21,6 +21,9 @@ struct DesktopHomeView: View {
     let tier = UserDefaults.standard.integer(forKey: "currentTierLevel")
     return SidebarNavItem.dashboard.rawValue
   }()
+  @State private var selectedConversation: ServerConversation? = nil
+  @State private var autoOpenIdentifySpeakersConversationId: String? = nil
+  @State private var pendingLocalSpeakerReviewSessionIds: Set<Int64> = []
   @State private var isSidebarCollapsed: Bool = false
   @AppStorage("currentTierLevel") private var currentTierLevel = 0
   @AppStorage("onboardingStep") private var onboardingStep = 0
@@ -598,6 +601,141 @@ struct DesktopHomeView: View {
       index == SidebarNavItem.memories.rawValue
   }
 
+  private func handleCompletedConversationMayNeedSpeakerReview(_ notification: Notification) {
+    guard let conversationId = notification.userInfo?["conversationId"] as? String,
+      !conversationId.isEmpty
+    else { return }
+
+    let sessionId = notificationSessionId(from: notification)
+    Task {
+      await appState.loadConversations()
+
+      let conversation: ServerConversation?
+      if let sessionId {
+        if let localConversation = await conversationForSpeakerReviewIfNeeded(sessionId: sessionId) {
+          conversation = localConversation
+        } else {
+          conversation = await conversationForSpeakerReviewIfNeeded(conversationId: conversationId)
+        }
+      } else {
+        conversation = await conversationForSpeakerReviewIfNeeded(conversationId: conversationId)
+      }
+
+      guard let conversation else { return }
+      await MainActor.run {
+        presentConversationForSpeakerReview(conversation)
+      }
+    }
+  }
+
+  private func handleLocalConversationAwaitingSpeakerReviewTranscriptSegments(
+    _ notification: Notification
+  ) {
+    guard let sessionId = notificationSessionId(from: notification) else { return }
+    pendingLocalSpeakerReviewSessionIds.insert(sessionId)
+  }
+
+  private func handleConversationsListNeedsRefreshForPendingSpeakerReview(_ notification: Notification) {
+    guard let sessionId = notificationSessionId(from: notification),
+      pendingLocalSpeakerReviewSessionIds.contains(sessionId)
+    else { return }
+
+    Task {
+      await appState.loadConversations()
+      let conversation = await conversationForSpeakerReviewIfNeeded(sessionId: sessionId)
+      await MainActor.run {
+        pendingLocalSpeakerReviewSessionIds.remove(sessionId)
+        guard let conversation else { return }
+        presentConversationForSpeakerReview(conversation)
+      }
+    }
+  }
+
+  private func presentConversationForSpeakerReview(_ conversation: ServerConversation) {
+    autoOpenIdentifySpeakersConversationId = conversation.id
+    selectedConversation = conversation
+    withAnimation(.easeInOut(duration: 0.2)) {
+      selectedIndex = SidebarNavItem.conversations.rawValue
+    }
+  }
+
+  private func conversationForSpeakerReviewIfNeeded(sessionId: Int64) async -> ServerConversation? {
+    do {
+      guard let session = try await TranscriptionStorage.shared.getSession(id: sessionId),
+        let rowId = session.id
+      else { return nil }
+
+      let segmentRecords = try await TranscriptionStorage.shared.getSegments(sessionId: rowId)
+      let segments = segmentRecords.map { $0.toTranscriptSegment() }
+      guard !SpeakerReviewQueueBuilder.makeQueue(from: segments).isEmpty else { return nil }
+
+      let conversationId = session.backendId ?? "local-\(rowId)"
+      if var conversation = appState.conversations.first(where: { $0.id == conversationId }) {
+        conversation.transcriptSegments = segments
+        return conversation
+      }
+
+      return session.toServerConversation(segments: segmentRecords)
+    } catch {
+      logError("DesktopHomeView: Failed to load local conversation for speaker review", error: error)
+      return nil
+    }
+  }
+
+  private func conversationForSpeakerReviewIfNeeded(conversationId: String) async -> ServerConversation? {
+    guard var conversation = appState.conversations.first(where: { $0.id == conversationId }) else {
+      return nil
+    }
+
+    if conversation.transcriptSegments.isEmpty,
+      let segments = await loadTranscriptSegments(for: conversation)
+    {
+      conversation.transcriptSegments = segments
+    }
+
+    guard !SpeakerReviewQueueBuilder.makeQueue(from: conversation.transcriptSegments).isEmpty else {
+      return nil
+    }
+
+    return conversation
+  }
+
+  private func loadTranscriptSegments(for conversation: ServerConversation) async -> [TranscriptSegment]? {
+    do {
+      let session: TranscriptionSessionRecord?
+      if conversation.id.hasPrefix("local-"),
+        let rowId = Int64(conversation.id.dropFirst("local-".count))
+      {
+        session = try await TranscriptionStorage.shared.getSession(id: rowId)
+      } else {
+        session = try await TranscriptionStorage.shared.getSessionByBackendId(conversation.id)
+      }
+
+      guard let session, let sessionRowId = session.id else { return nil }
+      return try await TranscriptionStorage.shared.getSegments(sessionId: sessionRowId)
+        .map { $0.toTranscriptSegment() }
+    } catch {
+      logError("DesktopHomeView: Failed to load transcript segments for speaker review", error: error)
+      return nil
+    }
+  }
+
+  private func notificationSessionId(from notification: Notification) -> Int64? {
+    guard let userInfo = notification.userInfo else { return nil }
+    for key in ["sessionId", "session_id"] {
+      if let value = userInfo[key] as? Int64 {
+        return value
+      }
+      if let value = userInfo[key] as? Int {
+        return Int64(value)
+      }
+      if let value = userInfo[key] as? String, let parsed = Int64(value) {
+        return parsed
+      }
+    }
+    return nil
+  }
+
   private var mainContent: some View {
     HStack(spacing: 0) {
       // Sidebar slot: settings sidebar overlays main sidebar
@@ -660,7 +798,9 @@ struct DesktopHomeView: View {
           viewModelContainer: viewModelContainer,
           selectedSettingsSection: $selectedSettingsSection,
           highlightedSettingId: $highlightedSettingId,
-          selectedTabIndex: $selectedIndex
+          selectedTabIndex: $selectedIndex,
+          selectedConversation: $selectedConversation,
+          autoOpenIdentifySpeakersConversationId: $autoOpenIdentifySpeakersConversationId
         )
         .id(selectedIndex)
         .transition(.opacity.combined(with: .move(edge: .trailing)))
@@ -696,6 +836,14 @@ struct DesktopHomeView: View {
     .onReceive(NotificationCenter.default.publisher(for: .showTryAskingPopup)) { _ in
       showTryAskingPopup = true
     }
+    .modifier(
+      SpeakerReviewNavigationNotifications(
+        onCompletedConversationMayNeedReview: handleCompletedConversationMayNeedSpeakerReview,
+        onLocalConversationAwaitingSegments:
+          handleLocalConversationAwaitingSpeakerReviewTranscriptSegments,
+        onConversationsListNeedsRefresh: handleConversationsListNeedsRefreshForPendingSpeakerReview
+      )
+    )
     .onReceive(NotificationCenter.default.publisher(for: .navigateToRewindSettings)) { _ in
       // Set the section directly and navigate to settings
       selectedSettingsSection = .rewind
@@ -785,6 +933,30 @@ struct DesktopHomeView: View {
   }
 }
 
+private struct SpeakerReviewNavigationNotifications: ViewModifier {
+  let onCompletedConversationMayNeedReview: (Notification) -> Void
+  let onLocalConversationAwaitingSegments: (Notification) -> Void
+  let onConversationsListNeedsRefresh: (Notification) -> Void
+
+  func body(content: Content) -> some View {
+    content
+      .onReceive(NotificationCenter.default.publisher(for: .completedConversationMayNeedSpeakerReview)) {
+        notification in
+        onCompletedConversationMayNeedReview(notification)
+      }
+      .onReceive(
+        NotificationCenter.default.publisher(
+          for: .localConversationAwaitingSpeakerReviewTranscriptSegments)
+      ) { notification in
+        onLocalConversationAwaitingSegments(notification)
+      }
+      .onReceive(NotificationCenter.default.publisher(for: .conversationsListNeedsRefresh)) {
+        notification in
+        onConversationsListNeedsRefresh(notification)
+      }
+  }
+}
+
 /// Isolated page content switch — does NOT observe AppState or ViewModelContainer
 /// as @ObservedObject, so pages like TasksPage won't re-render when unrelated
 /// AppState properties (conversations, permissions, etc.) change.
@@ -795,6 +967,8 @@ private struct PageContentView: View {
   @Binding var selectedSettingsSection: SettingsContentView.SettingsSection
   @Binding var highlightedSettingId: String?
   @Binding var selectedTabIndex: Int
+  @Binding var selectedConversation: ServerConversation?
+  @Binding var autoOpenIdentifySpeakersConversationId: String?
 
   var body: some View {
     let _ = log("RENDER: PageContentView body evaluated (index=\(selectedIndex))")
@@ -808,7 +982,10 @@ private struct PageContentView: View {
           chatProvider: viewModelContainer.chatProvider,
           selectedIndex: $selectedTabIndex)
       case 1:
-        ConversationsPageHost(appState: appState)
+        ConversationsPageHost(
+          appState: appState,
+          selectedConversation: $selectedConversation,
+          autoOpenIdentifySpeakersConversationId: $autoOpenIdentifySpeakersConversationId)
       case 2:
         ChatPage(
           appProvider: viewModelContainer.appProvider, chatProvider: viewModelContainer.chatProvider
@@ -861,10 +1038,14 @@ private struct PageContentView: View {
 /// so tapping a row navigates to the detail view.
 private struct ConversationsPageHost: View {
   let appState: AppState
-  @State private var selectedConversation: ServerConversation? = nil
+  @Binding var selectedConversation: ServerConversation?
+  @Binding var autoOpenIdentifySpeakersConversationId: String?
 
   var body: some View {
-    ConversationsPage(appState: appState, selectedConversation: $selectedConversation)
+    ConversationsPage(
+      appState: appState,
+      selectedConversation: $selectedConversation,
+      autoOpenIdentifySpeakersConversationId: $autoOpenIdentifySpeakersConversationId)
   }
 }
 

--- a/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
+++ b/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 /// Full detail view for a single conversation
 struct ConversationDetailView: View {
     let conversation: ServerConversation
+    var autoOpenIdentifySpeakers = false
+    var onAutoOpenIdentifySpeakersHandled: (() -> Void)?
     let onBack: () -> Void
     var folders: [Folder] = []
     var onMoveToFolder: ((String, String?) async -> Void)?
@@ -40,6 +42,8 @@ struct ConversationDetailView: View {
 
     // Speaker naming state
     @State private var selectedSegmentForNaming: TranscriptSegment? = nil
+    @State private var showIdentifySpeakers = false
+    @State private var didAutoPromptIdentifySpeakers = false
 
     static func assignmentMetadata(
         for segmentIndices: [Int],
@@ -199,6 +203,7 @@ struct ConversationDetailView: View {
                         updatedConversation.transcriptSegments = segments
                         loadedConversation = updatedConversation
                         log("ConversationDetail: Loaded \(segments.count) segments from local database")
+                        autoPromptIdentifySpeakersIfNeeded(segments)
                     } else {
                         log("ConversationDetail: No local session for \(conversation.id) — leaving empty")
                     }
@@ -206,6 +211,8 @@ struct ConversationDetailView: View {
                     logError("ConversationDetail: Failed to load conversation segments", error: error)
                 }
                 isLoadingConversation = false
+            } else {
+                autoPromptIdentifySpeakersIfNeeded(conversation.transcriptSegments)
             }
         }
         .onReceive(
@@ -217,6 +224,10 @@ struct ConversationDetailView: View {
             withAnimation(.easeInOut(duration: 0.2)) {
                 showTranscriptDrawer = true
             }
+        }
+        .onChange(of: autoOpenIdentifySpeakers) { _, shouldAutoOpen in
+            guard shouldAutoOpen else { return }
+            autoPromptIdentifySpeakersIfNeeded(displayConversation.transcriptSegments)
         }
         .dismissableSheet(isPresented: $showAppSelector) {
             AppSelectorSheet(
@@ -267,6 +278,46 @@ struct ConversationDetailView: View {
                 },
                 onDismiss: {
                     selectedSegmentForNaming = nil
+                }
+            )
+        }
+        .dismissableSheet(isPresented: $showIdentifySpeakers) {
+            SpeakerIdentificationReviewSheet(
+                conversationId: conversation.id,
+                segments: displayConversation.transcriptSegments,
+                people: people,
+                onAssign: { segmentIndices, personId, isUser in
+                    let assignment = Self.assignmentMetadata(
+                        for: segmentIndices,
+                        in: displayConversation.transcriptSegments
+                    )
+                    let success = await onAssignSpeaker?(
+                        conversation.id,
+                        assignment.targets,
+                        personId,
+                        isUser
+                    ) ?? false
+                    if success {
+                        await persistSpeakerAssignment(
+                            conversationId: conversation.id,
+                            backendSegmentIds: assignment.backendIds,
+                            fallbackSegmentOrders: assignment.fallbackOrders,
+                            isUser: isUser,
+                            personId: personId
+                        )
+                        updateDisplayedConversation(
+                            segmentIndices: segmentIndices,
+                            isUser: isUser,
+                            personId: personId
+                        )
+                    }
+                    return success
+                },
+                onCreatePerson: { name in
+                    await onCreatePerson?(name)
+                },
+                onDismiss: {
+                    showIdentifySpeakers = false
                 }
             )
         }
@@ -679,6 +730,23 @@ struct ConversationDetailView: View {
 
                 Spacer()
 
+                if hasSpeakersNeedingReview {
+                    Button(action: { showIdentifySpeakers = true }) {
+                        HStack(spacing: 6) {
+                            Image(systemName: "person.wave.2")
+                                .scaledFont(size: 12)
+                            Text("Identify")
+                                .scaledFont(size: 12, weight: .medium)
+                        }
+                        .foregroundColor(OmiColors.purplePrimary)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 6)
+                        .background(Capsule().fill(OmiColors.purplePrimary.opacity(0.15)))
+                    }
+                    .buttonStyle(.plain)
+                    .help("Identify speakers")
+                }
+
                 // Copy button
                 Button(action: copyTranscript) {
                     Image(systemName: "doc.on.doc")
@@ -765,12 +833,24 @@ struct ConversationDetailView: View {
                 segment: segment,
                 isUser: segment.isUser,
                 personName: segment.personId.flatMap { peopleDict[$0]?.name },
-                onSpeakerTapped: segment.isUser ? nil : {
+                onSpeakerTapped: {
                     selectedSegmentForNaming = segment
                 }
             )
             .padding(.horizontal, 16)
         }
+    }
+
+    private var hasSpeakersNeedingReview: Bool {
+        !SpeakerReviewQueueBuilder.makeQueue(from: displayConversation.transcriptSegments).isEmpty
+    }
+
+    private func autoPromptIdentifySpeakersIfNeeded(_ segments: [TranscriptSegment]) {
+        guard autoOpenIdentifySpeakers, !didAutoPromptIdentifySpeakers else { return }
+        didAutoPromptIdentifySpeakers = true
+        defer { onAutoOpenIdentifySpeakersHandled?() }
+        guard !SpeakerReviewQueueBuilder.makeQueue(from: segments).isEmpty else { return }
+        showIdentifySpeakers = true
     }
 
     @MainActor

--- a/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
+++ b/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
@@ -847,9 +847,14 @@ struct ConversationDetailView: View {
 
     private func autoPromptIdentifySpeakersIfNeeded(_ segments: [TranscriptSegment]) {
         guard autoOpenIdentifySpeakers, !didAutoPromptIdentifySpeakers else { return }
+        guard !SpeakerReviewQueueBuilder.makeQueue(from: segments).isEmpty else {
+            if !segments.isEmpty {
+                onAutoOpenIdentifySpeakersHandled?()
+            }
+            return
+        }
         didAutoPromptIdentifySpeakers = true
         defer { onAutoOpenIdentifySpeakersHandled?() }
-        guard !SpeakerReviewQueueBuilder.makeQueue(from: segments).isEmpty else { return }
         showIdentifySpeakers = true
     }
 

--- a/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
+++ b/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
@@ -60,6 +60,7 @@ struct ConversationsPage: View {
   @State private var showMergeConfirmation: Bool = false
   @State private var isMerging: Bool = false
   @State private var mergeError: String? = nil
+  @State private var autoOpenIdentifySpeakersConversationId: String? = nil
 
   var body: some View {
     Group {
@@ -67,6 +68,12 @@ struct ConversationsPage: View {
         // Detail view for selected conversation
         ConversationDetailView(
           conversation: selected,
+          autoOpenIdentifySpeakers: autoOpenIdentifySpeakersConversationId == selected.id,
+          onAutoOpenIdentifySpeakersHandled: {
+            if autoOpenIdentifySpeakersConversationId == selected.id {
+              autoOpenIdentifySpeakersConversationId = nil
+            }
+          },
           onBack: { selectedConversation = nil },
           folders: appState.folders,
           onMoveToFolder: { conversationId, folderId in
@@ -136,6 +143,10 @@ struct ConversationsPage: View {
       // Re-fetch so the list shows the latest data.
       Task { await appState.loadConversations() }
     }
+    .onReceive(NotificationCenter.default.publisher(for: .completedConversationMayNeedSpeakerReview)) {
+      notification in
+      handleCompletedConversationMayNeedSpeakerReview(notification)
+    }
     .dismissableSheet(isPresented: $showCreateFolderSheet) {
       FolderFormSheet(folder: nil, onDismiss: { showCreateFolderSheet = false })
         .environmentObject(appState)
@@ -188,6 +199,62 @@ struct ConversationsPage: View {
         }
         present(conversation)
       }
+    }
+  }
+
+  private func handleCompletedConversationMayNeedSpeakerReview(_ notification: Notification) {
+    guard let conversationId = notification.userInfo?["conversationId"] as? String,
+      !conversationId.isEmpty
+    else { return }
+
+    Task {
+      await appState.loadConversations()
+      guard let conversation = await conversationForSpeakerReviewIfNeeded(conversationId: conversationId) else {
+        return
+      }
+
+      await MainActor.run {
+        autoOpenIdentifySpeakersConversationId = conversation.id
+        selectedConversation = conversation
+      }
+    }
+  }
+
+  private func conversationForSpeakerReviewIfNeeded(conversationId: String) async -> ServerConversation? {
+    guard var conversation = appState.conversations.first(where: { $0.id == conversationId }) else {
+      return nil
+    }
+
+    if conversation.transcriptSegments.isEmpty,
+      let segments = await loadTranscriptSegments(for: conversation)
+    {
+      conversation.transcriptSegments = segments
+    }
+
+    guard !SpeakerReviewQueueBuilder.makeQueue(from: conversation.transcriptSegments).isEmpty else {
+      return nil
+    }
+
+    return conversation
+  }
+
+  private func loadTranscriptSegments(for conversation: ServerConversation) async -> [TranscriptSegment]? {
+    do {
+      let session: TranscriptionSessionRecord?
+      if conversation.id.hasPrefix("local-"),
+        let rowId = Int64(conversation.id.dropFirst("local-".count))
+      {
+        session = try await TranscriptionStorage.shared.getSession(id: rowId)
+      } else {
+        session = try await TranscriptionStorage.shared.getSessionByBackendId(conversation.id)
+      }
+
+      guard let session, let sessionRowId = session.id else { return nil }
+      return try await TranscriptionStorage.shared.getSegments(sessionId: sessionRowId)
+        .map { $0.toTranscriptSegment() }
+    } catch {
+      logError("Conversations: Failed to load transcript segments for speaker review", error: error)
+      return nil
     }
   }
   // MARK: - Main View with Recording Header + List

--- a/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
+++ b/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
@@ -60,7 +60,19 @@ struct ConversationsPage: View {
   @State private var showMergeConfirmation: Bool = false
   @State private var isMerging: Bool = false
   @State private var mergeError: String? = nil
-  @State private var autoOpenIdentifySpeakersConversationId: String? = nil
+  @Binding var autoOpenIdentifySpeakersConversationId: String?
+
+  init(
+    appState: AppState,
+    selectedConversation: Binding<ServerConversation?>,
+    embedded: Bool = false,
+    autoOpenIdentifySpeakersConversationId: Binding<String?> = .constant(nil)
+  ) {
+    self.appState = appState
+    self._selectedConversation = selectedConversation
+    self.embedded = embedded
+    self._autoOpenIdentifySpeakersConversationId = autoOpenIdentifySpeakersConversationId
+  }
 
   var body: some View {
     Group {
@@ -143,10 +155,6 @@ struct ConversationsPage: View {
       // Re-fetch so the list shows the latest data.
       Task { await appState.loadConversations() }
     }
-    .onReceive(NotificationCenter.default.publisher(for: .completedConversationMayNeedSpeakerReview)) {
-      notification in
-      handleCompletedConversationMayNeedSpeakerReview(notification)
-    }
     .dismissableSheet(isPresented: $showCreateFolderSheet) {
       FolderFormSheet(folder: nil, onDismiss: { showCreateFolderSheet = false })
         .environmentObject(appState)
@@ -202,61 +210,6 @@ struct ConversationsPage: View {
     }
   }
 
-  private func handleCompletedConversationMayNeedSpeakerReview(_ notification: Notification) {
-    guard let conversationId = notification.userInfo?["conversationId"] as? String,
-      !conversationId.isEmpty
-    else { return }
-
-    Task {
-      await appState.loadConversations()
-      guard let conversation = await conversationForSpeakerReviewIfNeeded(conversationId: conversationId) else {
-        return
-      }
-
-      await MainActor.run {
-        autoOpenIdentifySpeakersConversationId = conversation.id
-        selectedConversation = conversation
-      }
-    }
-  }
-
-  private func conversationForSpeakerReviewIfNeeded(conversationId: String) async -> ServerConversation? {
-    guard var conversation = appState.conversations.first(where: { $0.id == conversationId }) else {
-      return nil
-    }
-
-    if conversation.transcriptSegments.isEmpty,
-      let segments = await loadTranscriptSegments(for: conversation)
-    {
-      conversation.transcriptSegments = segments
-    }
-
-    guard !SpeakerReviewQueueBuilder.makeQueue(from: conversation.transcriptSegments).isEmpty else {
-      return nil
-    }
-
-    return conversation
-  }
-
-  private func loadTranscriptSegments(for conversation: ServerConversation) async -> [TranscriptSegment]? {
-    do {
-      let session: TranscriptionSessionRecord?
-      if conversation.id.hasPrefix("local-"),
-        let rowId = Int64(conversation.id.dropFirst("local-".count))
-      {
-        session = try await TranscriptionStorage.shared.getSession(id: rowId)
-      } else {
-        session = try await TranscriptionStorage.shared.getSessionByBackendId(conversation.id)
-      }
-
-      guard let session, let sessionRowId = session.id else { return nil }
-      return try await TranscriptionStorage.shared.getSegments(sessionId: sessionRowId)
-        .map { $0.toTranscriptSegment() }
-    } catch {
-      logError("Conversations: Failed to load transcript segments for speaker review", error: error)
-      return nil
-    }
-  }
   // MARK: - Main View with Recording Header + List
 
   private var mainConversationsView: some View {
@@ -868,7 +821,10 @@ private struct TranscriptNotesDivider: View {
 }
 
 #Preview {
-  ConversationsPage(appState: AppState(), selectedConversation: .constant(nil))
+  ConversationsPage(
+    appState: AppState(),
+    selectedConversation: .constant(nil),
+    autoOpenIdentifySpeakersConversationId: .constant(nil))
     .frame(width: 600, height: 800)
     .background(OmiColors.backgroundSecondary)
 }

--- a/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -1110,6 +1110,34 @@ struct SettingsContentView: View {
             .pickerStyle(.menu)
             .frame(width: 110)
           }
+
+          HStack {
+            Image(systemName: "waveform")
+              .scaledFont(size: 16)
+              .foregroundColor(OmiColors.purplePrimary)
+
+            VStack(alignment: .leading, spacing: 4) {
+              Text("Audio Review Retention")
+                .scaledFont(size: 15, weight: .medium)
+                .foregroundColor(OmiColors.textPrimary)
+
+              Text("How long to keep audio chunks for speaker review")
+                .scaledFont(size: 13)
+                .foregroundColor(OmiColors.textTertiary)
+            }
+
+            Spacer()
+
+            Picker("", selection: $rewindSettings.audioRetentionDays) {
+              Text("1 day").tag(1)
+              Text("3 days").tag(3)
+              Text("7 days").tag(7)
+              Text("14 days").tag(14)
+              Text("30 days").tag(30)
+            }
+            .pickerStyle(.menu)
+            .frame(width: 110)
+          }
         }
       }
     }

--- a/Desktop/Sources/Rewind/Core/RewindDatabase.swift
+++ b/Desktop/Sources/Rewind/Core/RewindDatabase.swift
@@ -323,6 +323,7 @@ actor RewindDatabase {
         consecutiveQueryIOErrors = 0
 
         try migrate(activeQueue)
+        try await purgeExpiredAudioChunksOnLaunch(activeQueue)
 
         // After unclean shutdown, do a cheap schema sanity check (not a full DB scan).
         // PRAGMA quick_check scans the ENTIRE database regardless of the (N) argument
@@ -342,6 +343,25 @@ actor RewindDatabase {
         FileManager.default.createFile(atPath: flagPath, contents: nil)
 
         log("RewindDatabase: Initialized successfully")
+    }
+
+    private func purgeExpiredAudioChunksOnLaunch(_ queue: DatabasePool) async throws {
+        let retentionDays = max(
+            1,
+            UserDefaults.standard.object(forKey: AudioPersistenceService.retentionDaysKey) as? Int
+                ?? AudioPersistenceService.defaultRetentionDays
+        )
+        let cutoff = Date().addingTimeInterval(-Double(retentionDays) * 24 * 60 * 60)
+        let deleted = try await queue.write { db -> Int in
+            try db.execute(
+                sql: "DELETE FROM audio_chunks WHERE endedAt < ?",
+                arguments: [cutoff]
+            )
+            return db.changesCount
+        }
+        if deleted > 0 {
+            log("RewindDatabase: Purged \(deleted) expired audio chunk(s) on launch")
+        }
     }
 
     // MARK: - Legacy Migration

--- a/Desktop/Sources/Rewind/Core/RewindModels.swift
+++ b/Desktop/Sources/Rewind/Core/RewindModels.swift
@@ -368,6 +368,12 @@ class RewindSettings: ObservableObject {
         }
     }
 
+    @Published var audioRetentionDays: Int {
+        didSet {
+            AudioPersistenceService.retentionDays = audioRetentionDays
+        }
+    }
+
     @Published var captureInterval: Double {
         didSet {
             defaults.set(captureInterval, forKey: "rewindCaptureInterval")
@@ -407,6 +413,7 @@ class RewindSettings: ObservableObject {
     private init() {
         // Load settings with defaults
         self.retentionDays = defaults.object(forKey: "rewindRetentionDays") as? Int ?? 7
+        self.audioRetentionDays = AudioPersistenceService.retentionDays
         self.captureInterval = defaults.object(forKey: "rewindCaptureInterval") as? Double ?? 3.0
         self.ocrRecognitionFast = defaults.object(forKey: "rewindOCRFast") as? Bool ?? true
         self.pauseOCROnBattery = defaults.object(forKey: "rewindPauseOCROnBattery") as? Bool ?? true

--- a/Desktop/Tests/AudioPersistenceServiceTests.swift
+++ b/Desktop/Tests/AudioPersistenceServiceTests.swift
@@ -1,0 +1,230 @@
+import GRDB
+import XCTest
+
+@testable import Omi_Computer
+
+final class AudioPersistenceServiceTests: XCTestCase {
+    private var testUserId = ""
+    private var previousRetentionDays = AudioPersistenceService.retentionDays
+
+    override func setUp() async throws {
+        try await super.setUp()
+        testUserId = "test-audio-persistence-\(UUID().uuidString)"
+        previousRetentionDays = AudioPersistenceService.retentionDays
+        AudioPersistenceService.retentionDays = 7
+        await RewindDatabase.shared.configure(userId: testUserId)
+        try await RewindDatabase.shared.initialize()
+        await AudioPersistenceService.shared.resetStateForTests()
+    }
+
+    override func tearDown() async throws {
+        await AudioPersistenceService.shared.resetStateForTests()
+        AudioPersistenceService.retentionDays = previousRetentionDays
+        await RewindDatabase.shared.close()
+        try await super.tearDown()
+    }
+
+    func testStopFlushesPartialChunkWithSessionId() async throws {
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+            throw XCTSkip("database queue unavailable")
+        }
+        let now = Date()
+        let sessionId = try await insertSession(dbQueue: dbQueue, startedAt: now)
+
+        await AudioPersistenceService.shared.start(source: "mixed", transcriptionSessionId: sessionId)
+        await AudioPersistenceService.shared.append(Data(repeating: 1, count: 3_200))
+        await AudioPersistenceService.shared.stop()
+
+        let row = try await dbQueue.read { db in
+            try Row.fetchOne(
+                db,
+                sql: """
+                    SELECT transcriptionSessionId, source, sampleRate, channels, LENGTH(pcm) AS byteCount
+                    FROM audio_chunks
+                    WHERE transcriptionSessionId = ?
+                    """,
+                arguments: [sessionId]
+            )
+        }
+        XCTAssertEqual(row?["transcriptionSessionId"] as Int64?, sessionId)
+        XCTAssertEqual(row?["source"] as String?, "mixed")
+        XCTAssertEqual(row?["sampleRate"] as Int?, 16000)
+        XCTAssertEqual(row?["channels"] as Int?, 1)
+        XCTAssertEqual(row?["byteCount"] as Int?, 3_200)
+    }
+
+    func testPreSessionChunksAreLinkedWhenSessionIdArrives() async throws {
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+            throw XCTSkip("database queue unavailable")
+        }
+        let captureStartedAt = Date()
+
+        await AudioPersistenceService.shared.start(
+            source: "mixed",
+            transcriptionSessionId: nil,
+            captureStartedAt: captureStartedAt
+        )
+        await AudioPersistenceService.shared.append(Data(repeating: 2, count: 3_200))
+        await AudioPersistenceService.shared.flush()
+
+        let orphanCount = try await dbQueue.read { db in
+            try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM audio_chunks WHERE transcriptionSessionId IS NULL") ?? 0
+        }
+        XCTAssertEqual(orphanCount, 1)
+
+        let sessionId = try await insertSession(
+            dbQueue: dbQueue,
+            startedAt: captureStartedAt.addingTimeInterval(30)
+        )
+        await AudioPersistenceService.shared.setTranscriptionSessionId(sessionId)
+
+        let linkedCount = try await dbQueue.read { db in
+            try Int.fetchOne(
+                db,
+                sql: "SELECT COUNT(*) FROM audio_chunks WHERE transcriptionSessionId = ?",
+                arguments: [sessionId]
+            ) ?? 0
+        }
+        XCTAssertEqual(linkedCount, 1)
+    }
+
+    func testReviewAudioWAVSlicesAcrossChunksUsingAudioAnchor() async throws {
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+            throw XCTSkip("database queue unavailable")
+        }
+        let audioStartedAt = Date()
+        let sessionId = try await insertSession(
+            dbQueue: dbQueue,
+            startedAt: audioStartedAt.addingTimeInterval(60)
+        )
+        let conversationId = "local-\(sessionId)"
+
+        try await insertAudioChunk(
+            dbQueue: dbQueue,
+            startedAt: audioStartedAt,
+            endedAt: audioStartedAt.addingTimeInterval(1),
+            sessionId: sessionId,
+            sampleRate: 4,
+            pcm: pcmData([0, 1, 2, 3])
+        )
+        try await insertAudioChunk(
+            dbQueue: dbQueue,
+            startedAt: audioStartedAt.addingTimeInterval(1),
+            endedAt: audioStartedAt.addingTimeInterval(2),
+            sessionId: sessionId,
+            sampleRate: 4,
+            pcm: pcmData([4, 5, 6, 7])
+        )
+
+        let wav = await AudioPersistenceService.shared.reviewAudioWAV(
+            conversationId: conversationId,
+            startTime: 0.5,
+            endTime: 1.5
+        )
+        let pcm = try XCTUnwrap(wav.map(wavPCM))
+        XCTAssertEqual(pcm, pcmData([2, 3, 4, 5]))
+    }
+
+    func testRetentionPurgeDeletesOnlyExpiredChunks() async throws {
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+            throw XCTSkip("database queue unavailable")
+        }
+        AudioPersistenceService.retentionDays = 7
+        let now = Date()
+        let oldStart = now.addingTimeInterval(-9 * 24 * 60 * 60)
+        let freshStart = now.addingTimeInterval(-2 * 24 * 60 * 60)
+
+        try await insertAudioChunk(dbQueue: dbQueue, startedAt: oldStart, endedAt: oldStart.addingTimeInterval(1))
+        try await insertAudioChunk(dbQueue: dbQueue, startedAt: freshStart, endedAt: freshStart.addingTimeInterval(1))
+
+        let deleted = await AudioPersistenceService.shared.purgeExpiredChunks(now: now)
+        XCTAssertEqual(deleted, 1)
+
+        let remaining = try await dbQueue.read { db in
+            try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM audio_chunks") ?? 0
+        }
+        XCTAssertEqual(remaining, 1)
+    }
+
+    func testRetentionPurgeIfNeededIsDeterministicAndThrottled() async throws {
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+            throw XCTSkip("database queue unavailable")
+        }
+        AudioPersistenceService.retentionDays = 7
+        let now = Date()
+        let oldStart = now.addingTimeInterval(-9 * 24 * 60 * 60)
+
+        try await insertAudioChunk(dbQueue: dbQueue, startedAt: oldStart, endedAt: oldStart.addingTimeInterval(1))
+        let firstDeleted = await AudioPersistenceService.shared.purgeExpiredChunksIfNeeded(now: now)
+        XCTAssertEqual(firstDeleted, 1)
+
+        try await insertAudioChunk(dbQueue: dbQueue, startedAt: oldStart, endedAt: oldStart.addingTimeInterval(1))
+        let throttledDeleted = await AudioPersistenceService.shared.purgeExpiredChunksIfNeeded(
+            now: now.addingTimeInterval(10)
+        )
+        XCTAssertEqual(throttledDeleted, 0)
+
+        let secondDeleted = await AudioPersistenceService.shared.purgeExpiredChunksIfNeeded(
+            now: now.addingTimeInterval(60 * 60 + 1)
+        )
+        XCTAssertEqual(secondDeleted, 1)
+    }
+
+    func testAudioMixerEmitsMicOnlyChunksWhenSystemAudioIsAbsent() {
+        let mixer = AudioMixer()
+        let micOnlyPCM = pcmData(Array(repeating: 42, count: 1_600))
+        var chunks: [Data] = []
+
+        mixer.start { chunk in
+            chunks.append(chunk)
+        }
+        mixer.setMicAudio(micOnlyPCM)
+        mixer.stop()
+
+        XCTAssertEqual(chunks.first, micOnlyPCM)
+    }
+
+    private func insertSession(dbQueue: DatabasePool, startedAt: Date) async throws -> Int64 {
+        try await dbQueue.write { db in
+            try db.execute(
+                sql: """
+                    INSERT INTO transcription_sessions(startedAt, source, language, timezone, status, retryCount, backendSynced, createdAt, updatedAt, summary_state)
+                    VALUES(?, 'desktop', 'en', 'UTC', 'recording', 0, 0, ?, ?, 'pending')
+                    """,
+                arguments: [startedAt, startedAt, startedAt]
+            )
+            let id = db.lastInsertedRowID
+            try db.execute(sql: "UPDATE transcription_sessions SET backendId = ? WHERE id = ?", arguments: ["local-\(id)", id])
+            return id
+        }
+    }
+
+    private func insertAudioChunk(
+        dbQueue: DatabasePool,
+        startedAt: Date,
+        endedAt: Date,
+        sessionId: Int64? = nil,
+        sampleRate: Int = 16000,
+        pcm: Data = Data(repeating: 1, count: 8)
+    ) async throws {
+        let duration = endedAt.timeIntervalSince(startedAt)
+        try await dbQueue.write { db in
+            try db.execute(
+                sql: """
+                    INSERT INTO audio_chunks(startedAt, endedAt, durationSeconds, source, sampleRate, channels, pcm, transcriptionSessionId, createdAt)
+                    VALUES(?, ?, ?, 'mixed', ?, 1, ?, ?, ?)
+                    """,
+                arguments: [startedAt, endedAt, duration, sampleRate, pcm, sessionId, Date()]
+            )
+        }
+    }
+
+    private func pcmData(_ samples: [Int16]) -> Data {
+        samples.withUnsafeBufferPointer { Data(buffer: $0) }
+    }
+
+    private func wavPCM(_ wav: Data) -> Data {
+        guard wav.count >= 44 else { return Data() }
+        return Data(wav.dropFirst(44))
+    }
+}

--- a/Desktop/Tests/AudioPersistenceServiceTests.swift
+++ b/Desktop/Tests/AudioPersistenceServiceTests.swift
@@ -53,6 +53,29 @@ final class AudioPersistenceServiceTests: XCTestCase {
         XCTAssertEqual(row?["byteCount"] as Int?, 3_200)
     }
 
+    func testQueuedStopDrainsPreviouslyQueuedAppends() async throws {
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+            throw XCTSkip("database queue unavailable")
+        }
+        let now = Date()
+        let sessionId = try await insertSession(dbQueue: dbQueue, startedAt: now)
+
+        await AudioPersistenceService.shared.start(source: "mixed", transcriptionSessionId: sessionId)
+        for _ in 0..<5 {
+            AudioPersistenceService.shared.enqueueAppend(Data(repeating: 7, count: 3_200))
+        }
+        await AudioPersistenceService.shared.stopQueued()
+
+        let byteCount = try await dbQueue.read { db in
+            try Int.fetchOne(
+                db,
+                sql: "SELECT LENGTH(pcm) FROM audio_chunks WHERE transcriptionSessionId = ?",
+                arguments: [sessionId]
+            )
+        }
+        XCTAssertEqual(byteCount, 16_000)
+    }
+
     func testPreSessionChunksAreLinkedWhenSessionIdArrives() async throws {
         guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
             throw XCTSkip("database queue unavailable")
@@ -88,29 +111,29 @@ final class AudioPersistenceServiceTests: XCTestCase {
         XCTAssertEqual(linkedCount, 1)
     }
 
-    func testReviewAudioWAVSlicesAcrossChunksUsingAudioAnchor() async throws {
+    func testReviewAudioWAVSlicesUsingSessionStartAnchor() async throws {
         guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
             throw XCTSkip("database queue unavailable")
         }
-        let audioStartedAt = Date()
+        let sessionStartedAt = Date()
         let sessionId = try await insertSession(
             dbQueue: dbQueue,
-            startedAt: audioStartedAt.addingTimeInterval(60)
+            startedAt: sessionStartedAt
         )
         let conversationId = "local-\(sessionId)"
 
         try await insertAudioChunk(
             dbQueue: dbQueue,
-            startedAt: audioStartedAt,
-            endedAt: audioStartedAt.addingTimeInterval(1),
+            startedAt: sessionStartedAt.addingTimeInterval(-1),
+            endedAt: sessionStartedAt,
             sessionId: sessionId,
             sampleRate: 4,
             pcm: pcmData([0, 1, 2, 3])
         )
         try await insertAudioChunk(
             dbQueue: dbQueue,
-            startedAt: audioStartedAt.addingTimeInterval(1),
-            endedAt: audioStartedAt.addingTimeInterval(2),
+            startedAt: sessionStartedAt,
+            endedAt: sessionStartedAt.addingTimeInterval(1),
             sessionId: sessionId,
             sampleRate: 4,
             pcm: pcmData([4, 5, 6, 7])
@@ -118,11 +141,11 @@ final class AudioPersistenceServiceTests: XCTestCase {
 
         let wav = await AudioPersistenceService.shared.reviewAudioWAV(
             conversationId: conversationId,
-            startTime: 0.5,
-            endTime: 1.5
+            startTime: 0.25,
+            endTime: 0.75
         )
         let pcm = try XCTUnwrap(wav.map(wavPCM))
-        XCTAssertEqual(pcm, pcmData([2, 3, 4, 5]))
+        XCTAssertEqual(pcm, pcmData([5, 6]))
     }
 
     func testRetentionPurgeDeletesOnlyExpiredChunks() async throws {
@@ -171,7 +194,7 @@ final class AudioPersistenceServiceTests: XCTestCase {
     }
 
     func testAudioMixerEmitsMicOnlyChunksWhenSystemAudioIsAbsent() {
-        let mixer = AudioMixer()
+        let mixer = AudioMixer(systemAudioAvailable: false)
         let micOnlyPCM = pcmData(Array(repeating: 42, count: 1_600))
         var chunks: [Data] = []
 
@@ -182,6 +205,38 @@ final class AudioPersistenceServiceTests: XCTestCase {
         mixer.stop()
 
         XCTAssertEqual(chunks.first, micOnlyPCM)
+    }
+
+    func testAudioMixerWaitsForTemporarilyEmptySystemBuffer() {
+        let mixer = AudioMixer(counterpartWaitTimeout: 60)
+        let micPCM = pcmData(Array(repeating: 10, count: 1_600))
+        let systemPCM = pcmData(Array(repeating: 5, count: 1_600))
+        var chunks: [Data] = []
+
+        mixer.start { chunk in
+            chunks.append(chunk)
+        }
+        mixer.setMicAudio(micPCM)
+        XCTAssertTrue(chunks.isEmpty)
+
+        mixer.setSystemAudio(systemPCM)
+        mixer.stop()
+
+        XCTAssertEqual(chunks.first, pcmData(Array(repeating: 15, count: 1_600)))
+    }
+
+    func testAudioMixerPadsAfterCounterpartWaitTimeout() {
+        let mixer = AudioMixer(counterpartWaitTimeout: 0)
+        let micPCM = pcmData(Array(repeating: 9, count: 1_600))
+        var chunks: [Data] = []
+
+        mixer.start { chunk in
+            chunks.append(chunk)
+        }
+        mixer.setMicAudio(micPCM)
+        mixer.stop()
+
+        XCTAssertEqual(chunks.first, micPCM)
     }
 
     private func insertSession(dbQueue: DatabasePool, startedAt: Date) async throws -> Int64 {

--- a/Desktop/Tests/LocalIntegrationDispatcherTests.swift
+++ b/Desktop/Tests/LocalIntegrationDispatcherTests.swift
@@ -46,6 +46,14 @@ final class LocalIntegrationDispatcherTests: XCTestCase {
 
     override func setUp() async throws {
         try await super.setUp()
+
+        // Disable background drain during dispatcher tests so we can
+        // deterministically assert on outbox row counts without the
+        // service racing to consume them.
+        await MainActor.run {
+            LocalIntegrationDrainService.shared.isEnabled = false
+        }
+
         // Real `try` — if `listEnabled()` fails we MUST NOT proceed: the
         // dispatcher fan-out below would otherwise write test memories to
         // whatever real integrations the user has enabled. Letting setUp
@@ -64,6 +72,11 @@ final class LocalIntegrationDispatcherTests: XCTestCase {
     }
 
     override func tearDown() async throws {
+        // Restore background drain.
+        await MainActor.run {
+            LocalIntegrationDrainService.shared.isEnabled = true
+        }
+
         // Defensive sweep: drop every outbox row that belongs to one of our
         // test integrations, then drop the integrations themselves. Other
         // tests (and prior runs of this suite) may have left rows; we only

--- a/Desktop/Tests/TranscriptSpeakerAssignmentTests.swift
+++ b/Desktop/Tests/TranscriptSpeakerAssignmentTests.swift
@@ -751,6 +751,37 @@ final class TranscriptSpeakerAssignmentTests: XCTestCase {
     XCTAssertEqual(queue[0].samples.map(\.segmentIndex), [2])
   }
 
+  func testSpeakerReviewQueueRequiresThreeSecondSamplesAndDoesNotCrossSegmentBounds() {
+    let segments = [
+      TranscriptSegment(
+        id: "too-short",
+        text: "This turn has words but is too short for review playback.",
+        speaker: "SPEAKER_01",
+        isUser: false,
+        personId: nil,
+        start: 1,
+        end: 3.5
+      ),
+      TranscriptSegment(
+        id: "reviewable",
+        text: "This turn is long enough to review safely.",
+        speaker: "SPEAKER_01",
+        isUser: false,
+        personId: nil,
+        start: 10,
+        end: 13.25
+      )
+    ]
+
+    let queue = SpeakerReviewQueueBuilder.makeQueue(from: segments)
+
+    XCTAssertEqual(queue.count, 1)
+    XCTAssertEqual(queue[0].segmentIndices, [0, 1])
+    XCTAssertEqual(queue[0].samples.map(\.segmentIndex), [1])
+    XCTAssertEqual(queue[0].samples.first?.start, 10)
+    XCTAssertEqual(queue[0].samples.first?.end, 13.25)
+  }
+
   func testSpeakerReviewQueuePrioritizesSuggestedSpeakers() {
     let segments = [
       TranscriptSegment(

--- a/Desktop/Tests/TranscriptSpeakerAssignmentTests.swift
+++ b/Desktop/Tests/TranscriptSpeakerAssignmentTests.swift
@@ -656,6 +656,185 @@ final class TranscriptSpeakerAssignmentTests: XCTestCase {
     XCTAssertEqual(assignment.fallbackOrders, [0])
   }
 
+  func testSpeakerReviewQueueExcludesUserShortAndNoiseOnlySegments() {
+    let segments = [
+      TranscriptSegment(
+        id: "user",
+        text: "this is mike",
+        speaker: "SPEAKER_00",
+        isUser: true,
+        personId: nil,
+        start: 0,
+        end: 5
+      ),
+      TranscriptSegment(
+        id: "short",
+        text: "hi",
+        speaker: "SPEAKER_01",
+        isUser: false,
+        personId: nil,
+        start: 5,
+        end: 5.5
+      ),
+      TranscriptSegment(
+        id: "music",
+        text: "(gentle music)",
+        speaker: "SPEAKER_01",
+        isUser: false,
+        personId: nil,
+        start: 6,
+        end: 10
+      ),
+      TranscriptSegment(
+        id: "reviewable",
+        text: "We should label this voice.",
+        speaker: "SPEAKER_02",
+        isUser: false,
+        personId: nil,
+        start: 11,
+        end: 15
+      )
+    ]
+
+    let queue = SpeakerReviewQueueBuilder.makeQueue(from: segments)
+    XCTAssertEqual(queue.count, 1)
+    XCTAssertEqual(queue[0].speakerId, 2)
+    XCTAssertEqual(queue[0].segmentIndices, [3])
+    XCTAssertEqual(queue[0].samples.first?.start, 11)
+    XCTAssertEqual(queue[0].samples.first?.end, 15)
+  }
+
+  func testSpeakerReviewQueueAssignsFullClusterWhileSamplingReviewableSegments() {
+    let segments = [
+      TranscriptSegment(
+        id: "short",
+        text: "ok",
+        speaker: "SPEAKER_01",
+        isUser: false,
+        personId: nil,
+        start: 0,
+        end: 0.5
+      ),
+      TranscriptSegment(
+        id: "music",
+        text: "(gentle music)",
+        speaker: "SPEAKER_01",
+        isUser: false,
+        personId: nil,
+        start: 1,
+        end: 4
+      ),
+      TranscriptSegment(
+        id: "reviewable",
+        text: "This is the sample we should review.",
+        speaker: "SPEAKER_01",
+        isUser: false,
+        personId: nil,
+        start: 5,
+        end: 9
+      ),
+      TranscriptSegment(
+        id: "already-named",
+        text: "Already assigned should not be relabeled by this queue item.",
+        speaker: "SPEAKER_01",
+        isUser: false,
+        personId: "existing-person",
+        start: 10,
+        end: 14
+      )
+    ]
+
+    let queue = SpeakerReviewQueueBuilder.makeQueue(from: segments)
+
+    XCTAssertEqual(queue.count, 1)
+    XCTAssertEqual(queue[0].segmentIndices, [0, 1, 2])
+    XCTAssertEqual(queue[0].samples.map(\.segmentIndex), [2])
+  }
+
+  func testSpeakerReviewQueuePrioritizesSuggestedSpeakers() {
+    let segments = [
+      TranscriptSegment(
+        id: "unknown",
+        text: "Unknown speaker with enough speech.",
+        speaker: "SPEAKER_03",
+        isUser: false,
+        personId: nil,
+        start: 0,
+        end: 4
+      ),
+      TranscriptSegment(
+        id: "suggested",
+        text: "Suggested speaker with enough speech.",
+        speaker: "SPEAKER_01",
+        isUser: false,
+        personId: nil,
+        suggestedPersonId: "p1",
+        suggestedSimilarity: 0.78,
+        suggestedMargin: 0.05,
+        suggestedSampleCount: 2,
+        start: 5,
+        end: 9
+      )
+    ]
+
+    let queue = SpeakerReviewQueueBuilder.makeQueue(from: segments)
+    XCTAssertEqual(queue.map(\.speakerId), [1, 3])
+    XCTAssertEqual(queue.first?.suggestedPersonId, "p1")
+  }
+
+  func testSpeakerReviewQueuePreservesSuggestionWhenLongestSampleIsUnknown() {
+    let segments = [
+      TranscriptSegment(
+        id: "long-unknown",
+        text: "This long sample lacks suggested identity metadata.",
+        speaker: "SPEAKER_01",
+        isUser: false,
+        personId: nil,
+        start: 0,
+        end: 8
+      ),
+      TranscriptSegment(
+        id: "short-suggested",
+        text: "yes",
+        speaker: "SPEAKER_01",
+        isUser: false,
+        personId: nil,
+        suggestedPersonId: "p1",
+        suggestedSimilarity: 0.82,
+        suggestedMargin: 0.04,
+        suggestedSampleCount: 2,
+        start: 9,
+        end: 9.5
+      ),
+      TranscriptSegment(
+        id: "other-unknown",
+        text: "Another unknown speaker with enough speech.",
+        speaker: "SPEAKER_02",
+        isUser: false,
+        personId: nil,
+        start: 10,
+        end: 14
+      )
+    ]
+
+    let queue = SpeakerReviewQueueBuilder.makeQueue(from: segments)
+
+    XCTAssertEqual(queue.map(\.speakerId), [1, 2])
+    XCTAssertEqual(queue.first?.suggestedPersonId, "p1")
+    XCTAssertEqual(queue.first?.suggestedSimilarity, 0.82)
+    XCTAssertEqual(queue.first?.segmentIndices, [0, 1])
+    XCTAssertEqual(queue.first?.samples.map(\.segmentIndex), [0])
+  }
+
+  func testSpeakerAssignmentTargetEncodesYouAndPersonAssignments() {
+    XCTAssertNil(SpeakerAssignmentTarget.you.personId)
+    XCTAssertTrue(SpeakerAssignmentTarget.you.isUser)
+
+    let personTarget = SpeakerAssignmentTarget.person("person-1")
+    XCTAssertEqual(personTarget.personId, "person-1")
+    XCTAssertFalse(personTarget.isUser)
+  }
+
   func testTranscriptSegmentDecodesSuggestedCandidateMetadata() throws {
     let json = """
       {

--- a/Desktop/Tests/VoiceProfileAssignmentRegressionTests.swift
+++ b/Desktop/Tests/VoiceProfileAssignmentRegressionTests.swift
@@ -18,14 +18,15 @@ final class VoiceProfileAssignmentRegressionTests: XCTestCase {
         try await super.tearDown()
     }
 
-    func testAssignSegmentsBackfillsOnlyOverlappingEmbeddings() async throws {
+    private func requireDatabaseQueue() async throws -> DatabasePool {
         guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
             throw XCTSkip("database queue unavailable")
         }
+        return dbQueue
+    }
 
-        // Seed one session with two segments that share a speaker cluster but are far apart in time.
-        let now = Date()
-        let sessionId: Int64 = try await dbQueue.write { db in
+    private func insertSession(in dbQueue: DatabasePool, now: Date) async throws -> Int64 {
+        try await dbQueue.write { db in
             try db.execute(
                 sql: """
                     INSERT INTO transcription_sessions(startedAt, source, language, timezone, status, retryCount, backendSynced, createdAt, updatedAt, summary_state)
@@ -35,58 +36,108 @@ final class VoiceProfileAssignmentRegressionTests: XCTestCase {
             )
             return db.lastInsertedRowID
         }
+    }
+
+    private func assignStableBackendId(_ sessionId: Int64, in dbQueue: DatabasePool) async throws {
+        try await dbQueue.write { db in
+            try db.execute(
+                sql: "UPDATE transcription_sessions SET backendId = ? WHERE id = ?",
+                arguments: ["local-\(sessionId)", sessionId]
+            )
+        }
+    }
+
+    @discardableResult
+    private func insertPerson(
+        in dbQueue: DatabasePool,
+        name: String,
+        now: Date,
+        id: String = UUID().uuidString
+    ) async throws -> String {
+        try await dbQueue.write { db in
+            try db.execute(
+                sql: "INSERT INTO people(id, displayName, defaultEmoji, createdAt, updatedAt) VALUES(?, ?, NULL, ?, ?)",
+                arguments: [id, name, now, now]
+            )
+        }
+        return id
+    }
+
+    private func insertSegment(
+        in dbQueue: DatabasePool,
+        sessionId: Int64,
+        text: String,
+        start: Double,
+        end: Double,
+        order: Int,
+        now: Date,
+        speakerId: Int = 1,
+        segmentId: String? = nil
+    ) async throws {
+        let resolvedSegmentId = segmentId ?? "seg-\(order)"
+        try await dbQueue.write { db in
+            try db.execute(
+                sql: """
+                    INSERT INTO transcription_segments(sessionId, speaker, text, startTime, endTime, segmentOrder, createdAt, segmentId, speakerLabel, isUser, personId)
+                    VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, 0, NULL)
+                    """,
+                arguments: [
+                    sessionId,
+                    speakerId,
+                    text,
+                    start,
+                    end,
+                    order,
+                    now,
+                    resolvedSegmentId,
+                    String(format: "SPEAKER_%02d", speakerId)
+                ]
+            )
+        }
+    }
+
+    private func insertEmbedding(
+        in dbQueue: DatabasePool,
+        sessionId: Int64,
+        embedding: Data,
+        start: Double,
+        end: Double,
+        now: Date,
+        speakerId: Int = 1,
+        embeddingModel: String = "mfcc"
+    ) async throws {
+        try await dbQueue.write { db in
+            try db.execute(
+                sql: """
+                    INSERT INTO speaker_embeddings(sessionId, chunkId, embedding, embeddingDim, startTime, endTime, speakerId, personId, createdAt, assignmentSource, matchConfidence, embeddingModel, embeddingVersion, isTrainingSample)
+                    VALUES(?, NULL, ?, 3, ?, ?, ?, NULL, ?, NULL, NULL, ?, 1, 0)
+                    """,
+                arguments: [sessionId, embedding, start, end, speakerId, now, embeddingModel]
+            )
+        }
+    }
+
+    func testAssignSegmentsBackfillsOnlyOverlappingEmbeddings() async throws {
+        let dbQueue = try await requireDatabaseQueue()
+        // Seed one session with two segments that share a speaker cluster but are far apart in time.
+        let now = Date()
+        let sessionId = try await insertSession(in: dbQueue, now: now)
 
         // Force stable local backendId so PeopleStore paths can resolve.
-        try await dbQueue.write { db in
-            try db.execute(sql: "UPDATE transcription_sessions SET backendId = ? WHERE id = ?", arguments: ["local-\(sessionId)", sessionId])
-        }
+        try await assignStableBackendId(sessionId, in: dbQueue)
 
         // Segment order 0: 0-1s. Segment order 1: 10-11s.
-        try await dbQueue.write { db in
-            try db.execute(
-                sql: """
-                    INSERT INTO transcription_segments(sessionId, speaker, text, startTime, endTime, segmentOrder, createdAt, segmentId, speakerLabel, isUser, personId)
-                    VALUES(?, 1, 'a', 0.0, 1.0, 0, ?, 'seg0', 'SPEAKER_01', 0, NULL)
-                    """,
-                arguments: [sessionId, now]
-            )
-            try db.execute(
-                sql: """
-                    INSERT INTO transcription_segments(sessionId, speaker, text, startTime, endTime, segmentOrder, createdAt, segmentId, speakerLabel, isUser, personId)
-                    VALUES(?, 1, 'b', 10.0, 11.0, 1, ?, 'seg1', 'SPEAKER_01', 0, NULL)
-                    """,
-                arguments: [sessionId, now]
-            )
-        }
+        try await insertSegment(in: dbQueue, sessionId: sessionId, text: "a", start: 0.0, end: 1.0, order: 0, now: now, segmentId: "seg0")
+        try await insertSegment(in: dbQueue, sessionId: sessionId, text: "b", start: 10.0, end: 11.0, order: 1, now: now, segmentId: "seg1")
 
         // Two embeddings, same speakerId=1 but different time windows.
         let e0 = SpeakerEmbeddingRecord.encode([0.1, 0.2, 0.3])
         let e1 = SpeakerEmbeddingRecord.encode([0.2, 0.2, 0.2])
-        try await dbQueue.write { db in
-            try db.execute(
-                sql: """
-                    INSERT INTO speaker_embeddings(sessionId, chunkId, embedding, embeddingDim, startTime, endTime, speakerId, personId, createdAt, assignmentSource, matchConfidence, embeddingModel, embeddingVersion, isTrainingSample)
-                    VALUES(?, NULL, ?, 3, 0.0, 1.0, 1, NULL, ?, NULL, NULL, 'mfcc', 1, 0)
-                    """,
-                arguments: [sessionId, e0, now]
-            )
-            try db.execute(
-                sql: """
-                    INSERT INTO speaker_embeddings(sessionId, chunkId, embedding, embeddingDim, startTime, endTime, speakerId, personId, createdAt, assignmentSource, matchConfidence, embeddingModel, embeddingVersion, isTrainingSample)
-                    VALUES(?, NULL, ?, 3, 10.0, 11.0, 1, NULL, ?, NULL, NULL, 'mfcc', 1, 0)
-                    """,
-                arguments: [sessionId, e1, now]
-            )
-        }
+        try await insertEmbedding(in: dbQueue, sessionId: sessionId, embedding: e0, start: 0.0, end: 1.0, now: now)
+        try await insertEmbedding(in: dbQueue, sessionId: sessionId, embedding: e1, start: 10.0, end: 11.0, now: now)
 
         // Seed people.
-        let pid = UUID().uuidString
-        try await dbQueue.write { db in
-            try db.execute(
-                sql: "INSERT INTO people(id, displayName, defaultEmoji, createdAt, updatedAt) VALUES(?, 'Test', NULL, ?, ?)",
-                arguments: [pid, now, now]
-            )
-        }
+        let pid = try await insertPerson(in: dbQueue, name: "Test", now: now)
 
         // Assign only segment order 0.
         let ok = await PeopleStore.shared.assignSegments(
@@ -115,40 +166,22 @@ final class VoiceProfileAssignmentRegressionTests: XCTestCase {
     }
 
     func testNonMFCCEmbeddingsNeverBecomeTrainingSamplesOnManualAssignment() async throws {
-        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
-            throw XCTSkip("database queue unavailable")
-        }
-
+        let dbQueue = try await requireDatabaseQueue()
         let now = Date()
-        let sessionId: Int64 = try await dbQueue.write { db in
-            try db.execute(
-                sql: """
-                    INSERT INTO transcription_sessions(startedAt, source, language, timezone, status, retryCount, backendSynced, createdAt, updatedAt, summary_state)
-                    VALUES(?, 'desktop', 'en', 'UTC', 'completed', 0, 0, ?, ?, 'pending')
-                    """,
-                arguments: [now, now, now]
-            )
-            return db.lastInsertedRowID
-        }
+        let sessionId = try await insertSession(in: dbQueue, now: now)
 
-        let pid = UUID().uuidString
-        try await dbQueue.write { db in
-            try db.execute(
-                sql: "INSERT INTO people(id, displayName, defaultEmoji, createdAt, updatedAt) VALUES(?, 'Test', NULL, ?, ?)",
-                arguments: [pid, now, now]
-            )
-        }
+        let pid = try await insertPerson(in: dbQueue, name: "Test", now: now)
 
         let e = SpeakerEmbeddingRecord.encode([1, 0, 0])
-        try await dbQueue.write { db in
-            try db.execute(
-                sql: """
-                    INSERT INTO speaker_embeddings(sessionId, chunkId, embedding, embeddingDim, startTime, endTime, speakerId, personId, createdAt, assignmentSource, matchConfidence, embeddingModel, embeddingVersion, isTrainingSample)
-                    VALUES(?, NULL, ?, 3, 0.0, 1.0, 1, NULL, ?, NULL, NULL, 'speakerkit-synthetic', 1, 0)
-                    """,
-                arguments: [sessionId, e, now]
-            )
-        }
+        try await insertEmbedding(
+            in: dbQueue,
+            sessionId: sessionId,
+            embedding: e,
+            start: 0.0,
+            end: 1.0,
+            now: now,
+            embeddingModel: "speakerkit-synthetic"
+        )
 
         try await SpeakerEmbeddingStore.shared.assignPersonToEmbeddings(sessionId: sessionId, speakerId: 1, personId: pid)
 
@@ -163,53 +196,26 @@ final class VoiceProfileAssignmentRegressionTests: XCTestCase {
     }
 
     func testShortManualOverlapAssignsPersonButDoesNotTrainVoiceProfile() async throws {
-        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
-            throw XCTSkip("database queue unavailable")
-        }
-
+        let dbQueue = try await requireDatabaseQueue()
         let now = Date()
-        let sessionId: Int64 = try await dbQueue.write { db in
-            try db.execute(
-                sql: """
-                    INSERT INTO transcription_sessions(startedAt, source, language, timezone, status, retryCount, backendSynced, createdAt, updatedAt, summary_state)
-                    VALUES(?, 'desktop', 'en', 'UTC', 'completed', 0, 0, ?, ?, 'pending')
-                    """,
-                arguments: [now, now, now]
-            )
-            return db.lastInsertedRowID
-        }
-        try await dbQueue.write { db in
-            try db.execute(sql: "UPDATE transcription_sessions SET backendId = ? WHERE id = ?", arguments: ["local-\(sessionId)", sessionId])
-        }
+        let sessionId = try await insertSession(in: dbQueue, now: now)
+        try await assignStableBackendId(sessionId, in: dbQueue)
 
-        try await dbQueue.write { db in
-            try db.execute(
-                sql: """
-                    INSERT INTO transcription_segments(sessionId, speaker, text, startTime, endTime, segmentOrder, createdAt, segmentId, speakerLabel, isUser, personId)
-                    VALUES(?, 1, 'short noisy clip', 0.0, 0.3, 0, ?, 'seg-short', 'SPEAKER_01', 0, NULL)
-                    """,
-                arguments: [sessionId, now]
-            )
-        }
+        try await insertSegment(
+            in: dbQueue,
+            sessionId: sessionId,
+            text: "short noisy clip",
+            start: 0.0,
+            end: 0.3,
+            order: 0,
+            now: now,
+            segmentId: "seg-short"
+        )
 
         let e = SpeakerEmbeddingRecord.encode([1, 0, 0])
-        try await dbQueue.write { db in
-            try db.execute(
-                sql: """
-                    INSERT INTO speaker_embeddings(sessionId, chunkId, embedding, embeddingDim, startTime, endTime, speakerId, personId, createdAt, assignmentSource, matchConfidence, embeddingModel, embeddingVersion, isTrainingSample)
-                    VALUES(?, NULL, ?, 3, 0.0, 1.0, 1, NULL, ?, NULL, NULL, 'mfcc', 1, 0)
-                    """,
-                arguments: [sessionId, e, now]
-            )
-        }
+        try await insertEmbedding(in: dbQueue, sessionId: sessionId, embedding: e, start: 0.0, end: 1.0, now: now)
 
-        let pid = UUID().uuidString
-        try await dbQueue.write { db in
-            try db.execute(
-                sql: "INSERT INTO people(id, displayName, defaultEmoji, createdAt, updatedAt) VALUES(?, 'Short Clip', NULL, ?, ?)",
-                arguments: [pid, now, now]
-            )
-        }
+        let pid = try await insertPerson(in: dbQueue, name: "Short Clip", now: now)
 
         let ok = await PeopleStore.shared.assignSegments(
             sessionId: sessionId,
@@ -233,69 +239,30 @@ final class VoiceProfileAssignmentRegressionTests: XCTestCase {
     }
 
     func testFullClusterAssignmentLabelsExcludedSegmentsButOnlyReviewableRangesTrain() async throws {
-        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
-            throw XCTSkip("database queue unavailable")
-        }
-
+        let dbQueue = try await requireDatabaseQueue()
         let now = Date()
-        let sessionId: Int64 = try await dbQueue.write { db in
-            try db.execute(
-                sql: """
-                    INSERT INTO transcription_sessions(startedAt, source, language, timezone, status, retryCount, backendSynced, createdAt, updatedAt, summary_state)
-                    VALUES(?, 'desktop', 'en', 'UTC', 'completed', 0, 0, ?, ?, 'pending')
-                    """,
-                arguments: [now, now, now]
-            )
-            return db.lastInsertedRowID
-        }
-        try await dbQueue.write { db in
-            try db.execute(sql: "UPDATE transcription_sessions SET backendId = ? WHERE id = ?", arguments: ["local-\(sessionId)", sessionId])
-        }
+        let sessionId = try await insertSession(in: dbQueue, now: now)
+        try await assignStableBackendId(sessionId, in: dbQueue)
 
-        try await dbQueue.write { db in
-            try db.execute(
-                sql: """
-                    INSERT INTO transcription_segments(sessionId, speaker, text, startTime, endTime, segmentOrder, createdAt, segmentId, speakerLabel, isUser, personId)
-                    VALUES(?, 1, 'ok', 0.0, 0.5, 0, ?, 'seg-short', 'SPEAKER_01', 0, NULL)
-                    """,
-                arguments: [sessionId, now]
-            )
-            try db.execute(
-                sql: """
-                    INSERT INTO transcription_segments(sessionId, speaker, text, startTime, endTime, segmentOrder, createdAt, segmentId, speakerLabel, isUser, personId)
-                    VALUES(?, 1, '(gentle music)', 1.0, 5.0, 1, ?, 'seg-music', 'SPEAKER_01', 0, NULL)
-                    """,
-                arguments: [sessionId, now]
-            )
-            try db.execute(
-                sql: """
-                    INSERT INTO transcription_segments(sessionId, speaker, text, startTime, endTime, segmentOrder, createdAt, segmentId, speakerLabel, isUser, personId)
-                    VALUES(?, 1, 'This is a clean reviewable speaker turn.', 6.0, 10.0, 2, ?, 'seg-reviewable', 'SPEAKER_01', 0, NULL)
-                    """,
-                arguments: [sessionId, now]
-            )
-        }
+        try await insertSegment(in: dbQueue, sessionId: sessionId, text: "ok", start: 0.0, end: 0.5, order: 0, now: now, segmentId: "seg-short")
+        try await insertSegment(in: dbQueue, sessionId: sessionId, text: "(gentle music)", start: 1.0, end: 5.0, order: 1, now: now, segmentId: "seg-music")
+        try await insertSegment(
+            in: dbQueue,
+            sessionId: sessionId,
+            text: "This is a clean reviewable speaker turn.",
+            start: 6.0,
+            end: 10.0,
+            order: 2,
+            now: now,
+            segmentId: "seg-reviewable"
+        )
 
         let embedding = SpeakerEmbeddingRecord.encode([1, 0, 0])
-        try await dbQueue.write { db in
-            for (start, end) in [(0.0, 0.5), (1.0, 5.0), (6.0, 10.0)] {
-                try db.execute(
-                    sql: """
-                        INSERT INTO speaker_embeddings(sessionId, chunkId, embedding, embeddingDim, startTime, endTime, speakerId, personId, createdAt, assignmentSource, matchConfidence, embeddingModel, embeddingVersion, isTrainingSample)
-                        VALUES(?, NULL, ?, 3, ?, ?, 1, NULL, ?, NULL, NULL, 'mfcc', 1, 0)
-                        """,
-                    arguments: [sessionId, embedding, start, end, now]
-                )
-            }
+        for (start, end) in [(0.0, 0.5), (1.0, 5.0), (6.0, 10.0)] {
+            try await insertEmbedding(in: dbQueue, sessionId: sessionId, embedding: embedding, start: start, end: end, now: now)
         }
 
-        let pid = UUID().uuidString
-        try await dbQueue.write { db in
-            try db.execute(
-                sql: "INSERT INTO people(id, displayName, defaultEmoji, createdAt, updatedAt) VALUES(?, 'Cluster Person', NULL, ?, ?)",
-                arguments: [pid, now, now]
-            )
-        }
+        let pid = try await insertPerson(in: dbQueue, name: "Cluster Person", now: now)
 
         let ok = await PeopleStore.shared.assignSegments(
             sessionId: sessionId,
@@ -326,21 +293,9 @@ final class VoiceProfileAssignmentRegressionTests: XCTestCase {
     }
 
     func testRecordEmbeddingDoesNotPersistConfidenceWithoutAppliedPerson() async throws {
-        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
-            throw XCTSkip("database queue unavailable")
-        }
-
+        let dbQueue = try await requireDatabaseQueue()
         let now = Date()
-        let sessionId: Int64 = try await dbQueue.write { db in
-            try db.execute(
-                sql: """
-                    INSERT INTO transcription_sessions(startedAt, source, language, timezone, status, retryCount, backendSynced, createdAt, updatedAt, summary_state)
-                    VALUES(?, 'desktop', 'en', 'UTC', 'completed', 0, 0, ?, ?, 'pending')
-                    """,
-                arguments: [now, now, now]
-            )
-            return db.lastInsertedRowID
-        }
+        let sessionId = try await insertSession(in: dbQueue, now: now)
 
         _ = await SpeakerEmbeddingStore.shared.recordEmbedding(
             sessionId: sessionId,
@@ -354,13 +309,7 @@ final class VoiceProfileAssignmentRegressionTests: XCTestCase {
             matchConfidence: 0.77
         )
 
-        let pid = UUID().uuidString
-        try await dbQueue.write { db in
-            try db.execute(
-                sql: "INSERT INTO people(id, displayName, defaultEmoji, createdAt, updatedAt) VALUES(?, 'Known', NULL, ?, ?)",
-                arguments: [pid, now, now]
-            )
-        }
+        let pid = try await insertPerson(in: dbQueue, name: "Known", now: now)
 
         _ = await SpeakerEmbeddingStore.shared.recordEmbedding(
             sessionId: sessionId,
@@ -392,28 +341,14 @@ final class VoiceProfileAssignmentRegressionTests: XCTestCase {
     }
 
     func testMergePersonIsAtomicAcrossSegmentsEmbeddingsAndPeople() async throws {
-        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
-            throw XCTSkip("database queue unavailable")
-        }
-
+        let dbQueue = try await requireDatabaseQueue()
         let now = Date()
-        let sessionId: Int64 = try await dbQueue.write { db in
-            try db.execute(
-                sql: """
-                    INSERT INTO transcription_sessions(startedAt, source, language, timezone, status, retryCount, backendSynced, createdAt, updatedAt, summary_state)
-                    VALUES(?, 'desktop', 'en', 'UTC', 'completed', 0, 0, ?, ?, 'pending')
-                    """,
-                arguments: [now, now, now]
-            )
-            return db.lastInsertedRowID
-        }
+        let sessionId = try await insertSession(in: dbQueue, now: now)
 
         let sourceId = UUID().uuidString
         let targetId = UUID().uuidString
-        try await dbQueue.write { db in
-            try db.execute(sql: "INSERT INTO people(id, displayName, defaultEmoji, createdAt, updatedAt) VALUES(?, 'Source', NULL, ?, ?)", arguments: [sourceId, now, now])
-            try db.execute(sql: "INSERT INTO people(id, displayName, defaultEmoji, createdAt, updatedAt) VALUES(?, 'Target', NULL, ?, ?)", arguments: [targetId, now, now])
-        }
+        try await insertPerson(in: dbQueue, name: "Source", now: now, id: sourceId)
+        try await insertPerson(in: dbQueue, name: "Target", now: now, id: targetId)
 
         try await dbQueue.write { db in
             try db.execute(

--- a/Desktop/Tests/VoiceProfileAssignmentRegressionTests.swift
+++ b/Desktop/Tests/VoiceProfileAssignmentRegressionTests.swift
@@ -150,7 +150,7 @@ final class VoiceProfileAssignmentRegressionTests: XCTestCase {
             )
         }
 
-        await SpeakerEmbeddingStore.shared.assignPersonToEmbeddings(sessionId: sessionId, speakerId: 1, personId: pid)
+        try await SpeakerEmbeddingStore.shared.assignPersonToEmbeddings(sessionId: sessionId, speakerId: 1, personId: pid)
 
         let training: Int = try await dbQueue.read { db in
             try Int.fetchOne(
@@ -230,6 +230,99 @@ final class VoiceProfileAssignmentRegressionTests: XCTestCase {
 
         XCTAssertEqual(row.0, pid)
         XCTAssertEqual(row.1, 0, "Short selected overlap should not train the voice profile")
+    }
+
+    func testFullClusterAssignmentLabelsExcludedSegmentsButOnlyReviewableRangesTrain() async throws {
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+            throw XCTSkip("database queue unavailable")
+        }
+
+        let now = Date()
+        let sessionId: Int64 = try await dbQueue.write { db in
+            try db.execute(
+                sql: """
+                    INSERT INTO transcription_sessions(startedAt, source, language, timezone, status, retryCount, backendSynced, createdAt, updatedAt, summary_state)
+                    VALUES(?, 'desktop', 'en', 'UTC', 'completed', 0, 0, ?, ?, 'pending')
+                    """,
+                arguments: [now, now, now]
+            )
+            return db.lastInsertedRowID
+        }
+        try await dbQueue.write { db in
+            try db.execute(sql: "UPDATE transcription_sessions SET backendId = ? WHERE id = ?", arguments: ["local-\(sessionId)", sessionId])
+        }
+
+        try await dbQueue.write { db in
+            try db.execute(
+                sql: """
+                    INSERT INTO transcription_segments(sessionId, speaker, text, startTime, endTime, segmentOrder, createdAt, segmentId, speakerLabel, isUser, personId)
+                    VALUES(?, 1, 'ok', 0.0, 0.5, 0, ?, 'seg-short', 'SPEAKER_01', 0, NULL)
+                    """,
+                arguments: [sessionId, now]
+            )
+            try db.execute(
+                sql: """
+                    INSERT INTO transcription_segments(sessionId, speaker, text, startTime, endTime, segmentOrder, createdAt, segmentId, speakerLabel, isUser, personId)
+                    VALUES(?, 1, '(gentle music)', 1.0, 5.0, 1, ?, 'seg-music', 'SPEAKER_01', 0, NULL)
+                    """,
+                arguments: [sessionId, now]
+            )
+            try db.execute(
+                sql: """
+                    INSERT INTO transcription_segments(sessionId, speaker, text, startTime, endTime, segmentOrder, createdAt, segmentId, speakerLabel, isUser, personId)
+                    VALUES(?, 1, 'This is a clean reviewable speaker turn.', 6.0, 10.0, 2, ?, 'seg-reviewable', 'SPEAKER_01', 0, NULL)
+                    """,
+                arguments: [sessionId, now]
+            )
+        }
+
+        let embedding = SpeakerEmbeddingRecord.encode([1, 0, 0])
+        try await dbQueue.write { db in
+            for (start, end) in [(0.0, 0.5), (1.0, 5.0), (6.0, 10.0)] {
+                try db.execute(
+                    sql: """
+                        INSERT INTO speaker_embeddings(sessionId, chunkId, embedding, embeddingDim, startTime, endTime, speakerId, personId, createdAt, assignmentSource, matchConfidence, embeddingModel, embeddingVersion, isTrainingSample)
+                        VALUES(?, NULL, ?, 3, ?, ?, 1, NULL, ?, NULL, NULL, 'mfcc', 1, 0)
+                        """,
+                    arguments: [sessionId, embedding, start, end, now]
+                )
+            }
+        }
+
+        let pid = UUID().uuidString
+        try await dbQueue.write { db in
+            try db.execute(
+                sql: "INSERT INTO people(id, displayName, defaultEmoji, createdAt, updatedAt) VALUES(?, 'Cluster Person', NULL, ?, ?)",
+                arguments: [pid, now, now]
+            )
+        }
+
+        let ok = await PeopleStore.shared.assignSegments(
+            sessionId: sessionId,
+            segmentIds: ["#index:0", "#index:1", "#index:2"],
+            personId: pid,
+            isUser: false
+        )
+        XCTAssertTrue(ok)
+
+        let segmentPeople: [String?] = try await dbQueue.read { db in
+            try Row.fetchAll(
+                db,
+                sql: "SELECT personId FROM transcription_segments WHERE sessionId = ? ORDER BY segmentOrder",
+                arguments: [sessionId]
+            ).map { $0["personId"] }
+        }
+        XCTAssertEqual(segmentPeople, [pid, pid, pid])
+
+        let embeddings: [(Double, String?, Int)] = try await dbQueue.read { db in
+            try Row.fetchAll(
+                db,
+                sql: "SELECT startTime, personId, isTrainingSample FROM speaker_embeddings WHERE sessionId = ? ORDER BY startTime",
+                arguments: [sessionId]
+            ).map { ($0["startTime"], $0["personId"], $0["isTrainingSample"] ?? 0) }
+        }
+        XCTAssertEqual(embeddings.map(\.1), [pid, pid, pid])
+        XCTAssertEqual(embeddings.map(\.2), [0, 0, 1])
     }
 
     func testRecordEmbeddingDoesNotPersistConfidenceWithoutAppliedPerson() async throws {

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,47 +1,64 @@
-# Voice Fingerprinting For Transcript Speaker Identity
+# Descript-Style Speaker Identification
 
-Issue: #111
+Issue: #112
 
-## Implementation Checklist
+## UX Scenarios
 
-- [x] Confirm current speaker diarization, assignment, and people flows
-- [x] Add voice-profile metadata migrations for speaker embedding samples
-- [x] Replace raw optional person match with conservative known/suggested/unknown result
-- [x] Make speaker assignment apply to all same-session speaker segments by default
-- [x] Persist confirmed assignment metadata and backfill matching speaker embeddings
-- [x] Surface confidence/suggestion metadata to transcript models where needed
-- [x] Add People voice-profile management primitives for reset/delete/merge basics
-- [x] Add focused tests for assignment and matcher behavior
-- [x] Run Swift build/tests
-- [x] Review diff, update docs if API/UX behavior changed
+- [x] From a transcript, Mike can click any speaker label or avatar, including the purple `Y`, to correct who is speaking.
+- [x] From a transcript, Mike can open an `Identify Speakers` flow that reviews each unknown/suggested speaker cluster one at a time.
+- [x] For each detected speaker, Mike hears a short representative audio sample before choosing an existing person or creating a new one.
+- [x] If the sample is unclear, Mike can play another sample from the same speaker cluster.
+- [x] Once Mike identifies a speaker, IR labels matching segments in that conversation and updates the local voice profile.
+- [x] Over time, confirmed profiles let IR suggest or auto-apply names across newly recorded conversations.
+- [x] Raw mixed mic+system audio is retained locally only for a configurable review window, defaulting to 7 days, then deleted while embeddings and transcript labels remain.
+- [x] After a recording finishes, IR prompts Mike to identify speakers when unknown or suggested speakers exist.
 
-## Verification
+## Current State
 
-- [x] `xcrun swift build -c debug --package-path Desktop`
-- [x] `xcrun swift test --package-path Desktop --filter TranscriptSpeakerAssignmentTests`
-- [x] Delegate read-only review of recent session changes to at least 3 subagents
-- [x] Aggregate review feedback and identify actionable findings
-- [x] Delegate fixes for actionable findings; issues were addressed
-- [x] Adjudicate questionable single-agent findings; only consensus fixes were delegated for implementation
-- [x] Delegate local CI-equivalent workflow run for `.github/workflows/*`; Swift build/tests, Rust cargo tests, and diff check passed
-- [ ] Review all user commands from this session and confirm completion
-- [ ] Close exit-gate items from the default workflow
-- [ ] Commit completed work
-- [ ] Merge completed work to main
-- [ ] Cleanup branch/worktree artifacts
-- [ ] Verify GitHub Actions on main are passing green
+- [x] Voice profiles and conservative known/suggested/unknown identity decisions exist from #111.
+- [x] Transcript speaker picker exists, but `isUser` / `You` bubbles are not clickable.
+- [x] `audio_chunks` schema already exists for local PCM storage.
+- [x] `AudioPersistenceService` already exists, but the current live audio path does not appear wired to append mixed audio chunks.
 
-## Results
+## Plan
 
-- First-pass voice identity backbone landed: conservative matching states, voice-profile sample metadata, assignment backfill hardening, and focused tests.
-- Adjudication round completed: consensus fixes are migration append-ordering, short/noisy manual-sample gating, and separating suggested/unknown confidence from applied identities.
-- Final CI-equivalent verification completed after all fixes: `xcrun swift build`, full Swift tests, Rust tests with/without `activity_test_wiring`, and `git diff --check` passed.
-- `test-install.yml` was checked with non-mutating equivalents; full install flow was not run because it writes to `/Applications`, mounts a DMG, launches the GUI app, and deletes the app.
-- Read-only release lookup found latest Omi release assets `omi.dmg` and `Omi.zip`, while `test-install.yml` currently looks for `Omi.Beta.dmg`.
-- People management UI remains a follow-up layer on top of the new reset/delete/merge store primitives.
+- [x] Make speaker labels and avatars clickable for every segment, including `You`.
+  - Existing code gates taps in `TranscriptDetailView`, `ConversationDetailView.transcriptBubblesContent`, and `SpeakerBubbleView`.
+- [x] Update `NameSpeakerSheet` so reassignment from `You` to a person is first-class, not blocked by `isUser`.
+  - Existing same-speaker filters exclude `isUser`; remove that exclusion while still saving `isUser=false` for normal people.
+- [x] Add an `Identify Speakers` entry point in the transcript header or speaker count pill.
+  - Use the drawer header because unknown/suggested state is visible while reviewing transcript detail.
+- [x] Build a review queue grouped by session speaker cluster and suggested/unknown identity state.
+  - Use `TranscriptSegment.speakerId`, `personId`, and suggested metadata; exclude already named known speakers from the default queue.
+- [x] Select good playback samples per speaker: prefer clear speech, 3-8 seconds, enough duration, no music/noise-only text, avoid very short turns.
+  - Add deterministic sample-selection helpers so tests can cover the filter without SwiftUI.
+- [x] Wire live mixed audio into `AudioPersistenceService` and link chunks to `transcriptionSessionId`.
+  - Existing tee in `AppState.startMicrophoneAudioCapture` sends mono mix to WhisperKit and diarization only.
+- [x] Add audio fetch APIs for a session/time range and convert PCM to playable audio for review.
+  - Add this to `AudioPersistenceService` near existing chunk writes; UI can play a temporary WAV file via `AVAudioPlayer`.
+- [x] Add a configurable local retention policy for `audio_chunks`; default to 7 days and purge on app launch and periodically.
+  - Store the setting in `UserDefaults` and purge from `RewindDatabase.performInitialization` plus service timer/explicit calls.
+- [x] Confirmed speaker identification should update transcript segments plus speaker embeddings for the selected sample ranges.
+  - Existing `PeopleStore.assignSegments` already backfills embeddings by segment time range; review flow should call the same assignment path.
+- [x] Cross-conversation behavior should apply automatically when confidence is high; do not add a second broad-apply confirmation step.
+- [x] Keep wrong-name risk low with strict thresholds, sample-count gates, and no training from excluded samples.
+- [x] Exclude short/music/noise-only segments like `(gentle music)` from speaker review and voice training.
+- [x] Add tests for clickable-user reassignment, audio retention purge, sample selection, and assignment backfill by sample range.
 
-## Review Notes
+## Decisions
 
-- Optimize for fewer wrong names over faster auto-labeling.
-- Store embeddings only; do not retain raw audio snippets for voice identity.
-- Treat Mike as a normal person profile, not a special `You` identity.
+- [x] Retain mixed mic+system audio only; no separate mic/system channel storage for this feature.
+- [x] Make retention a setting, with 7 days as the default.
+- [x] Show the Identify Speakers prompt automatically after a recording when reviewable speakers exist.
+- [x] Do not require a second cross-conversation apply confirmation.
+- [x] Exclude short/music/noise segments from speaker review and voice training.
+
+## References
+
+- Descript flow: detect speakers, then identify by listening to samples and assigning names.
+- Descript docs: https://help.descript.com/hc/en-us/articles/10249423506061-Detect-and-label-speakers-in-your-transcript
+- Descript speaker labels docs: https://help.descript.com/hc/en-us/articles/10164803814285-Speakers
+
+## Open Questions
+
+- When one speaker cluster has multiple possible people, should the UI require review before applying any name, or show suggested names inline?

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -62,3 +62,11 @@ Issue: #112
 ## Open Questions
 
 - When one speaker cluster has multiple possible people, should the UI require review before applying any name, or show suggested names inline?
+
+## Follow-up Review Todo
+
+- [x] Delegate at least 3 subagents to code review the recent session changes.
+- [x] Aggregate review feedback and identify consensus findings.
+- [x] Delegate fixes for consensus review findings.
+- [x] If a questionable finding appears from only one reviewer, delegate 3 more subagents to validate whether it is real before fixing.
+- [x] After addressing feedback, delegate a local CI-equivalent run covering the same logic as `.github/workflows/*`.


### PR DESCRIPTION
## Summary
- make transcript speaker labels and avatars clickable, including You
- add Identify Speakers review flow with suggested/unknown queue, sample playback, skip, You/person assignment, and post-recording auto-open gating
- persist live mixed audio chunks with session linkage, WAV review fetch, retention purge/settings, and mic-only mixer output
- tighten speaker assignment success semantics and add focused tests

## Verification
- git diff --check
- xcrun swift build -c debug --package-path Desktop
- xcrun swift test --package-path Desktop (451 tests)
- cargo test --locked -p infinite-recall-api
- cargo test --locked -p infinite-recall-api --features activity_test_wiring
- GitNexus detect_changes scope=all

Closes #112

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audio review playback with WAV export for selected conversation excerpts
  * Speaker identification review sheet with assign/confirm workflow and sample playback
  * Audio review retention setting (1/3/7/14/30 days)

* **Improvements**
  * More robust mixed audio handling with better mic/system alignment and availability handling
  * Clickable speaker labels, explicit “You” display, people-selection UI, and auto-open identify-speakers flow
  * Launch-time audio retention cleanup and orphaned-audio linking

* **Bug Fixes**
  * Faster failure when transcription session is missing

* **Tests**
  * New tests for audio persistence, mixing, retention, and speaker-assignment logic
<!-- end of auto-generated comment: release notes by coderabbit.ai -->