### PR TITLE
fix(ir): daemon cold-start, Rewind spinner, conversations sweeper

### DIFF
--- a/Backend-Rust/api/src/db.rs
+++ b/Backend-Rust/api/src/db.rs
@@ -25,12 +25,78 @@ use rusqlite::OpenFlags;
 pub type SqlitePool = Pool<SqliteConnectionManager>;
 pub type PooledConn = r2d2::PooledConnection<SqliteConnectionManager>;
 
+/// Classify whether a startup DB-open failure is worth retrying.
+///
+/// Transient: file-missing (Swift app may still be creating it), SQLITE_BUSY
+/// / SQLITE_LOCKED (active writer), SQLITE_IOERR family (filesystem hiccup,
+/// often clears on a brief retry), SQLITE_CANTOPEN (shared-state file race
+/// during boot), SQLITE_PROTOCOL (transient WAL handshake).
+///
+/// Terminal: permission denied, SQLITE_NOTADB (real corruption), schema
+/// mismatch — retrying will not change the outcome and the caller should
+/// bail immediately.
+pub fn is_transient_open_error(err: &anyhow::Error) -> bool {
+    // Walk the full error chain. Anyhow contexts wrap io::Error / rusqlite
+    // errors, and r2d2::Error wraps rusqlite::Error inside its own type —
+    // both should be reachable via `source()` (which `anyhow::Chain` walks
+    // for us) so a single chain walk handles every wrapping layer.
+    for cause in err.chain() {
+        if let Some(io_err) = cause.downcast_ref::<std::io::Error>() {
+            if matches!(io_err.kind(), std::io::ErrorKind::NotFound) {
+                return true;
+            }
+            // Other io kinds (PermissionDenied, etc.) are terminal.
+            return false;
+        }
+        if let Some(rs_err) = cause.downcast_ref::<rusqlite::Error>() {
+            if let rusqlite::Error::SqliteFailure(ffi, _) = rs_err {
+                use rusqlite::ErrorCode::*;
+                // rusqlite collapses extended codes to a primary-code enum:
+                // SQLITE_IOERR family -> SystemIoFailure, SQLITE_CANTOPEN ->
+                // CannotOpen, SQLITE_PROTOCOL -> FileLockingProtocolFailed.
+                match ffi.code {
+                    DatabaseBusy
+                    | DatabaseLocked
+                    | SystemIoFailure
+                    | CannotOpen
+                    | FileLockingProtocolFailed => return true,
+                    NotADatabase => return false,  // real corruption
+                    _ => {}
+                }
+            }
+        }
+        // r2d2::Error wraps the inner rusqlite::Error and exposes it via
+        // `source()`, which the anyhow chain walks automatically. Nothing
+        // extra needed here — covered by the next iteration of the loop.
+    }
+    // Unknown — treat as terminal so we surface the error fast rather
+    // than spin in a retry loop.
+    false
+}
+
 pub fn open_read_only_pool(path: &Path) -> Result<SqlitePool> {
-    if !path.exists() {
-        anyhow::bail!(
-            "database not found at {} — start the Swift app at least once to create it",
-            path.display()
-        );
+    // Three distinct error paths so callers (and humans reading logs) can
+    // tell why the open failed:
+    //   1. file missing  — Swift app hasn't started yet
+    //   2. file unreadable — wrong permissions / sandbox / FS error
+    //   3. file present but SQLite refuses to open it — corruption,
+    //      schema, or a transient lock
+    match std::fs::metadata(path) {
+        Err(io_err) if io_err.kind() == std::io::ErrorKind::NotFound => {
+            // Preserve the io::Error in the anyhow chain so
+            // `is_transient_open_error` can classify NotFound -> retry.
+            return Err(anyhow::Error::from(io_err).context(format!(
+                "database not found at {} — start the Swift app at least once to create it",
+                path.display()
+            )));
+        }
+        Err(io_err) => {
+            return Err(anyhow::Error::from(io_err).context(format!(
+                "database at {} is not readable",
+                path.display()
+            )));
+        }
+        Ok(_) => {}
     }
     let manager = SqliteConnectionManager::file(path).with_flags(
         OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
@@ -38,11 +104,13 @@ pub fn open_read_only_pool(path: &Path) -> Result<SqlitePool> {
     let pool = Pool::builder()
         .max_size(8)
         .build(manager)
-        .context("building r2d2 read pool")?;
+        .with_context(|| format!("database at {} could not be opened", path.display()))?;
     // Sanity check: open once.
-    let conn = pool.get().context("checking out initial read connection")?;
+    let conn = pool
+        .get()
+        .with_context(|| format!("database at {} could not be opened", path.display()))?;
     conn.query_row("SELECT 1", [], |_| Ok(()))
-        .context("smoke-testing read-only connection")?;
+        .with_context(|| format!("database at {} could not be opened", path.display()))?;
     Ok(pool)
 }
 
@@ -116,4 +184,93 @@ where
     })
     .await
     .context("join blocking task")?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_transient_open_error;
+    #[allow(unused_imports)]
+    use anyhow::Context as _;
+
+    fn rusqlite_err_with_code(code: rusqlite::ErrorCode) -> rusqlite::Error {
+        // Synthesize a `SqliteFailure` with the given primary code. The
+        // extended_code value is irrelevant for `is_transient_open_error`
+        // since rusqlite collapses to the primary `ErrorCode` enum.
+        let ffi = rusqlite::ffi::Error {
+            code,
+            extended_code: 0,
+        };
+        rusqlite::Error::SqliteFailure(ffi, None)
+    }
+
+    #[test]
+    fn io_not_found_is_transient() {
+        let io = std::io::Error::from(std::io::ErrorKind::NotFound);
+        let err: anyhow::Error = anyhow::Error::from(io);
+        assert!(is_transient_open_error(&err));
+    }
+
+    #[test]
+    fn io_permission_denied_is_terminal() {
+        let io = std::io::Error::from(std::io::ErrorKind::PermissionDenied);
+        let err: anyhow::Error = anyhow::Error::from(io);
+        assert!(!is_transient_open_error(&err));
+    }
+
+    #[test]
+    fn sqlite_busy_is_transient() {
+        let rs = rusqlite_err_with_code(rusqlite::ErrorCode::DatabaseBusy);
+        let err: anyhow::Error = anyhow::Error::from(rs);
+        assert!(is_transient_open_error(&err));
+    }
+
+    #[test]
+    fn sqlite_locked_is_transient() {
+        let rs = rusqlite_err_with_code(rusqlite::ErrorCode::DatabaseLocked);
+        let err: anyhow::Error = anyhow::Error::from(rs);
+        assert!(is_transient_open_error(&err));
+    }
+
+    #[test]
+    fn sqlite_ioerr_is_transient() {
+        let rs = rusqlite_err_with_code(rusqlite::ErrorCode::SystemIoFailure);
+        let err: anyhow::Error = anyhow::Error::from(rs);
+        assert!(is_transient_open_error(&err));
+    }
+
+    #[test]
+    fn sqlite_cantopen_is_transient() {
+        let rs = rusqlite_err_with_code(rusqlite::ErrorCode::CannotOpen);
+        let err: anyhow::Error = anyhow::Error::from(rs);
+        assert!(is_transient_open_error(&err));
+    }
+
+    #[test]
+    fn sqlite_protocol_is_transient() {
+        let rs = rusqlite_err_with_code(rusqlite::ErrorCode::FileLockingProtocolFailed);
+        let err: anyhow::Error = anyhow::Error::from(rs);
+        assert!(is_transient_open_error(&err));
+    }
+
+    #[test]
+    fn sqlite_notadb_is_terminal() {
+        let rs = rusqlite_err_with_code(rusqlite::ErrorCode::NotADatabase);
+        let err: anyhow::Error = anyhow::Error::from(rs);
+        assert!(!is_transient_open_error(&err));
+    }
+
+    #[test]
+    fn nested_under_anyhow_context_still_classifies() {
+        let io = std::io::Error::from(std::io::ErrorKind::NotFound);
+        let err: anyhow::Error = anyhow::Error::from(io)
+            .context("opening sqlite read pool")
+            .context("starting daemon");
+        assert!(is_transient_open_error(&err));
+
+        let rs = rusqlite_err_with_code(rusqlite::ErrorCode::DatabaseBusy);
+        let err: anyhow::Error = anyhow::Error::from(rs)
+            .context("opening connection")
+            .context("startup");
+        assert!(is_transient_open_error(&err));
+    }
 }

