### PR TITLE
fix(data-loss): soft-discard sessions instead of hard-DELETE

### DIFF
--- a/Desktop/Sources/Rewind/Core/RewindDatabase.swift
+++ b/Desktop/Sources/Rewind/Core/RewindDatabase.swift
@@ -2530,6 +2530,30 @@ actor RewindDatabase {
                 """)
         }
 
+        // Soft-discard metadata: replaces hard-DELETE in `discardEmptySession`
+        // so user data survives the summarize/transcribe race and a future
+        // recovery UI can list + restore auto-discarded rows. No backfill —
+        // pre-existing rows keep null reason/timestamp.
+        migrator.registerMigration("addDiscardMetadataColumns") { db in
+            // Be idempotent: a fork or partial migration may have added
+            // either column already.
+            let info = try Row.fetchAll(db, sql: "PRAGMA table_info(transcription_sessions)")
+            let existingColumns = Set(info.compactMap { ($0["name"] as String?) })
+
+            if !existingColumns.contains("discard_reason") {
+                try db.execute(sql: """
+                    ALTER TABLE transcription_sessions
+                      ADD COLUMN discard_reason TEXT
+                    """)
+            }
+            if !existingColumns.contains("discarded_at") {
+                try db.execute(sql: """
+                    ALTER TABLE transcription_sessions
+                      ADD COLUMN discarded_at DATETIME
+                    """)
+            }
+        }
+
         migrator.registerMigration("createKGProvenanceAndExtractionStatus") { db in
             try db.create(table: "local_kg_node_sources") { t in
                 t.column("memoryId", .integer).notNull()

--- a/Desktop/Sources/Rewind/Core/RewindDatabase.swift
+++ b/Desktop/Sources/Rewind/Core/RewindDatabase.swift
@@ -2534,6 +2534,10 @@ actor RewindDatabase {
         // so user data survives the summarize/transcribe race and a future
         // recovery UI can list + restore auto-discarded rows. No backfill —
         // pre-existing rows keep null reason/timestamp.
+        //
+        // TODO(PR B / recovery UI): add indexes on `discarded` and
+        // `discarded_at` once the "Recently auto-deleted" page lands and
+        // becomes a hot reader — see #114 plan.
         migrator.registerMigration("addDiscardMetadataColumns") { db in
             // Be idempotent: a fork or partial migration may have added
             // either column already.

--- a/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
+++ b/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
@@ -706,6 +706,7 @@ actor TranscriptionStorage {
 
         log("TranscriptionStorage: Soft-discarding session \(id) — reason=\(reason)")
 
+        let now = Date()
         try await db.write { database in
             try database.execute(
                 sql: """
@@ -713,10 +714,11 @@ actor TranscriptionStorage {
                        SET discarded = 1,
                            discard_reason = ?,
                            discarded_at = ?,
-                           summary_state = 'unavailable'
+                           summary_state = 'unavailable',
+                           updatedAt = ?
                      WHERE id = ?
                     """,
-                arguments: [reason, Date(), id]
+                arguments: [reason, now, now, id]
             )
         }
     }
@@ -735,21 +737,25 @@ actor TranscriptionStorage {
     /// awaiting backoff/retry and the transcribe attempt can still recover.
     ///
     /// Dedup key matches `ConversationTranscribeBackfillService.dedupKey(for:)`
-    /// — kept inline rather than imported to avoid a circular dep.
+    /// — kept inline rather than imported to avoid a circular dep on the
+    /// backfill service. `PendingWork.Kind` itself lives in `Core` and is
+    /// safely shared across the module, so we use its rawValue constant
+    /// instead of a literal string.
     func transcribeIsTerminal(sessionId: Int64) async throws -> Bool {
         let db = try await ensureInitialized()
-        let dedupKey = "transcribe:\(sessionId)"
+        let workType = PendingWork.Kind.transcribe.rawValue
+        let dedupKey = "\(workType):\(sessionId)"
 
         let activeCount: Int = try await db.read { database in
             try Int.fetchOne(
                 database,
                 sql: """
                     SELECT COUNT(*) FROM pending_work
-                     WHERE workType = 'transcribe'
+                     WHERE workType = ?
                        AND dedupKey = ?
                        AND status IN ('queued', 'claimed', 'failed')
                     """,
-                arguments: [dedupKey]
+                arguments: [workType, dedupKey]
             ) ?? 0
         }
         return activeCount == 0

--- a/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
+++ b/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
@@ -688,38 +688,71 @@ actor TranscriptionStorage {
         }
     }
 
-    /// Hard-delete a single empty Short Recording conversation (and its
-    /// segments + audio chunks) atomically. Used by the auto-delete path for
-    /// `summary_state='unavailable'` rows that are local-only and never sync.
+    /// Soft-discard a single empty conversation by flipping `discarded=1` and
+    /// recording the reason + timestamp. Replaces the previous hard-DELETE
+    /// implementation, which destroyed user data when summarize raced ahead
+    /// of the now-async transcribe job (PR #79 + #86 regression).
     ///
-    /// All mutations run inside a single GRDB transaction so we never end up
-    /// with orphaned segments or chunks if the process dies mid-delete.
-    ///
-    /// Note: `audio_chunks` stores raw PCM directly as a blob (`pcm` column);
-    /// there is no separate on-disk audio file path to unlink. Deleting the
-    /// row is sufficient to remove the audio bytes.
+    /// The conversation list, RAG, and chat tools all already filter on
+    /// `discarded`, so a soft-discarded row disappears from the user's view
+    /// the same way a hard-deleted one did — but the audio_chunks + segments
+    /// stay intact so a future recovery UI can restore the row.
     ///
     /// - Parameters:
     ///   - id: session id to discard
-    ///   - reason: short tag included in the log line for traceability
+    ///   - reason: short tag persisted in `discard_reason` and the log line
     func discardEmptySession(id: Int64, reason: String) async throws {
         let db = try await ensureInitialized()
 
-        log("TranscriptionStorage: Discarding empty session \(id) — reason=\(reason)")
+        log("TranscriptionStorage: Soft-discarding session \(id) — reason=\(reason)")
 
         try await db.write { database in
             try database.execute(
-                sql: "DELETE FROM audio_chunks WHERE transcriptionSessionId = ?",
-                arguments: [id]
-            )
-            // transcription_segments rows cascade via FK on transcription_sessions delete.
-            try database.execute(
-                sql: "DELETE FROM transcription_sessions WHERE id = ?",
-                arguments: [id]
+                sql: """
+                    UPDATE transcription_sessions
+                       SET discarded = 1,
+                           discard_reason = ?,
+                           discarded_at = ?,
+                           summary_state = 'unavailable'
+                     WHERE id = ?
+                    """,
+                arguments: [reason, Date(), id]
             )
         }
+    }
 
-        log("Auto-deleted empty conversation \(id) — reason=\(reason)")
+    /// Returns true when the `.transcribe` work for `sessionId` has reached
+    /// a terminal state — i.e. there is no `queued`, `claimed`, or `failed`
+    /// pending_work row for that session's transcribe dedup key.
+    ///
+    /// Used by the summarize path to defer auto-discarding empty transcripts
+    /// while transcribe is still in-flight. `done`/`dead` rows count as
+    /// terminal; missing rows also count as terminal (the transcribe job
+    /// either drained, was never enqueued, or was hand-cleaned). `failed`
+    /// rows are explicitly NOT terminal — `PendingWorkStorage` claims work
+    /// with `status IN ('queued', 'failed')` and the dedup partial unique
+    /// index treats `failed` as part of the active set, so a `failed` row is
+    /// awaiting backoff/retry and the transcribe attempt can still recover.
+    ///
+    /// Dedup key matches `ConversationTranscribeBackfillService.dedupKey(for:)`
+    /// — kept inline rather than imported to avoid a circular dep.
+    func transcribeIsTerminal(sessionId: Int64) async throws -> Bool {
+        let db = try await ensureInitialized()
+        let dedupKey = "transcribe:\(sessionId)"
+
+        let activeCount: Int = try await db.read { database in
+            try Int.fetchOne(
+                database,
+                sql: """
+                    SELECT COUNT(*) FROM pending_work
+                     WHERE workType = 'transcribe'
+                       AND dedupKey = ?
+                       AND status IN ('queued', 'claimed', 'failed')
+                    """,
+                arguments: [dedupKey]
+            ) ?? 0
+        }
+        return activeCount == 0
     }
 
     /// Fetch the first segment's text per session in a single SQL pass.

--- a/Desktop/Sources/Rewind/Services/ConversationActionItemsBackfillService.swift
+++ b/Desktop/Sources/Rewind/Services/ConversationActionItemsBackfillService.swift
@@ -179,6 +179,7 @@ actor ConversationActionItemsBackfillService {
             SELECT s.id FROM transcription_sessions AS s
              WHERE s.finishedAt IS NOT NULL
                AND s.deleted = 0
+               AND s.discarded = 0
                AND s.action_items_extracted_at IS NULL
                AND EXISTS (
                    SELECT 1 FROM transcription_segments seg

--- a/Desktop/Sources/Rewind/Services/ConversationSummaryBackfillService.swift
+++ b/Desktop/Sources/Rewind/Services/ConversationSummaryBackfillService.swift
@@ -198,13 +198,20 @@ actor ConversationSummaryBackfillService {
         log("ConversationSummaryBackfillService: marked backfill needed (\(reason))")
     }
 
-    /// One-time sweep: convert pre-existing "Short Recording" placeholder
-    /// sessions into discarded/empty rows so the conversations list stops
-    /// showing legacy noise from the old short-transcript path. Idempotent
-    /// via the `irEmptyShortRecordingBackfillCompletedV1` UserDefaults flag —
-    /// safe to call on every launch.
+    /// One-time sweep: soft-discard pre-existing rows that are genuinely
+    /// empty (no transcription segments) and were marked unavailable by the
+    /// summary-state migration. Soft-discard via the rewritten
+    /// `discardEmptySession`, so rows land in the recovery panel and stay
+    /// recoverable.
+    ///
+    /// V2 supersedes V1, which keyed off `title = 'Short Recording'` — that
+    /// title was a catch-all placeholder that ate sessions far longer than
+    /// 2-second blips. V2 only sweeps rows with zero segments, so a session
+    /// with real transcript content but an unfortunate title is left alone.
+    /// We bump the flag so machines that completed V1 re-run with the
+    /// safer V2 rules. Idempotent — safe to call on every launch.
     func backfillDiscardEmptyShortRecordingsOnce() async {
-        let flagKey = "irEmptyShortRecordingBackfillCompletedV1"
+        let flagKey = "irEmptyShortRecordingBackfillCompletedV2"
         guard !UserDefaults.standard.bool(forKey: flagKey) else {
             return
         }
@@ -214,11 +221,18 @@ actor ConversationSummaryBackfillService {
             return
         }
 
+        // Only rows that are genuinely empty (no segments) AND already marked
+        // unavailable. Drops the V1 title='Short Recording' criterion — that
+        // was over-aggressive — and replaces it with a hard structural check.
         let sql = """
             SELECT id FROM transcription_sessions
              WHERE deleted = 0
+               AND discarded = 0
                AND summary_state = 'unavailable'
-               AND title = 'Short Recording'
+               AND (
+                   SELECT COUNT(*) FROM transcription_segments seg
+                    WHERE seg.sessionId = transcription_sessions.id
+               ) = 0
             """
 
         let ids: [Int64]
@@ -245,6 +259,9 @@ actor ConversationSummaryBackfillService {
 
         if failures == 0 {
             UserDefaults.standard.set(true, forKey: flagKey)
+            // V1 flag is obsolete after V2 sweep — clear it to avoid stale
+            // keys accumulating across future Vn bumps.
+            UserDefaults.standard.removeObject(forKey: "irEmptyShortRecordingBackfillCompletedV1")
             log("ConversationSummaryBackfillService: discard-empty backfill complete — processed \(ids.count) row(s)")
         } else {
             log("ConversationSummaryBackfillService: discard-empty backfill partial — \(ids.count - failures) ok, \(failures) failed; will retry next launch")
@@ -339,10 +356,20 @@ actor ConversationSummaryBackfillService {
         let sessionId = row.id
         let transcript = row.transcript
 
-        // Short transcript → discard the empty session entirely instead of
+        // Short transcript → soft-discard the empty session instead of
         // writing a "Short Recording" placeholder. Empty short recordings
-        // are noise in the conversations list; surface them as deleted.
+        // are noise in the conversations list; surface them as discarded.
+        //
+        // BUT: PR #79 made transcribe an enqueued job, so summarize can fire
+        // before any segments exist on a freshly-finished recording. Defer
+        // when transcribe is still queued/claimed — otherwise we'd discard
+        // every recording that takes longer to transcribe than to summarize.
         guard transcript.count >= Self.minTranscriptLength else {
+            let isTerminal = try await TranscriptionStorage.shared.transcribeIsTerminal(sessionId: sessionId)
+            guard isTerminal else {
+                log("ConversationSummaryBackfillService: session \(sessionId) transcript empty but transcribe not terminal — deferring (\(mode))")
+                return .deferred
+            }
             log("ConversationSummaryBackfillService: session \(sessionId) transcript too short (\(transcript.count) chars), discarding empty session (\(mode))")
             try await TranscriptionStorage.shared.discardEmptySession(id: sessionId, reason: "short_transcript")
             await notifyConversationListNeedsRefresh()

--- a/Desktop/Sources/Rewind/Services/ConversationSummaryBackfillService.swift
+++ b/Desktop/Sources/Rewind/Services/ConversationSummaryBackfillService.swift
@@ -229,10 +229,10 @@ actor ConversationSummaryBackfillService {
              WHERE deleted = 0
                AND discarded = 0
                AND summary_state = 'unavailable'
-               AND (
-                   SELECT COUNT(*) FROM transcription_segments seg
+               AND NOT EXISTS (
+                   SELECT 1 FROM transcription_segments seg
                     WHERE seg.sessionId = transcription_sessions.id
-               ) = 0
+               )
             """
 
         let ids: [Int64]

--- a/Desktop/Sources/Rewind/Services/ConversationTranscribeBackfillService.swift
+++ b/Desktop/Sources/Rewind/Services/ConversationTranscribeBackfillService.swift
@@ -119,6 +119,7 @@ actor ConversationTranscribeBackfillService {
             SELECT s.id FROM transcription_sessions AS s
              WHERE s.finishedAt IS NOT NULL
                AND s.deleted = 0
+               AND s.discarded = 0
                AND NOT EXISTS (
                    SELECT 1 FROM transcription_segments seg
                     WHERE seg.sessionId = s.id


### PR DESCRIPTION
## Summary

PR A of #114 — stops the live race that hard-deleted user conversations when summarize fired before the (now-async) transcribe job drained. PR B (recovery UI + legacy-uid recovery script) is separate.

## What changed

- **`discardEmptySession`** flips from hard `DELETE` to soft `UPDATE discarded=1, summary_state='unavailable', discard_reason, discarded_at`. Adds the two metadata columns via new `addDiscardMetadataColumns` migration.
- **`transcribeIsTerminal(sessionId:)`** new helper: queries `pending_work` for active rows (`queued`/`claimed`/`failed` — `failed` is awaiting retry per queue semantics).
- **`process()`** short-transcript branch defers when transcript empty AND transcribe still active.
- **`backfillDiscardEmptyShortRecordingsOnce`** drops `title='Short Recording'` (over-aggressive); requires zero segments + `discarded=0`; flag bumped V1→V2; clears stale V1 key.
- **`ConversationTranscribeBackfillService` + `ConversationActionItemsBackfillService`** filter `discarded=0` so soft-discarded rows aren't resurrected by re-enqueue.

## Review process

3 parallel reviewers (`code-reviewer`, `silent-failure-hunter`, `feature-dev:code-reviewer`) → 5 consensus fixes applied. 1 single-agent CRITICAL claim (segment-commit/status race) put to a 3-voter vote — refuted 3-0 (GRDB writer-queue serializes; `ack()` runs strictly after segment commits).

## Test plan

- [x] `xcrun swift build -c debug --package-path Desktop` — passes
- [x] `xcrun swift test --package-path Desktop` — passes
- [x] `cargo test --locked -p infinite-recall-api` — passes
- [x] `cargo test --locked -p infinite-recall-api --features activity_test_wiring` — passes
- [ ] Manual: record a 2-second clip, tail `/private/tmp/omi-dev.log`, confirm "deferred" or "Soft-discarding" instead of "Auto-deleted"
- [ ] Manual: confirm prior conversations stop disappearing on next launch sweep

Closes #114 once PR B (recovery UI + legacy-uid recovery script) lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Database now stores soft-discard metadata (discard reason and timestamp).

* **Improvements**
  * Empty sessions are soft-discarded instead of hard-deleted; short sessions defer discard until transcription is fully complete.
  * One-time backfill selects by summary state and segment count (V2) and clears the old flag after completion.
  * Discarded sessions are excluded from background processing and backfills.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->