--- a/Backend-Rust/api/src/lib.rs
+++ b/Backend-Rust/api/src/lib.rs
@@ -251,4 +251,67 @@ mod retry_tests {
     // — those pin `is_transient_open_error` directly without needing to
     // drive a real SQLite handle through the full retry loop, which is
     // non-deterministic to set up across macOS/Linux test environments.
+    //
+    // The test below complements those by driving the FULL retry loop with a
+    // real terminal failure: 16 bytes of garbage bytes at the path, so
+    // `metadata()` succeeds (file exists) but SQLite open fails with
+    // SQLITE_NOTADB / similar. If the loop ever drops the
+    // `is_transient_open_error` classifier, this test's elapsed-time guard
+    // and the lack of meaningful retry budget would expose it.
+
+    /// Regression guard for the terminal fast-fail path: a non-transient
+    /// open error MUST cause `open_read_only_pool_with_retry` to return an
+    /// `Err` without burning the full 5-attempt × 1s retry budget.
+    ///
+    /// We trigger a deterministic terminal failure by pointing the open at a
+    /// path inside a directory that `metadata()` cannot stat: a regular file
+    /// used as a parent. `std::fs::metadata("/some/file/child")` returns
+    /// `ErrorKind::NotADirectory` (`io_err.kind()` is non-NotFound), which
+    /// `open_read_only_pool` propagates with full io::Error context, which
+    /// `is_transient_open_error` then classifies as terminal (the
+    /// "Other io kinds (PermissionDenied, etc.) are terminal" branch in
+    /// db.rs:48). The classifier is the same gate the loop's bail uses, so a
+    /// bug there also fails this test.
+    ///
+    /// The cheapest observable signal that the loop respected the
+    /// classification is wall-clock: a terminal bail returns in
+    /// milliseconds; a buggy loop ignoring the classifier would burn the
+    /// full ~4s retry budget (4 × 1s sleeps).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn terminal_failure_does_not_retry() {
+        use tokio::time::Instant;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        // Create a regular file…
+        let blocker = dir.path().join("not-a-dir");
+        std::fs::write(&blocker, b"i am a file").expect("create blocker");
+        // …and ask metadata() about a child inside it. Linux returns ENOTDIR;
+        // macOS returns the same. Either surfaces as a non-NotFound io::Error,
+        // which `is_transient_open_error` classifies as terminal.
+        let path: PathBuf = blocker.join("child.db");
+
+        let path_for_open = path.clone();
+        let started = Instant::now();
+        let result = tokio::task::spawn_blocking(move || {
+            open_read_only_pool_with_retry(&path_for_open)
+        })
+        .await
+        .expect("join blocking");
+        let elapsed = started.elapsed();
+
+        assert!(
+            result.is_err(),
+            "expected terminal io error to surface as Err, got Ok"
+        );
+        // Tight upper bound: terminal classification should bail on the first
+        // attempt (no sleep). Allow 1s of slack for slow CI runners and
+        // tokio scheduling jitter, but a buggy loop ignoring the classifier
+        // would take ~4s minimum.
+        assert!(
+            elapsed < std::time::Duration::from_millis(1000),
+            "terminal failure path took {:?} — loop appears to be retrying. \
+             Expected <1s; full retry budget would be ~4s.",
+            elapsed,
+        );
+    }
 }

--- a/Backend-Rust/api/src/lib.rs
+++ b/Backend-Rust/api/src/lib.rs
@@ -34,8 +34,7 @@ pub async fn run() -> Result<()> {
     let db_path = resolve_db_path();
     tracing::info!(db = %db_path.display(), "opening sqlite (read pool + write pool)");
 
-    let pool = db::open_read_only_pool(&db_path)
-        .with_context(|| format!("opening sqlite read pool at {}", db_path.display()))?;
+    let pool = open_read_only_pool_with_retry(&db_path)?;
     let write_pool = db::open_read_write_pool(&db_path)
         .with_context(|| format!("opening sqlite write pool at {}", db_path.display()))?;
 
@@ -124,6 +123,57 @@ pub async fn run() -> Result<()> {
     Ok(())
 }
 
+/// Open the read-only pool with a small startup retry. On a fresh launch
+/// (or right after a state-dir wipe) the Swift app may still be creating
+/// the SQLite file when the daemon boots; we want to wait a few seconds
+/// rather than crashing the daemon and bouncing on launchd's KeepAlive.
+///
+/// Only transient failures retry — file missing or SQLITE_BUSY/locked.
+/// Permission errors, corruption, etc. fail fast (no point retrying).
+pub(crate) fn open_read_only_pool_with_retry(db_path: &std::path::Path) -> Result<db::SqlitePool> {
+    const MAX_ATTEMPTS: usize = 5;
+    const BACKOFF: std::time::Duration = std::time::Duration::from_secs(1);
+
+    let mut last_err: Option<anyhow::Error> = None;
+    for attempt in 1..=MAX_ATTEMPTS {
+        match db::open_read_only_pool(db_path) {
+            Ok(pool) => {
+                if attempt > 1 {
+                    tracing::info!(
+                        attempt,
+                        "sqlite read pool opened after retry"
+                    );
+                }
+                return Ok(pool);
+            }
+            Err(err) => {
+                if !db::is_transient_open_error(&err) {
+                    return Err(err.context(format!(
+                        "opening sqlite read pool at {} (terminal failure, no retry)",
+                        db_path.display()
+                    )));
+                }
+                tracing::info!(
+                    attempt,
+                    max_attempts = MAX_ATTEMPTS,
+                    error = %err,
+                    "transient sqlite open failure; will retry"
+                );
+                last_err = Some(err);
+                if attempt < MAX_ATTEMPTS {
+                    std::thread::sleep(BACKOFF);
+                }
+            }
+        }
+    }
+    let err = last_err.unwrap_or_else(|| anyhow::anyhow!("unknown sqlite open failure"));
+    Err(err.context(format!(
+        "opening sqlite read pool at {} failed after {} attempts",
+        db_path.display(),
+        MAX_ATTEMPTS
+    )))
+}
+
 /// Pick the SQLite path. Honors `INFINITE_RECALL_DB`, otherwise falls back
 /// to the Swift app's location under Application Support.
 fn resolve_db_path() -> std::path::PathBuf {
@@ -143,4 +193,62 @@ fn resolve_activity_db_path() -> std::path::PathBuf {
     }
     let home = dirs::home_dir().expect("HOME dir resolvable");
     home.join("Library/Application Support/InfiniteRecall/activity.db")
+}
+
+#[cfg(test)]
+mod retry_tests {
+    use super::open_read_only_pool_with_retry;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    /// Build a minimal but valid SQLite file at `path` so the read-only pool
+    /// can actually open it. We write nothing — opening the file with a
+    /// `rusqlite::Connection` (read-write) creates the header + first page.
+    fn create_empty_sqlite_db(path: &std::path::Path) {
+        let conn = rusqlite::Connection::open(path).expect("create sqlite");
+        conn.execute_batch("PRAGMA journal_mode=WAL;").ok();
+        drop(conn);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn retries_until_file_appears() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path: PathBuf = dir.path().join("late.db");
+
+        // The retry function blocks (uses std::thread::sleep), so we run it
+        // on a blocking task while a parallel task creates the file at 1.5s.
+        let path_for_creator = path.clone();
+        let created = Arc::new(AtomicBool::new(false));
+        let created_flag = created.clone();
+        let creator = tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(1500)).await;
+            create_empty_sqlite_db(&path_for_creator);
+            created_flag.store(true, Ordering::SeqCst);
+        });
+
+        let path_for_open = path.clone();
+        let open_result = tokio::task::spawn_blocking(move || {
+            open_read_only_pool_with_retry(&path_for_open)
+        })
+        .await
+        .expect("join blocking");
+
+        creator.await.expect("creator");
+        assert!(
+            created.load(Ordering::SeqCst),
+            "creator must have run before assertion"
+        );
+        assert!(
+            open_result.is_ok(),
+            "expected pool open to succeed within retry budget, got: {:?}",
+            open_result.err()
+        );
+    }
+
+    // Terminal-error fast-fail behavior is covered by the `db::tests` unit
+    // suite (`sqlite_notadb_is_terminal`, `io_permission_denied_is_terminal`)
+    // — those pin `is_transient_open_error` directly without needing to
+    // drive a real SQLite handle through the full retry loop, which is
+    // non-deterministic to set up across macOS/Linux test environments.
 }

--- a/Desktop/Sources/APIClient.swift
+++ b/Desktop/Sources/APIClient.swift
@@ -5013,7 +5013,7 @@ extension APIClient {
   /// Throws `LocalDaemonToken.TokenError` if the daemon hasn't written
   /// its token yet. The Activity service catches this and surfaces it via
   /// `ActivityMonitorService.lastError` instead of silently 401-looping.
-  fileprivate func activityHeaders() throws -> [String: String] {
+  fileprivate func activityHeaders() async throws -> [String: String] {
     var headers: [String: String] = [
       "Content-Type": "application/json",
       "X-App-Platform": "macos",
@@ -5021,7 +5021,11 @@ extension APIClient {
     if let testHeader = testAuthHeader {
       headers["Authorization"] = testHeader
     } else {
-      let token = try LocalDaemonToken.read()
+      // Poll for up to 10 s on the initial fetch so a freshly-launched
+      // daemon that's still writing api-token.txt doesn't surface a
+      // spurious "daemon token unavailable" banner. Subsequent calls hit
+      // the in-memory cache in `LocalDaemonToken` and are free.
+      let token = try await LocalDaemonToken.read(waitFor: 10)
       headers["Authorization"] = "Bearer \(token)"
     }
     return headers
@@ -5074,7 +5078,7 @@ extension APIClient {
     }
     var request = URLRequest(url: url)
     request.httpMethod = "GET"
-    request.allHTTPHeaderFields = try activityHeaders()
+    request.allHTTPHeaderFields = try await activityHeaders()
     request.timeoutInterval = 5
 
     let (data, response) = try await session.data(for: request)
@@ -5103,7 +5107,7 @@ extension APIClient {
 
     var request = URLRequest(url: url)
     request.httpMethod = "POST"
-    request.allHTTPHeaderFields = try activityHeaders()
+    request.allHTTPHeaderFields = try await activityHeaders()
     request.httpBody = try Self.makeActivityEncoder().encode(body)
     request.timeoutInterval = 5
 
@@ -5136,7 +5140,7 @@ extension APIClient {
 
     var request = URLRequest(url: url)
     request.httpMethod = "POST"
-    request.allHTTPHeaderFields = try activityHeaders()
+    request.allHTTPHeaderFields = try await activityHeaders()
     request.httpBody = try Self.makeActivityEncoder().encode(body)
     request.timeoutInterval = 5
 
@@ -5162,7 +5166,7 @@ extension APIClient {
 
     var request = URLRequest(url: url)
     request.httpMethod = "POST"
-    request.allHTTPHeaderFields = try activityHeaders()
+    request.allHTTPHeaderFields = try await activityHeaders()
     request.timeoutInterval = 10  // 5s server-side grace + SIGKILL + margin
 
     let (data, response) = try await session.data(for: request)
@@ -5208,7 +5212,7 @@ extension APIClient {
 
     var request = URLRequest(url: url)
     request.httpMethod = "POST"
-    request.allHTTPHeaderFields = try activityHeaders()
+    request.allHTTPHeaderFields = try await activityHeaders()
     request.httpBody = try Self.makeActivityEncoder().encode(body)
     request.timeoutInterval = 5
 
@@ -5236,7 +5240,7 @@ extension APIClient {
 
     var request = URLRequest(url: url)
     request.httpMethod = "POST"
-    request.allHTTPHeaderFields = try activityHeaders()
+    request.allHTTPHeaderFields = try await activityHeaders()
     request.httpBody = try Self.makeActivityEncoder().encode(gateState)
     request.timeoutInterval = 5
 

--- a/Desktop/Sources/Activity/ActivityMonitorService.swift
+++ b/Desktop/Sources/Activity/ActivityMonitorService.swift
@@ -156,6 +156,13 @@ public final class ActivityMonitorService: ObservableObject, InternalPostFailure
         self.lastError = nil
     }
 
+    /// Surface a user-visible error from outside the service (e.g. UI-side
+    /// recovery actions like the Restart Daemon button). Routed through the
+    /// same `lastError` channel so the existing banner picks it up.
+    public func setLastError(_ message: String) {
+        self.lastError = message
+    }
+
     /// POST /v1/activity/processes/:pid/terminate — ask the Rust daemon to
     /// SIGTERM the LocalModel worker child for `pid` so its memory is
     /// reclaimed. launchd `KeepAlive=true` will respawn it on the next

--- a/Desktop/Sources/Activity/ActivityPage.swift
+++ b/Desktop/Sources/Activity/ActivityPage.swift
@@ -141,6 +141,8 @@ struct ActivityPage: View {
     @State private var pendingUnload: PendingUnload? = nil
     @State private var unloadErrorMessage: String? = nil
 
+    @State private var isRestartingDaemon: Bool = false
+
     /// Drives the per-row "elapsed timer" updates without polling the service.
     @State private var tick = Date()
     private let tickTimer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
@@ -173,7 +175,14 @@ struct ActivityPage: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
-                gateBanner
+                // When we have a service error AND no snapshot yet, the
+                // gateBanner would otherwise display a spurious
+                // "Loading activity…" header right next to the error
+                // banner. Hide the gate banner in that case so the error
+                // is the only thing the user has to act on.
+                if !(service.lastError != nil && snapshot == nil) {
+                    gateBanner
+                }
                 if let err = service.lastError {
                     errorBanner(err)
                 }
@@ -245,6 +254,34 @@ struct ActivityPage: View {
                 .fixedSize(horizontal: false, vertical: true)
             Spacer()
             Button {
+                Task { await restartDaemon() }
+            } label: {
+                HStack(spacing: 4) {
+                    if isRestartingDaemon {
+                        ProgressView()
+                            .controlSize(.small)
+                            .scaleEffect(0.6)
+                        Text("Restarting…")
+                    } else {
+                        Image(systemName: "arrow.clockwise")
+                            .scaledFont(size: 11)
+                        Text("Restart daemon")
+                    }
+                }
+                .scaledFont(size: 11, weight: .medium)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+            }
+            .buttonStyle(.borderless)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(OmiColors.backgroundPrimary.opacity(0.7))
+            )
+            .disabled(isRestartingDaemon)
+            .accessibilityLabel("Restart daemon")
+            .accessibilityIdentifier("activity_error_restart_button")
+
+            Button {
                 service.clearLastError()
             } label: {
                 Image(systemName: "xmark")
@@ -264,6 +301,55 @@ struct ActivityPage: View {
                 )
         )
         .accessibilityIdentifier("activity_error_banner")
+    }
+
+    /// Kickstart the launchd-managed Rust daemon, hold the "Restarting…"
+    /// state for ~2 s so the button isn't pummelled in tight clicks, then
+    /// re-fetch the snapshot. The token-file poll inside `activityHeaders`
+    /// (LocalDaemonToken.read(waitFor:)) covers the brief window between
+    /// the daemon restarting and api-token.txt being rewritten.
+    private func restartDaemon() async {
+        guard !isRestartingDaemon else { return }
+        isRestartingDaemon = true
+        defer { isRestartingDaemon = false }
+
+        let uid = String(getuid())
+
+        // Run launchctl off the MainActor so the spinner doesn't freeze
+        // while we wait on the subprocess.
+        let result: (exitCode: Int32, stderr: String) = await Task.detached(priority: .userInitiated) {
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+            process.arguments = [
+                "kickstart", "-k", "gui/\(uid)/com.infiniterecall.api",
+            ]
+            let stderrPipe = Pipe()
+            process.standardError = stderrPipe
+            do {
+                try process.run()
+                process.waitUntilExit()
+                let data = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+                let text = String(data: data, encoding: .utf8) ?? ""
+                return (process.terminationStatus, text)
+            } catch {
+                return (-1, error.localizedDescription)
+            }
+        }.value
+
+        if result.exitCode != 0 {
+            Self.log.error(
+                "launchctl kickstart failed: code=\(result.exitCode, privacy: .public) stderr=\(result.stderr, privacy: .public)"
+            )
+            service.setLastError(
+                "Restart failed: launchctl exited \(result.exitCode). Try ./setup-api-server.sh from a Terminal."
+            )
+            return
+        }
+
+        try? await Task.sleep(nanoseconds: 2_000_000_000)
+
+        service.clearLastError()
+        await service.refreshNow()
     }
     // === /activity:C3 ===
 

--- a/Desktop/Sources/Activity/ActivityPage.swift
+++ b/Desktop/Sources/Activity/ActivityPage.swift
@@ -348,7 +348,21 @@ struct ActivityPage: View {
 
         try? await Task.sleep(nanoseconds: 2_000_000_000)
 
-        service.clearLastError()
+        // Only clear `lastError` if the surfaced banner is one of the failure
+        // modes a daemon kickstart actually fixes:
+        //   - `daemon token unavailable …` from `LocalDaemonToken.TokenError.fileMissing`
+        //   - `snapshot failed: …` from a transient daemon-snapshot RPC failure
+        //
+        // Without this gate, an unrelated banner (e.g. a process-terminate
+        // failure surfaced via `setLastError`) is silently wiped the moment
+        // the user clicks "Restart daemon", masking errors that have nothing
+        // to do with the daemon. `service.refreshNow()` below will overwrite
+        // a daemon-related error organically on its next snapshot anyway.
+        if let current = service.lastError,
+           current.contains("daemon token unavailable")
+            || current.hasPrefix("snapshot failed:") {
+            service.clearLastError()
+        }
         await service.refreshNow()
     }
     // === /activity:C3 ===

--- a/Desktop/Sources/Activity/LocalDaemonToken.swift
+++ b/Desktop/Sources/Activity/LocalDaemonToken.swift
@@ -68,7 +68,17 @@ enum LocalDaemonToken {
   /// Read the daemon token from disk (cached in memory after first read).
   /// Throws a typed `TokenError` so callers can render a useful message
   /// rather than silently 401-looping.
+  ///
+  /// Synchronous, non-waiting variant: throws immediately if the file is
+  /// missing. Prefer `read(waitFor:)` on the initial fetch path so that a
+  /// fresh app launch — where the Rust daemon may still be writing the
+  /// token file — doesn't surface a "daemon token unavailable" error
+  /// banner that resolves itself a few hundred ms later.
   static func read() throws -> String {
+    return try readOnce()
+  }
+
+  private static func readOnce() throws -> String {
     let url = tokenFileURL
     let path = url.path
 
@@ -96,6 +106,36 @@ enum LocalDaemonToken {
     cachedToken = trimmed
     cachedFromPath = path
     return trimmed
+  }
+
+  /// Read the daemon token, polling for the file every 500 ms up to
+  /// `waitFor` seconds before throwing `TokenError.fileMissing`. All other
+  /// errors (`unreadable`, `empty`) are terminal — they throw immediately
+  /// since polling won't fix a permission or corruption problem.
+  ///
+  /// Use this on the *initial* token fetch (e.g. the first activity
+  /// snapshot after app launch) so we don't race a daemon that's still
+  /// writing the token file. Subsequent calls hit the in-memory cache and
+  /// are effectively free.
+  static func read(waitFor timeout: TimeInterval) async throws -> String {
+    let pollInterval: TimeInterval = 0.5
+    let deadline = Date().addingTimeInterval(timeout)
+    while true {
+      try Task.checkCancellation()
+      do {
+        return try readOnce()
+      } catch TokenError.fileMissing(let url) {
+        if Date() >= deadline {
+          throw TokenError.fileMissing(url)
+        }
+        do {
+          try await Task.sleep(nanoseconds: UInt64(pollInterval * 1_000_000_000))
+        } catch {
+          // Propagate cancellation; don't keep polling on a discarded request.
+          throw CancellationError()
+        }
+      }
+    }
   }
 
   /// Test/diagnostic hook: clear the in-memory cache.

--- a/Desktop/Sources/AppState.swift
+++ b/Desktop/Sources/AppState.swift
@@ -92,6 +92,17 @@ class AppState: ObservableObject {
   @Published var showStarredOnly: Bool = false
   @Published var selectedDateFilter: Date? = nil
   @Published var selectedFolderId: String? = nil
+  /// When true, the Conversations list shows ONLY discarded conversations
+  /// (the "Discarded" filter chip). Reload is triggered explicitly by the
+  /// chip toggle (`toggleDiscardedFilter`) rather than via a Combine
+  /// subscriber — the existing star/date/folder filters use the same
+  /// "set value, then reload" call-site pattern, and a separate observer
+  /// would race against those reloads.
+  @Published var showDiscardedOnly: Bool = false
+  /// Passive count of discarded conversations available, surfaced as a
+  /// "(N hidden)" hint near the Conversations header. Refreshed on each
+  /// `loadConversations()` so it stays in sync without its own timer.
+  @Published var discardedConversationsCount: Int = 0
 
   // Folders
   @Published var folders: [Folder] = []
@@ -2065,7 +2076,8 @@ class AppState: ObservableObject {
           try await TranscriptionStorage.shared.getLocalConversations(
             limit: 50,
             starredOnly: self.showStarredOnly,
-            folderId: self.selectedFolderId
+            folderId: self.selectedFolderId,
+            discardedOnly: self.showDiscardedOnly
           )
         }
         group.addTask {
@@ -2106,10 +2118,25 @@ class AppState: ObservableObject {
           }
         }
 
-        // Get local count
+        // Get local count (matches the active filter so the header total
+        // reflects what the user is currently looking at).
         let localCount = try await TranscriptionStorage.shared.getLocalConversationsCount(
-          starredOnly: showStarredOnly)
+          starredOnly: showStarredOnly,
+          discardedOnly: showDiscardedOnly)
         totalConversationsCount = localCount
+
+        // Passive "(N hidden)" hint: count discarded rows separately so the
+        // Conversations header can offer a way to reach them via the chip.
+        // When the chip is ON the primary count above already counts the
+        // discarded rows, so skip the redundant query.
+        if !showDiscardedOnly {
+          do {
+            discardedConversationsCount = try await TranscriptionStorage.shared
+              .getLocalConversationsCount(discardedOnly: true)
+          } catch {
+            logError("Conversations: Failed to load discarded count", error: error)
+          }
+        }
 
         // Stop loading state so UI shows cached data immediately
         isLoadingConversations = false
@@ -2288,6 +2315,18 @@ class AppState: ObservableObject {
     await loadConversations()
   }
 
+  /// Toggle the "Discarded only" filter and reload conversations.
+  ///
+  /// Mutually exclusive with `showStarredOnly` at the SQL layer (both are
+  /// single-flag predicates), but we don't enforce that here — the chip UI
+  /// is the source of truth for which is on. If both flags are set, the
+  /// SQL `discarded = true AND starred = true` produces a valid (likely
+  /// empty) result.
+  func toggleDiscardedFilter() async {
+    showDiscardedOnly.toggle()
+    await loadConversations()
+  }
+
   /// Set date filter and reload conversations
   func setDateFilter(_ date: Date?) async {
     selectedDateFilter = date
@@ -2299,6 +2338,7 @@ class AppState: ObservableObject {
     showStarredOnly = false
     selectedDateFilter = nil
     selectedFolderId = nil
+    showDiscardedOnly = false
     await loadConversations()
   }
 

--- a/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
+++ b/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
@@ -53,6 +53,7 @@ struct ConversationsPage: View {
   // Filter loading states (to show loading on the clicked button)
   @State private var isFilteringStarred: Bool = false
   @State private var isFilteringDate: Bool = false
+  @State private var isFilteringDiscarded: Bool = false
 
   // Multi-select state for merging
   @State private var isMultiSelectMode: Bool = false
@@ -531,6 +532,46 @@ struct ConversationsPage: View {
       .buttonStyle(.plain)
       .disabled(isFilteringStarred)
 
+      // Discarded filter chip — toggles `appState.showDiscardedOnly`.
+      // Semantics: "All" (default) shows active conversations only;
+      // "Discarded" ON shows only soft-discarded rows. This is a binary
+      // toggle (not a 3-mode segmented control) to stay consistent with
+      // the surrounding Starred / Date chips.
+      Button(action: {
+        Task {
+          isFilteringDiscarded = true
+          await appState.toggleDiscardedFilter()
+          isFilteringDiscarded = false
+        }
+      }) {
+        HStack(spacing: 6) {
+          if isFilteringDiscarded {
+            ProgressView()
+              .scaleEffect(0.5)
+              .frame(width: 12, height: 12)
+          } else {
+            Image(systemName: appState.showDiscardedOnly ? "trash.fill" : "trash")
+              .scaledFont(size: 12)
+          }
+          Text("Discarded")
+            .scaledFont(size: 12, weight: .medium)
+        }
+        .foregroundColor(
+          appState.showDiscardedOnly ? OmiColors.textPrimary : OmiColors.textSecondary
+        )
+        .padding(.horizontal, 14)
+        .padding(.vertical, 9)
+        .omiControlSurface(
+          fill: appState.showDiscardedOnly
+            ? OmiColors.textPrimary.opacity(0.16) : OmiColors.backgroundSecondary,
+          radius: 16,
+          stroke: appState.showDiscardedOnly
+            ? OmiColors.border.opacity(0.36) : OmiColors.border.opacity(0.14)
+        )
+      }
+      .buttonStyle(.plain)
+      .disabled(isFilteringDiscarded)
+
       // Date filter button
       Button(action: {
         showDatePicker.toggle()
@@ -583,7 +624,7 @@ struct ConversationsPage: View {
 
       // Clear all filters button (only show if any filter is active)
       if appState.showStarredOnly || appState.selectedDateFilter != nil
-        || appState.selectedFolderId != nil
+        || appState.selectedFolderId != nil || appState.showDiscardedOnly
       {
         Button(action: {
           Task {
@@ -595,6 +636,27 @@ struct ConversationsPage: View {
             .foregroundColor(OmiColors.textTertiary)
         }
         .buttonStyle(.plain)
+      }
+
+      Spacer(minLength: 0)
+
+      // Passive hint: when there are discarded conversations the user can't
+      // currently see (chip OFF), show a small "(N hidden)" so they know the
+      // Discarded chip will surface them. Tapping it activates the chip.
+      if !appState.showDiscardedOnly && appState.discardedConversationsCount > 0 {
+        Button(action: {
+          Task {
+            isFilteringDiscarded = true
+            await appState.toggleDiscardedFilter()
+            isFilteringDiscarded = false
+          }
+        }) {
+          Text("(\(appState.discardedConversationsCount) hidden)")
+            .scaledFont(size: 11)
+            .foregroundColor(OmiColors.textTertiary)
+        }
+        .buttonStyle(.plain)
+        .help("Show discarded conversations")
       }
     }
   }

--- a/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
+++ b/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
@@ -1087,7 +1087,9 @@ actor TranscriptionStorage {
         limit: Int = 50,
         offset: Int = 0,
         starredOnly: Bool = false,
-        folderId: String? = nil
+        folderId: String? = nil,
+        includeDiscarded: Bool = false,
+        discardedOnly: Bool = false
     ) async throws -> [ServerConversation] {
         let db = try await ensureInitialized()
 
@@ -1097,7 +1099,18 @@ actor TranscriptionStorage {
             // so the original filter wiped the entire conversation list.
             var query = TranscriptionSessionRecord
                 .filter(Column("deleted") == false)
-                .filter(Column("discarded") == false)
+
+            // Discarded handling:
+            //   - default (`includeDiscarded == false`, `discardedOnly == false`):
+            //     hide discarded rows (current behavior).
+            //   - `discardedOnly == true`: show ONLY discarded rows (Discarded chip).
+            //   - `includeDiscarded == true` (and not discardedOnly): include both
+            //     active and discarded rows together.
+            if discardedOnly {
+                query = query.filter(Column("discarded") == true)
+            } else if !includeDiscarded {
+                query = query.filter(Column("discarded") == false)
+            }
 
             if starredOnly {
                 query = query.filter(Column("starred") == true)
@@ -1122,7 +1135,11 @@ actor TranscriptionStorage {
     }
 
     /// Get count of local conversations
-    func getLocalConversationsCount(starredOnly: Bool = false) async throws -> Int {
+    func getLocalConversationsCount(
+        starredOnly: Bool = false,
+        includeDiscarded: Bool = false,
+        discardedOnly: Bool = false
+    ) async throws -> Int {
         let db = try await ensureInitialized()
 
         return try await db.read { database in
@@ -1131,7 +1148,12 @@ actor TranscriptionStorage {
             // so the original filter wiped the entire conversation list.
             var query = TranscriptionSessionRecord
                 .filter(Column("deleted") == false)
-                .filter(Column("discarded") == false)
+
+            if discardedOnly {
+                query = query.filter(Column("discarded") == true)
+            } else if !includeDiscarded {
+                query = query.filter(Column("discarded") == false)
+            }
 
             if starredOnly {
                 query = query.filter(Column("starred") == true)

--- a/Desktop/Sources/Rewind/Services/ConversationSummaryBackfillService.swift
+++ b/Desktop/Sources/Rewind/Services/ConversationSummaryBackfillService.swift
@@ -221,6 +221,23 @@ actor ConversationSummaryBackfillService {
             return
         }
 
+        // Daemon-health gate: only `.fileMissing` is genuinely transient
+        // (daemon not yet started). On `.unreadable` / `.empty` the daemon is
+        // broken in a way that won't self-heal across launches — looping
+        // forever on it accomplishes nothing, and `segment_count = 0` is a
+        // structural check that doesn't actually need daemon liveness to be
+        // safe. Log loudly on those and proceed with the sweep.
+        do {
+            let syncRead: () throws -> String = LocalDaemonToken.read  // sync overload, not waitFor:
+            _ = try syncRead()
+        } catch LocalDaemonToken.TokenError.fileMissing {
+            log("ConversationSummaryBackfillService: skipping discard sweep — daemon not yet started, will retry next cycle")
+            return
+        } catch {
+            logError("ConversationSummaryBackfillService: daemon token unreadable/empty during discard sweep — proceeding without health gate", error: error)
+            // fall through to the sweep
+        }
+
         // Only rows that are genuinely empty (no segments) AND already marked
         // unavailable. Drops the V1 title='Short Recording' criterion — that
         // was over-aggressive — and replaces it with a hard structural check.

--- a/Desktop/Sources/Rewind/UI/RewindPage.swift
+++ b/Desktop/Sources/Rewind/UI/RewindPage.swift
@@ -89,10 +89,13 @@ struct RewindPage: View {
             // Background
             Color.black.ignoresSafeArea()
 
-            if viewModel.isLoading && viewModel.screenshots.isEmpty && viewModel.activeSearchQuery == nil {
-                loadingView
-            } else if let error = viewModel.errorMessage {
+            if let error = viewModel.errorMessage, viewModel.activeSearchQuery == nil {
+                // Error/retry takes precedence over the loading spinner so a
+                // failed init (or watchdog timeout) can never leave the user
+                // staring at "Loading screenshots…" forever.
                 errorView(error)
+            } else if viewModel.isLoading && viewModel.screenshots.isEmpty && viewModel.activeSearchQuery == nil {
+                loadingView
             } else {
                 // Main content with persistent search field
                 VStack(spacing: 0) {

--- a/Desktop/Sources/Rewind/UI/RewindViewModel.swift
+++ b/Desktop/Sources/Rewind/UI/RewindViewModel.swift
@@ -57,6 +57,8 @@ class RewindViewModel: ObservableObject {
     // MARK: - Private State
 
     private var searchTask: Task<Void, Never>?
+    private var loadWatchdogTask: Task<Void, Never>?
+    private var loadStatsTask: Task<Void, Never>?
     private var cancellables = Set<AnyCancellable>()
 
     /// Whether initial data has been loaded (prevents race condition with debounced search)
@@ -129,6 +131,34 @@ class RewindViewModel: ObservableObject {
         isLoading = true
         errorMessage = nil
 
+        // `defer` runs on every exit path so the spinner can never get stuck
+        // "Loading screenshots…" forever — even if the await chain throws or
+        // is cancelled.
+        defer {
+            isLoading = false
+            loadWatchdogTask?.cancel()
+            loadWatchdogTask = nil
+
+            log("RewindViewModel: Posting rewindPageDidLoad notification")
+            NotificationCenter.default.post(name: .rewindPageDidLoad, object: nil)
+        }
+
+        // Watchdog: surfaces a visible error/retry if work hasn't completed in
+        // 30s. First-launch DB init on a cold APFS cache can legitimately take
+        // longer than the previous 15s. The Task inherits MainActor isolation
+        // from the surrounding @MainActor context, so direct property writes
+        // are safe — no nested `MainActor.run` hop needed.
+        loadWatchdogTask?.cancel()
+        loadWatchdogTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 30 * 1_000_000_000)
+            guard let self, !Task.isCancelled else { return }
+            if self.isLoading && self.errorMessage == nil {
+                self.errorMessage = "Loading timed out. Tap retry."
+                self.isLoading = false
+                logError("RewindViewModel: loadInitialData watchdog fired after 30s")
+            }
+        }
+
         do {
             // Configure database for the current user BEFORE anything touches the DB.
             // Without this, RewindIndexer.initialize() opens the DB for "anonymous",
@@ -156,8 +186,10 @@ class RewindViewModel: ObservableObject {
                 log("RewindViewModel: Database was recovered from corruption, \(recoveredCount) records salvaged")
             }
 
-            // Load today's screenshots (date filter is always active)
-            await loadScreenshotsForDate(selectedDate)
+            // Load today's screenshots (date filter is always active).
+            // Propagates DB errors so the catch below surfaces them to the UI
+            // instead of silently leaving the spinner running.
+            try await loadScreenshotsForDate(selectedDate)
 
             // Load available apps for filtering
             availableApps = try await RewindDatabase.shared.getUniqueAppNames()
@@ -165,22 +197,25 @@ class RewindViewModel: ObservableObject {
             // Mark as initialized after successful load
             isInitialized = true
 
-        } catch {
-            errorMessage = error.localizedDescription
-            logError("RewindViewModel: Failed to load initial data: \(error)")
-        }
+            // Flash-of-timeout fix: if the 30s watchdog fired moments before
+            // we got here, clear the stale banner so the user sees the loaded
+            // data, not a misleading timeout message.
+            errorMessage = nil
 
-        isLoading = false
-
-        // Notify that Rewind page finished loading (for sidebar loading indicator)
-        log("RewindViewModel: Posting rewindPageDidLoad notification")
-        NotificationCenter.default.post(name: .rewindPageDidLoad, object: nil)
-
-        // Load stats asynchronously (includes storage size calculation which can be slow)
-        Task {
-            if let indexerStats = await RewindIndexer.shared.getStats() {
-                stats = indexerStats
+            // Stats fetch only on success — previously this was in the defer
+            // and fired on watchdog timeouts and errors too. Cancel any prior
+            // stats task so a slow earlier fetch can't clobber a fresh one.
+            loadStatsTask?.cancel()
+            loadStatsTask = Task { [weak self] in
+                guard let self, !Task.isCancelled else { return }
+                if let indexerStats = await RewindIndexer.shared.getStats() {
+                    guard !Task.isCancelled else { return }
+                    self.stats = indexerStats
+                }
             }
+        } catch {
+            errorMessage = "Couldn't open Rewind database: \(error.localizedDescription)"
+            logError("RewindViewModel: Failed to load initial data: \(error)")
         }
     }
 
@@ -206,10 +241,12 @@ class RewindViewModel: ObservableObject {
         let trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
 
         if trimmedQuery.isEmpty {
-            // Reset to date-filtered view (date filter is always active)
+            // Reset to date-filtered view (date filter is always active).
+            // Silent reload: a transient DB error here should log and move on,
+            // not block the search-clear UX.
             isSearching = false
             activeSearchQuery = nil
-            await loadScreenshotsForDate(selectedDate)
+            await reloadScreenshotsSilently(selectedDate)
             return
         }
 
@@ -277,7 +314,8 @@ class RewindViewModel: ObservableObject {
         if !searchQuery.isEmpty {
             await performSearch(query: searchQuery)
         } else {
-            await loadScreenshotsForDate(selectedDate)
+            // Silent: post-init filter change, transient DB error should not stick.
+            await reloadScreenshotsSilently(selectedDate)
         }
     }
 
@@ -287,42 +325,59 @@ class RewindViewModel: ObservableObject {
         if !searchQuery.isEmpty {
             await performSearch(query: searchQuery)
         } else {
-            await loadScreenshotsForDate(date)
+            // Silent: post-init date change, transient DB error should not stick.
+            await reloadScreenshotsSilently(date)
         }
     }
 
-    private func loadScreenshotsForDate(_ date: Date) async {
-        isLoading = true
-
+    /// Loads screenshots for a date and propagates any DB error.
+    /// Callers that need to surface failures to the user (init / retry path)
+    /// should `try` this. Callers that prefer fire-and-forget should use
+    /// `reloadScreenshotsSilently(_:)` instead — silent-swallow is intentional
+    /// there but must NOT leak back into init paths.
+    ///
+    /// Note: this does NOT touch `isLoading`. The caller owns that state — see
+    /// `loadInitialData` (manages isLoading via top-level defer) and
+    /// `reloadScreenshotsSilently` (sets it around the call for filter/search).
+    private func loadScreenshotsForDate(_ date: Date) async throws {
         let calendar = Calendar.current
         let startOfDay = calendar.startOfDay(for: date)
         let endOfDay = calendar.date(byAdding: .day, value: 1, to: startOfDay)!
 
-        do {
-            var results = try await RewindDatabase.shared.getScreenshotsSampled(
-                from: startOfDay,
-                to: endOfDay,
-                targetCount: 500
-            )
+        var results = try await RewindDatabase.shared.getScreenshotsSampled(
+            from: startOfDay,
+            to: endOfDay,
+            targetCount: 500
+        )
 
-            // Filter out frames from the active (unfinalized) video chunk — they can't be displayed yet
-            let activeChunk = await VideoChunkEncoder.shared.currentChunkPath
-            if let activeChunk = activeChunk {
-                results = results.filter { $0.videoChunkPath != activeChunk }
-            }
-
-            // Apply app filter if set
-            if let app = selectedApp {
-                results = results.filter { $0.appName == app }
-            }
-
-            screenshots = results
-
-        } catch {
-            logError("RewindViewModel: Failed to load screenshots for date: \(error)")
+        // Filter out frames from the active (unfinalized) video chunk — they can't be displayed yet
+        let activeChunk = await VideoChunkEncoder.shared.currentChunkPath
+        if let activeChunk = activeChunk {
+            results = results.filter { $0.videoChunkPath != activeChunk }
         }
 
-        isLoading = false
+        // Apply app filter if set
+        if let app = selectedApp {
+            results = results.filter { $0.appName == app }
+        }
+
+        screenshots = results
+    }
+
+    /// Silent variant: swallows DB errors and just logs them. Use only for
+    /// background/user-driven reloads (filter change, date change, search
+    /// clear) where a transient failure should not block the UI. Never use
+    /// this on the init path — it would re-introduce the "spinner forever"
+    /// bug. Manages `isLoading` so the spinner shows during the reload but
+    /// always clears, even on thrown error.
+    private func reloadScreenshotsSilently(_ date: Date) async {
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            try await loadScreenshotsForDate(date)
+        } catch {
+            logError("RewindViewModel: Failed to reload screenshots for date: \(error)")
+        }
     }
 
     /// Silent variant for auto-refresh: never touches isLoading, and only

--- a/Desktop/Sources/Rewind/UI/RewindViewModel.swift
+++ b/Desktop/Sources/Rewind/UI/RewindViewModel.swift
@@ -61,8 +61,19 @@ class RewindViewModel: ObservableObject {
     private var loadStatsTask: Task<Void, Never>?
     private var cancellables = Set<AnyCancellable>()
 
-    /// Whether initial data has been loaded (prevents race condition with debounced search)
+    /// Whether initial data has been loaded (prevents race condition with
+    /// debounced search). Also used by the watchdog re-check guard so a
+    /// successful load can never trip the "Loading timed out" banner after
+    /// the fact (see `loadInitialData`).
     private var isInitialized = false
+
+    // TODO: testing seam needed — `loadInitialData` reaches into
+    // `RewindDatabase.shared` and `RewindIndexer.shared` directly. Adding a
+    // `RewindViewModelTests` covering the watchdog/defer interaction (per
+    // the second-pass review) requires injecting a database-and-indexer pair
+    // into `RewindViewModel` (e.g. struct of closures with `.live` /
+    // `.testing` cases, or a protocol-typed dependency). Out of scope for
+    // this batch fix — flagged here as the follow-up.
 
     /// Set by RewindPage when the transcript/notes panel is expanded.
     /// Auto-refresh skips when true so the view tree stays stable and @State is preserved.
@@ -152,11 +163,19 @@ class RewindViewModel: ObservableObject {
         loadWatchdogTask = Task { [weak self] in
             try? await Task.sleep(nanoseconds: 30 * 1_000_000_000)
             guard let self, !Task.isCancelled else { return }
-            if self.isLoading && self.errorMessage == nil {
-                self.errorMessage = "Loading timed out. Tap retry."
-                self.isLoading = false
-                logError("RewindViewModel: loadInitialData watchdog fired after 30s")
-            }
+            // Re-check `isInitialized`: if `loadInitialData` already finished
+            // (success OR error path), `defer` may not yet have flipped
+            // `isLoading` to false in this MainActor turn. Without this guard
+            // the watchdog spuriously sets "Loading timed out" right after a
+            // legitimate load — including the error path, where
+            // `errorMessage` is set but `isLoading` is still `true`.
+            guard self.isLoading
+                && self.errorMessage == nil
+                && !self.isInitialized
+            else { return }
+            self.errorMessage = "Loading timed out. Tap retry."
+            self.isLoading = false
+            logError("RewindViewModel: loadInitialData watchdog fired after 30s")
         }
 
         do {

--- a/Desktop/Tests/LocalDaemonTokenHealthGateTests.swift
+++ b/Desktop/Tests/LocalDaemonTokenHealthGateTests.swift
@@ -1,0 +1,95 @@
+import XCTest
+@testable import Omi_Computer
+
+/// Coverage for the daemon-health gate used by
+/// `ConversationSummaryBackfillService.backfillDiscardEmptyShortRecordingsOnce`.
+///
+/// The gate's contract: when the daemon token file is missing,
+/// `LocalDaemonToken.read()` throws `TokenError.fileMissing`, which the
+/// sweep treats as a transient skip (return without setting the V2 flag).
+/// All other token errors are surfaced and the sweep proceeds.
+///
+/// Driving the full backfill function requires `RewindDatabase` to be set
+/// up, which is out of scope for a unit test. Instead we pin the load-bearing
+/// behavior the gate depends on: the token reader emits the right typed
+/// error, and pattern-matching on `TokenError.fileMissing` works.
+final class LocalDaemonTokenHealthGateTests: XCTestCase {
+
+    private var originalEnv: String?
+
+    override func setUp() {
+        super.setUp()
+        originalEnv = ProcessInfo.processInfo.environment["INFINITE_RECALL_TOKEN_PATH"]
+        LocalDaemonToken.resetCache()
+    }
+
+    override func tearDown() {
+        if let val = originalEnv {
+            setenv("INFINITE_RECALL_TOKEN_PATH", val, 1)
+        } else {
+            unsetenv("INFINITE_RECALL_TOKEN_PATH")
+        }
+        LocalDaemonToken.resetCache()
+        super.tearDown()
+    }
+
+    func testMissingTokenThrowsFileMissing() throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ir-token-test-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let path = tmpDir.appendingPathComponent("api-token.txt").path
+        setenv("INFINITE_RECALL_TOKEN_PATH", path, 1)
+        LocalDaemonToken.resetCache()
+
+        XCTAssertThrowsError(try LocalDaemonToken.read()) { err in
+            // The gate keys off this exact case; any other error means the
+            // gate would (correctly) fall through to the sweep.
+            switch err {
+            case LocalDaemonToken.TokenError.fileMissing:
+                return  // expected
+            default:
+                XCTFail("expected .fileMissing, got: \(err)")
+            }
+        }
+    }
+
+    func testEmptyTokenThrowsEmptyNotFileMissing() throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ir-token-test-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let url = tmpDir.appendingPathComponent("api-token.txt")
+        try Data().write(to: url)
+        setenv("INFINITE_RECALL_TOKEN_PATH", url.path, 1)
+        LocalDaemonToken.resetCache()
+
+        XCTAssertThrowsError(try LocalDaemonToken.read()) { err in
+            switch err {
+            case LocalDaemonToken.TokenError.empty:
+                return  // expected — gate must NOT treat this as fileMissing
+            case LocalDaemonToken.TokenError.fileMissing:
+                XCTFail("empty file misclassified as .fileMissing — gate would skip incorrectly")
+            default:
+                XCTFail("unexpected error: \(err)")
+            }
+        }
+    }
+
+    func testValidTokenRoundTrips() throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ir-token-test-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let url = tmpDir.appendingPathComponent("api-token.txt")
+        try "alive-token-abc\n".data(using: .utf8)!.write(to: url)
+        setenv("INFINITE_RECALL_TOKEN_PATH", url.path, 1)
+        LocalDaemonToken.resetCache()
+
+        let token = try LocalDaemonToken.read()
+        XCTAssertEqual(token, "alive-token-abc")
+    }
+}

--- a/Desktop/Tests/LocalDaemonTokenReadTests.swift
+++ b/Desktop/Tests/LocalDaemonTokenReadTests.swift
@@ -1,19 +1,18 @@
 import XCTest
 @testable import Omi_Computer
 
-/// Coverage for the daemon-health gate used by
-/// `ConversationSummaryBackfillService.backfillDiscardEmptyShortRecordingsOnce`.
+/// `LocalDaemonToken.read()` semantics — file presence, empty-file detection,
+/// and round-trip of a valid token.
 ///
-/// The gate's contract: when the daemon token file is missing,
-/// `LocalDaemonToken.read()` throws `TokenError.fileMissing`, which the
-/// sweep treats as a transient skip (return without setting the V2 flag).
-/// All other token errors are surfaced and the sweep proceeds.
-///
-/// Driving the full backfill function requires `RewindDatabase` to be set
-/// up, which is out of scope for a unit test. Instead we pin the load-bearing
-/// behavior the gate depends on: the token reader emits the right typed
-/// error, and pattern-matching on `TokenError.fileMissing` works.
-final class LocalDaemonTokenHealthGateTests: XCTestCase {
+/// Renamed from `LocalDaemonTokenHealthGateTests` (Reviewer 3 follow-up):
+/// the previous name overstated coverage. The actual health gate inside
+/// `ConversationSummaryBackfillService.backfillDiscardEmptyShortRecordingsOnce`
+/// is not exercised here — driving it requires a `RewindDatabase` setup and
+/// a DI seam for the token reader, neither of which exists today. What the
+/// tests in this file DO pin is the typed-error contract the gate keys off
+/// (`TokenError.fileMissing` vs `.empty` vs success), so a regression in
+/// `LocalDaemonToken` itself can't silently break the gate.
+final class LocalDaemonTokenReadTests: XCTestCase {
 
     private var originalEnv: String?
 

--- a/Desktop/Tests/TranscriptionStorageDiscardedFilterTests.swift
+++ b/Desktop/Tests/TranscriptionStorageDiscardedFilterTests.swift
@@ -1,0 +1,240 @@
+import XCTest
+import GRDB
+@testable import Omi_Computer
+
+/// Truth-table coverage for the discarded/deleted filter logic in
+/// `TranscriptionStorage.getLocalConversations` and
+/// `TranscriptionStorage.getLocalConversationsCount`.
+///
+/// Driving the production singleton against a real DB is out of scope (it
+/// pulls in the full `RewindDatabase` schema and singleton setup), so we
+/// follow the same pattern as `TranscriptionStorageRepairTests`: mirror the
+/// EXACT SQL the production methods emit through GRDB and pin the row-level
+/// invariants.
+///
+/// Source of truth (keep in sync):
+/// `TranscriptionStorage.getLocalConversations` &
+/// `TranscriptionStorage.getLocalConversationsCount` —
+/// `Desktop/Sources/Rewind/Core/TranscriptionStorage.swift`.
+///
+/// The branch logic mirrored here is:
+///   var query = ...filter(deleted == false)
+///   if discardedOnly {
+///       query = query.filter(discarded == true)
+///   } else if !includeDiscarded {
+///       query = query.filter(discarded == false)
+///   }
+///
+/// Precedence note: when both `includeDiscarded == true` AND
+/// `discardedOnly == true`, `discardedOnly` wins (it's the first arm of the
+/// if/else). The test below pins this so a future refactor can't silently
+/// flip the semantics.
+final class TranscriptionStorageDiscardedFilterTests: XCTestCase {
+
+    // MARK: - Harness
+
+    /// Minimal in-memory schema covering the columns the discarded filter
+    /// reads. Production schema has many more columns; we only need
+    /// `deleted`, `discarded`, plus a primary key + `startedAt` for ORDER BY
+    /// (used by `getLocalConversations`).
+    private func makeQueue() throws -> DatabaseQueue {
+        let queue = try DatabaseQueue()
+        try queue.write { db in
+            try db.execute(sql: """
+                CREATE TABLE transcription_sessions (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    deleted INTEGER NOT NULL DEFAULT 0,
+                    discarded INTEGER NOT NULL DEFAULT 0,
+                    startedAt DATETIME NOT NULL
+                )
+                """)
+        }
+        return queue
+    }
+
+    @discardableResult
+    private func insertRow(
+        _ queue: DatabaseQueue,
+        deleted: Bool,
+        discarded: Bool
+    ) throws -> Int64 {
+        try queue.write { db -> Int64 in
+            try db.execute(
+                sql: """
+                    INSERT INTO transcription_sessions
+                        (deleted, discarded, startedAt)
+                    VALUES (?, ?, ?)
+                    """,
+                arguments: [deleted, discarded, Date()]
+            )
+            return db.lastInsertedRowID
+        }
+    }
+
+    /// Insert the 4-row truth-table fixture and return the row IDs in
+    /// (deleted, discarded) tuple order:
+    /// (0,0) active, (0,1) discarded, (1,0) deleted, (1,1) deleted+discarded.
+    private struct Fixture {
+        let active: Int64
+        let discarded: Int64
+        let deleted: Int64
+        let deletedAndDiscarded: Int64
+    }
+
+    private func seedTruthTable(_ queue: DatabaseQueue) throws -> Fixture {
+        let active = try insertRow(queue, deleted: false, discarded: false)
+        let discarded = try insertRow(queue, deleted: false, discarded: true)
+        let deleted = try insertRow(queue, deleted: true, discarded: false)
+        let deletedAndDiscarded = try insertRow(queue, deleted: true, discarded: true)
+        return Fixture(
+            active: active,
+            discarded: discarded,
+            deleted: deleted,
+            deletedAndDiscarded: deletedAndDiscarded
+        )
+    }
+
+    /// Mirror the production `getLocalConversations` filter chain via GRDB
+    /// query interface (using a generic Row fetch so we don't have to drag
+    /// `TranscriptionSessionRecord` and the full schema into the harness).
+    private func fetchIDs(
+        _ queue: DatabaseQueue,
+        includeDiscarded: Bool,
+        discardedOnly: Bool
+    ) throws -> Set<Int64> {
+        try queue.read { db in
+            var sql = "SELECT id FROM transcription_sessions WHERE deleted = 0"
+            if discardedOnly {
+                sql += " AND discarded = 1"
+            } else if !includeDiscarded {
+                sql += " AND discarded = 0"
+            }
+            sql += " ORDER BY startedAt DESC"
+            let ids = try Int64.fetchAll(db, sql: sql)
+            return Set(ids)
+        }
+    }
+
+    /// Mirror of `getLocalConversationsCount` — same predicate, COUNT(*).
+    private func countRows(
+        _ queue: DatabaseQueue,
+        includeDiscarded: Bool,
+        discardedOnly: Bool
+    ) throws -> Int {
+        try queue.read { db in
+            var sql = "SELECT COUNT(*) FROM transcription_sessions WHERE deleted = 0"
+            if discardedOnly {
+                sql += " AND discarded = 1"
+            } else if !includeDiscarded {
+                sql += " AND discarded = 0"
+            }
+            return try Int.fetchOne(db, sql: sql) ?? 0
+        }
+    }
+
+    // MARK: - getLocalConversations truth table
+
+    /// Default args: hide discarded AND deleted rows. Only the active row
+    /// shows up — this is the conversations-list default behavior.
+    func testDefault_HidesDiscardedAndDeleted() throws {
+        let queue = try makeQueue()
+        let f = try seedTruthTable(queue)
+
+        let ids = try fetchIDs(queue, includeDiscarded: false, discardedOnly: false)
+
+        XCTAssertEqual(ids, [f.active], "default must show only the active row")
+    }
+
+    /// `includeDiscarded == true`: surface both active and discarded rows;
+    /// deleted rows still hidden.
+    func testIncludeDiscarded_ShowsActiveAndDiscarded() throws {
+        let queue = try makeQueue()
+        let f = try seedTruthTable(queue)
+
+        let ids = try fetchIDs(queue, includeDiscarded: true, discardedOnly: false)
+
+        XCTAssertEqual(
+            ids, [f.active, f.discarded],
+            "includeDiscarded=true must show active + discarded, never deleted"
+        )
+    }
+
+    /// `discardedOnly == true`: only discarded non-deleted rows. Used by the
+    /// "Discarded" chip in the UI.
+    func testDiscardedOnly_ShowsOnlyDiscardedNonDeleted() throws {
+        let queue = try makeQueue()
+        let f = try seedTruthTable(queue)
+
+        let ids = try fetchIDs(queue, includeDiscarded: false, discardedOnly: true)
+
+        XCTAssertEqual(
+            ids, [f.discarded],
+            "discardedOnly=true must show only discarded rows that aren't also deleted"
+        )
+    }
+
+    /// Precedence rule: when BOTH `includeDiscarded` and `discardedOnly` are
+    /// true, the if/else picks `discardedOnly` (first arm). Pin this so a
+    /// future refactor can't flip semantics silently.
+    func testBothFlagsTrue_DiscardedOnlyWins() throws {
+        let queue = try makeQueue()
+        let f = try seedTruthTable(queue)
+
+        let ids = try fetchIDs(queue, includeDiscarded: true, discardedOnly: true)
+
+        XCTAssertEqual(
+            ids, [f.discarded],
+            "when both flags are true, discardedOnly takes precedence (matches if/else order)"
+        )
+    }
+
+    /// Across every combination, deleted rows MUST never surface. They live
+    /// in the DB as soft-deleted and only restoration tooling (out of scope)
+    /// should see them.
+    func testDeletedRowsNeverSurface() throws {
+        let queue = try makeQueue()
+        let f = try seedTruthTable(queue)
+
+        for include in [false, true] {
+            for only in [false, true] {
+                let ids = try fetchIDs(queue, includeDiscarded: include, discardedOnly: only)
+                XCTAssertFalse(
+                    ids.contains(f.deleted),
+                    "deleted row must never surface (include=\(include), only=\(only))"
+                )
+                XCTAssertFalse(
+                    ids.contains(f.deletedAndDiscarded),
+                    "deleted+discarded row must never surface (include=\(include), only=\(only))"
+                )
+            }
+        }
+    }
+
+    // MARK: - getLocalConversationsCount truth table
+
+    /// Same truth table, but counted. Mirror of the rows test so a divergence
+    /// between query and count predicates is caught immediately.
+    func testCount_DefaultArgs_OnlyActive() throws {
+        let queue = try makeQueue()
+        _ = try seedTruthTable(queue)
+        XCTAssertEqual(try countRows(queue, includeDiscarded: false, discardedOnly: false), 1)
+    }
+
+    func testCount_IncludeDiscarded_TwoRows() throws {
+        let queue = try makeQueue()
+        _ = try seedTruthTable(queue)
+        XCTAssertEqual(try countRows(queue, includeDiscarded: true, discardedOnly: false), 2)
+    }
+
+    func testCount_DiscardedOnly_OneRow() throws {
+        let queue = try makeQueue()
+        _ = try seedTruthTable(queue)
+        XCTAssertEqual(try countRows(queue, includeDiscarded: false, discardedOnly: true), 1)
+    }
+
+    func testCount_BothFlags_DiscardedOnlyWins() throws {
+        let queue = try makeQueue()
+        _ = try seedTruthTable(queue)
+        XCTAssertEqual(try countRows(queue, includeDiscarded: true, discardedOnly: true), 1)
+    }
+}

--- a/scripts/com.infiniterecall.api.plist
+++ b/scripts/com.infiniterecall.api.plist
@@ -1,4 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Infinite Recall — local Rust daemon launchd agent.
+
+    IMPORTANT: The binary path below MUST live OUTSIDE
+    ~/Library/Application Support/InfiniteRecall/. That directory is reset
+    on schema migrations and any wipe of app state will delete the binary,
+    leaving launchd unable to start the daemon. Keep the binary in
+    /usr/local/bin/ (or another stable, non-state location).
+-->
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
         "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">

--- a/scripts/setup-api-server.sh
+++ b/scripts/setup-api-server.sh
@@ -1,14 +1,19 @@
 #!/usr/bin/env bash
 # Build & install the local Infinite Recall REST API as a launchd agent.
 #
-# Mirrors the mlx-lm sidecar pattern. Idempotent: re-run after rebuilds to
-# bounce the agent.
+# Mirrors the mlx-lm sidecar pattern. Idempotent: re-run after rebuilds.
 #
 # When invoked by the in-app installer (Swift LocalAIInstaller), the script
-# emits structured `PROGRESS:` lines on stdout. In that mode the binary is
-# installed into `~/Library/Application Support/InfiniteRecall/bin/` to avoid
-# sudo prompts. Pass --yes / set INFINITE_RECALL_AUTO_CONFIRM=1 to opt in.
+# emits structured `PROGRESS:` lines on stdout. The binary always installs
+# to `/usr/local/bin/` — never inside ~/Library/Application Support/ — so a
+# wipe of app state (schema migration, manual reset, etc.) does not delete
+# the daemon binary out from under launchd. Pass --yes /
+# INFINITE_RECALL_AUTO_CONFIRM=1 to skip the sudo prompt confirmation.
 set -euo pipefail
+
+# Emit a `failed` step on any early exit so the calling Swift LocalAIInstaller
+# stops waiting for a "done" message and surfaces the error to the user.
+trap 'rc=$?; if [ $rc -ne 0 ]; then printf "PROGRESS:STEP=failed\n"; fi' EXIT
 
 BIN_NAME="infinite-recall-api"
 CLI_BIN_NAME="recall"
@@ -28,14 +33,18 @@ for arg in "$@"; do
   esac
 done
 
-# When running headless from the app, install to user dir (no sudo).
-if [ "${AUTO_CONFIRM}" = "1" ]; then
-    INSTALL_DIR="$HOME/Library/Application Support/InfiniteRecall/bin"
-else
-    INSTALL_DIR="/usr/local/bin"
-fi
+INSTALL_DIR="/usr/local/bin"
 
 progress() { printf "PROGRESS:%s\n" "$1"; }
+
+# Headless safety: if AUTO_CONFIRM=1 and we'd need sudo but sudo would
+# prompt, fail loudly instead of hanging the in-app installer on a TTY
+# password prompt that nobody can see.
+if [ "$AUTO_CONFIRM" = "1" ] && [ ! -w "$INSTALL_DIR" ] && ! sudo -n true 2>/dev/null; then
+    progress "STEP=needs_sudo"
+    echo "ERROR: $INSTALL_DIR not writable and sudo would prompt — re-run with passwordless sudo arranged" >&2
+    exit 2
+fi
 
 progress "STEP=checking_prereqs"
 if ! command -v cargo >/dev/null 2>&1; then
@@ -61,21 +70,19 @@ fi
 
 progress "STEP=installing_launchd"
 echo "==> Installing $BIN_NAME to $INSTALL_DIR"
-mkdir -p "$INSTALL_DIR"
-if [ "${AUTO_CONFIRM}" = "1" ]; then
-    install -m 0755 "$BUILT" "$INSTALL_DIR/$BIN_NAME"
-    install -m 0755 "$BUILT_CLI" "$INSTALL_DIR/$CLI_BIN_NAME"
+if [ -w "$INSTALL_DIR" ]; then
+    INSTALL="install"
 else
-    sudo install -m 0755 "$BUILT" "$INSTALL_DIR/$BIN_NAME"
-    sudo install -m 0755 "$BUILT_CLI" "$INSTALL_DIR/$CLI_BIN_NAME"
+    INSTALL="sudo install"
 fi
+$INSTALL -d -m 0755 "$INSTALL_DIR"
+$INSTALL -m 0755 "$BUILT" "$INSTALL_DIR/$BIN_NAME"
+$INSTALL -m 0755 "$BUILT_CLI" "$INSTALL_DIR/$CLI_BIN_NAME"
 echo "==> Installed $CLI_BIN_NAME to $INSTALL_DIR/$CLI_BIN_NAME"
 
 echo "==> Installing launchd plist to $TARGET_PLIST"
 mkdir -p "$LAUNCH_DIR"
-# Render the plist with the actual binary path (so user-dir installs work).
-sed -e "s|/usr/local/bin/${BIN_NAME}|${INSTALL_DIR}/${BIN_NAME}|g" \
-    "$SOURCE_PLIST" > "$TARGET_PLIST"
+install -m 0644 "$SOURCE_PLIST" "$TARGET_PLIST"
 
 # Reload (unload if present, then load). Tolerate missing.
 progress "STEP=starting_service"

--- a/scripts/setup-api-server.sh
+++ b/scripts/setup-api-server.sh
@@ -13,7 +13,14 @@ set -euo pipefail
 
 # Emit a `failed` step on any early exit so the calling Swift LocalAIInstaller
 # stops waiting for a "done" message and surfaces the error to the user.
-trap 'rc=$?; if [ $rc -ne 0 ]; then printf "PROGRESS:STEP=failed\n"; fi' EXIT
+#
+# Guard with `_failure_step_emitted` so structured exits (e.g. `needs_sudo`)
+# can publish their own step name and bail without the trap clobbering it
+# with `STEP=failed`. The Swift installer reads the LAST progress line, so
+# unconditionally emitting `failed` on every nonzero exit was overriding
+# `needs_sudo` and other meaningful structured-failure signals.
+_failure_step_emitted=0
+trap 'rc=$?; if [ $rc -ne 0 ] && [ "$_failure_step_emitted" = "0" ]; then printf "PROGRESS:STEP=failed\n"; fi' EXIT
 
 BIN_NAME="infinite-recall-api"
 CLI_BIN_NAME="recall"
@@ -43,6 +50,7 @@ progress() { printf "PROGRESS:%s\n" "$1"; }
 if [ "$AUTO_CONFIRM" = "1" ] && [ ! -w "$INSTALL_DIR" ] && ! sudo -n true 2>/dev/null; then
     progress "STEP=needs_sudo"
     echo "ERROR: $INSTALL_DIR not writable and sudo would prompt — re-run with passwordless sudo arranged" >&2
+    _failure_step_emitted=1
     exit 2
 fi
 


### PR DESCRIPTION
## Summary

Three independently-rooted bugs that surfaced together when the local Rust daemon dropped on May 4. Diagnosed, restored on the affected machine, and fixed in code.

### Bug #1 — Activity tab: "snapshot failed: daemon token unavailable"
**Root cause (verified live):** the daemon binary lived inside its own state directory (`~/Library/Application Support/InfiniteRecall/bin/`). Something wiped that directory on May 4 15:01, deleting the deployed binary along with the api-token. The running daemon (`PID 1360`) survived only because Unix held its unlinked text segment — but launchd's `ProgramArguments` pointed at a path that no longer existed, so the next restart would crash-loop. Stale `err.log` from May 2 misled the original "respawn loop" hypothesis.

**Fixes:**
- Daemon binary moved out of AppSupport. Repo plist + `setup-api-server.sh` now canonical on `/usr/local/bin/`.
- `db.rs` cold-start retries 5×1s on transient errors (`NotFound`, `SQLITE_BUSY/LOCKED/IOERR/CANTOPEN/PROTOCOL`); terminal errors bail fast.
- Three distinct error messages: file missing / unreadable / open-failed (the original generic "database not found" misled diagnosis once already).
- `LocalDaemonToken.read(waitFor:)` polls 10s before throwing — smooths the first-launch race.
- Activity tab gets a "Restart daemon" button (`launchctl kickstart -k gui/$UID/...`) running on `Task.detached` so it doesn't block MainActor; non-zero exits surface to the user instead of silently pretending success.

### Bug #2 — Rewind tab: indefinite "Loading screenshots…"
**Root cause:** `RewindViewModel.loadInitialData()` cleared `isLoading=false` only on the success path. Any throw before the final assignment → spinner forever. `loadScreenshotsForDate` silently swallowed DB errors.

**Fixes:**
- Top-level `defer { isLoading = false; cancel watchdog; ... }` so the spinner clears on every exit (success, throw, cancellation).
- 30s watchdog Task flips to error+retry state if init wedges.
- `loadScreenshotsForDate` now `throws`; new `reloadScreenshotsSilently` for filter/date-change call sites that intentionally swallow.
- `RewindPage` predicate reordered so `errorView` wins over `loadingView`.
- Watchdog inherits MainActor from enclosing `@MainActor`-isolated function (no redundant `MainActor.run`); flash-of-timeout race fixed by clearing `errorMessage` on success path.

### Bug #3 — Conversations disappearing
**Root cause:** when the daemon was down, transcribe/summarize jobs flipped `summary_state='unavailable'`, and the discard sweeper soft-flipped those rows to `discarded=1`. The local list query filters out discarded rows, so they vanished from the user's view.

**Fixes:**
- Sweeper checks daemon health before each pass: on `TokenError.fileMissing` the sweep is **skipped** (transient), on `unreadable`/`empty` it logs loudly and proceeds (terminal token state isn't reason to block forever).
- New "Discarded" filter chip in Conversations, plus a tappable "(N hidden)" affordance so users can find soft-discarded rows.
- `TranscriptionStorage.getLocalConversations` gains `includeDiscarded` / `discardedOnly` params (default behavior unchanged).
- `AppState.discardedConversationsCount` skips redundant COUNT(\*) when the chip is already showing only discarded; logs on query failure instead of `try?`-swallowing.

### Reviewer-driven hardening (consensus from 3 parallel reviews)
- `restartDaemon()`: detached Task + termination-status surfaced to UI (was silently failing).
- `setup-api-server.sh`: fail fast on headless `AUTO_CONFIRM=1` runs when sudo would prompt; emit `PROGRESS:STEP=needs_sudo`/`failed` so `LocalAIInstaller` knows.
- `is_transient_open_error`: classifier expanded to cover the SQLite errors that actually surface during macOS APFS cold-start races.
- `LocalDaemonToken.read(waitFor:)`: respects task cancellation instead of polling for the full 10s after the request was discarded.
- Stripped "(Bug #N)" rotting comment labels; collapsed duplicated rationale comments to one home each.

### Tests added
- 9 unit tests for `is_transient_open_error` (Rust): NotFound, PermissionDenied, BUSY, LOCKED, IOERR, CANTOPEN, PROTOCOL, NOTADB, nested-under-anyhow.
- Tokio integration test `retries_until_file_appears` for `open_read_only_pool_with_retry`.
- `LocalDaemonTokenHealthGateTests.swift` — 3 tests pinning the daemon-health gate's token-error semantics.

## Test plan
- [x] `xcrun swift build -c debug --package-path Desktop` — clean
- [x] `xcrun swift test --package-path Desktop` — **472 tests, 0 failures**
- [x] `cargo test --locked -p infinite-recall-api` — **83 + 4 passed**
- [x] `cargo test --locked -p infinite-recall-api --features activity_test_wiring` — **23 + 4 passed**
- [x] `plutil -lint scripts/com.infiniterecall.api.plist` — OK
- [x] Live verification on Mike's machine: daemon binary redeployed, `api-token.txt` materialized, Activity tab unblocks
- [ ] Reviewer to verify on a fresh install that `setup-api-server.sh --yes` no longer hangs when sudo would prompt
- [ ] Reviewer to verify Rewind error UI on a forced DB-init failure (rename `omi.db` briefly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Discarded only" filter for conversations with hidden count indicator.
  * Added daemon restart functionality with automatic retry on the error banner.
  * Improved async token loading with timeout and polling support.

* **Bug Fixes**
  * Enhanced error classification to distinguish transient failures from terminal ones.
  * Improved error messages and recovery options for database connection issues.
  * Better error state display prioritization over loading spinners.

* **Tests**
  * Added token file reading tests.
  * Added conversation filtering tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->