### PR TITLE
fix(tasks): batch fixes for #120 #124 #127 #132

### DIFF
--- a/Desktop/Sources/PowerWorkBridge.swift
+++ b/Desktop/Sources/PowerWorkBridge.swift
@@ -860,6 +860,9 @@ final class PowerWorkBridge {
             loadTranscript: { id in
                 try await ConversationTranscriptLoader.loadAssembled(sessionId: id)
             },
+            loadSessionSource: { id in
+                try await loadTranscriptionSessionSource(sessionId: id)
+            },
             extractItems: { transcript, id in
                 try await callExtractActionItemsLLM(truncated: transcript, sessionId: id)
             },
@@ -870,6 +873,43 @@ final class PowerWorkBridge {
                 try await ConversationActionItemsBackfillService.shared.markSessionExtracted(sessionId: id)
             }
         )
+    }
+
+    /// Reads `transcription_sessions.source` for the given session and maps
+    /// it to the canonical task `source` string used by the Tasks UI filters
+    /// (`transcription:omi`, `transcription:desktop`). Falls back to
+    /// `conversation` for any other / unknown ConversationSource value, so
+    /// non-omi/desktop voice paths still match the legacy bucket.
+    ///
+    /// See issue #120: voice-extracted tasks were always inserted with
+    /// `source = "conversation"`, making them invisible to the user-facing
+    /// Transcription Omi / Transcription Desktop filters.
+    fileprivate static func loadTranscriptionSessionSource(sessionId: Int64) async throws -> String? {
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+            return nil
+        }
+        let raw: String? = try await dbQueue.read { db -> String? in
+            try String.fetchOne(
+                db,
+                sql: "SELECT source FROM transcription_sessions WHERE id = ? AND deleted = 0",
+                arguments: [sessionId]
+            )
+        }
+        return raw
+    }
+
+    /// Map a `transcription_sessions.source` raw value to the canonical
+    /// task-source string the Tasks UI / API expect.
+    /// - `"omi"` → `"transcription:omi"`
+    /// - `"desktop"` → `"transcription:desktop"`
+    /// - anything else (including nil) → `"conversation"` (legacy bucket;
+    ///   matches pre-#120 behavior so non-omi/desktop paths keep working).
+    nonisolated static func taskSourceForSessionSource(_ raw: String?) -> String {
+        switch raw {
+        case "omi": return "transcription:omi"
+        case "desktop": return "transcription:desktop"
+        default: return "conversation"
+        }
     }
 
     /// Testable seam: same body as `processExtractActionItems` but with all
@@ -886,6 +926,7 @@ final class PowerWorkBridge {
     static func _processExtractActionItems(
         sessionId: Int64,
         loadTranscript: (Int64) async throws -> String?,
+        loadSessionSource: (Int64) async throws -> String? = { _ in nil },
         extractItems: (String, Int64) async throws -> [LLMActionItem],
         insert: (ActionItemRecord) async throws -> Void,
         markExtracted: (Int64) async throws -> Void
@@ -937,6 +978,20 @@ final class PowerWorkBridge {
         // successfully. Acceptable trade-off vs. permanent silent loss; a
         // follow-up should add a `(conversationId, hash(description))`
         // upsert.
+        // #120: Resolve the canonical task-source string from
+        // transcription_sessions.source so voice-extracted items match the
+        // Tasks UI's "Transcription Omi" / "Transcription Desktop" filters.
+        // Failures fall back silently to the legacy "conversation" bucket so
+        // a transient DB read error does not also block the LLM result.
+        let sessionSourceRaw: String?
+        do {
+            sessionSourceRaw = try await loadSessionSource(sessionId)
+        } catch {
+            logError("PowerWorkBridge: .extractActionItems — loadSessionSource failed for session \(sessionId), defaulting to 'conversation'", error: error)
+            sessionSourceRaw = nil
+        }
+        let resolvedTaskSource = Self.taskSourceForSessionSource(sessionSourceRaw)
+
         let validPriorities: Set<String> = ["high", "medium", "low"]
         var inserted = 0
         var anyInsertFailed = false
@@ -959,7 +1014,7 @@ final class PowerWorkBridge {
 
             let record = ActionItemRecord(
                 description: description,
-                source: "conversation",
+                source: resolvedTaskSource,
                 conversationId: String(sessionId),
                 priority: priority,
                 category: item.category,

--- a/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift
+++ b/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift
@@ -53,13 +53,17 @@ actor TaskAssistant: ProactiveAssistant {
     /// Parse an inferred deadline string into a Date, or default to end of today.
     /// Tries ISO8601, then common natural language patterns.
     ///
-    /// #124: When the model emits no `inferred_deadline` (nil or empty), the
-    /// Tasks doc promises the task defaults to end-of-day so it lands in the
-    /// *Today* bucket. Previously this branch returned `nil` and the task was
-    /// silently bucketed under *No Deadline*. We now fall back to
-    /// `Self.endOfToday()` to match the documented behavior.
+    /// #124: When the model emits no `inferred_deadline` (nil, empty, or
+    /// whitespace-only), the Tasks doc promises the task defaults to
+    /// end-of-day so it lands in the *Today* bucket. Previously this branch
+    /// returned `nil` and the task was silently bucketed under *No Deadline*.
+    /// We now fall back to `Self.endOfToday()` to match the documented
+    /// behavior. Whitespace-only inputs (`"   "`) are treated as missing per
+    /// CodeRabbit feedback on PR #144 — they should follow the same fallback
+    /// path as `nil` / `""`, not get passed to the parsers.
     private func parseDueDate(from inferredDeadline: String?) -> Date? {
-        guard let deadline = inferredDeadline, !deadline.isEmpty else {
+        let trimmed = inferredDeadline?.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let deadline = trimmed, !deadline.isEmpty else {
             return Self.endOfToday()
         }
         let startOfToday = Calendar.current.startOfDay(for: Date())

--- a/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift
+++ b/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift
@@ -52,9 +52,15 @@ actor TaskAssistant: ProactiveAssistant {
 
     /// Parse an inferred deadline string into a Date, or default to end of today.
     /// Tries ISO8601, then common natural language patterns.
+    ///
+    /// #124: When the model emits no `inferred_deadline` (nil or empty), the
+    /// Tasks doc promises the task defaults to end-of-day so it lands in the
+    /// *Today* bucket. Previously this branch returned `nil` and the task was
+    /// silently bucketed under *No Deadline*. We now fall back to
+    /// `Self.endOfToday()` to match the documented behavior.
     private func parseDueDate(from inferredDeadline: String?) -> Date? {
         guard let deadline = inferredDeadline, !deadline.isEmpty else {
-            return nil
+            return Self.endOfToday()
         }
         let startOfToday = Calendar.current.startOfDay(for: Date())
 

--- a/Desktop/Sources/Stores/TasksStore.swift
+++ b/Desktop/Sources/Stores/TasksStore.swift
@@ -1415,10 +1415,23 @@ class TasksStore: ObservableObject {
                 priority: task.priority,
                 category: task.category,
                 metadata: metadataDict,
-                recurrenceRule: task.recurrenceRule
+                recurrenceRule: task.recurrenceRule,
+                recurrenceParentId: task.recurrenceParentId
             )
             // Update local record with new backend ID
             try await ActionItemStorage.shared.syncTaskActionItems([created])
+            // CodeRabbit (PR #144): the in-memory array still holds the
+            // old `task` with the deleted backend ID after step 2. Without
+            // this swap, edit/toggle/delete on the restored row would call
+            // the backend with an ID that no longer exists. Replace the
+            // stale entry with the freshly-created backend record.
+            if task.completed {
+                if let idx = completedTasks.firstIndex(where: { $0.id == task.id }) {
+                    completedTasks[idx] = created
+                }
+            } else if let idx = incompleteTasks.firstIndex(where: { $0.id == task.id }) {
+                incompleteTasks[idx] = created
+            }
             log("TasksStore: Restored task via undo (new backend ID: \(created.id))")
         } catch {
             logError("TasksStore: Failed to re-create task on backend (local restore preserved)", error: error)

--- a/Desktop/Sources/Stores/TasksStore.swift
+++ b/Desktop/Sources/Stores/TasksStore.swift
@@ -1386,12 +1386,36 @@ class TasksStore: ObservableObject {
             incompleteTasks.insert(task, at: 0)
         }
 
-        // 3. Re-create on backend (hard-delete already removed it)
+        // 3. Re-create on backend (hard-delete already removed it).
+        //
+        // #127: Mirror createTask's full payload so undo doesn't silently
+        // strip source / category / tags / recurrenceRule / metadata.
+        // Without this, the next backend sync overwrites the local row with
+        // the skinny re-created copy and loses the user's metadata.
         do {
+            // Decode the existing metadata JSON back into a dictionary so it
+            // can be re-encoded by createActionItem. If the round-trip fails
+            // (malformed JSON, unexpected shape) fall back to reconstructing
+            // {tags: [...]} from the computed `tags` field so at least the
+            // tag list survives.
+            var metadataDict: [String: Any]? = nil
+            if let metadataJson = task.metadata,
+                let data = metadataJson.data(using: .utf8),
+                let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+            {
+                metadataDict = parsed
+            } else if !task.tags.isEmpty {
+                metadataDict = ["tags": task.tags]
+            }
+
             let created = try await APIClient.shared.createActionItem(
                 description: task.description,
                 dueAt: task.dueAt,
-                priority: task.priority
+                source: task.source,
+                priority: task.priority,
+                category: task.category,
+                metadata: metadataDict,
+                recurrenceRule: task.recurrenceRule
             )
             // Update local record with new backend ID
             try await ActionItemStorage.shared.syncTaskActionItems([created])

--- a/Desktop/Tests/PowerWorkBridgeTests.swift
+++ b/Desktop/Tests/PowerWorkBridgeTests.swift
@@ -345,4 +345,47 @@ final class PowerWorkBridgeTests: XCTestCase {
 
         XCTAssertEqual(insertCount, 1, "Insert ran before mark failed")
     }
+
+    // MARK: - #120: voice-extracted source mapping
+
+    /// `transcription_sessions.source = "omi"` → `"transcription:omi"` so the
+    /// task lands in the *Transcription Omi* filter bucket on TasksPage.
+    func test_taskSourceForSessionSource_omi_mapsToTranscriptionOmi() {
+        XCTAssertEqual(PowerWorkBridge.taskSourceForSessionSource("omi"), "transcription:omi")
+    }
+
+    /// `transcription_sessions.source = "desktop"` → `"transcription:desktop"`.
+    func test_taskSourceForSessionSource_desktop_mapsToTranscriptionDesktop() {
+        XCTAssertEqual(PowerWorkBridge.taskSourceForSessionSource("desktop"), "transcription:desktop")
+    }
+
+    /// Anything else (nil, "unknown", legacy values) falls back to the
+    /// pre-#120 "conversation" bucket so non-omi/desktop voice paths still
+    /// match the legacy behavior.
+    func test_taskSourceForSessionSource_unknown_fallsBackToConversation() {
+        XCTAssertEqual(PowerWorkBridge.taskSourceForSessionSource(nil), "conversation")
+        XCTAssertEqual(PowerWorkBridge.taskSourceForSessionSource("unknown"), "conversation")
+        XCTAssertEqual(PowerWorkBridge.taskSourceForSessionSource("phone"), "conversation")
+    }
+
+    /// End-to-end through the seam: when `loadSessionSource` returns "omi",
+    /// the inserted record carries `source = "transcription:omi"`. This is
+    /// the regression guard for #120 — the previous code hard-coded
+    /// `"conversation"` and the Tasks UI's source filters never matched.
+    func test_processExtractActionItems_resolvesSessionSourceForInsertedRecord() async throws {
+        var inserted: [ActionItemRecord] = []
+
+        try await PowerWorkBridge._processExtractActionItems(
+            sessionId: 99,
+            loadTranscript: { _ in String(repeating: "x", count: 200) },
+            loadSessionSource: { _ in "omi" },
+            extractItems: { _, _ in [Self.makeItem("voice task")] },
+            insert: { record in inserted.append(record) },
+            markExtracted: { _ in }
+        )
+
+        XCTAssertEqual(inserted.count, 1)
+        XCTAssertEqual(inserted.first?.source, "transcription:omi",
+                       "voice-extracted task must map omi session → transcription:omi (fixes #120)")
+    }
 }

--- a/docs/features/tasks.md
+++ b/docs/features/tasks.md
@@ -56,7 +56,7 @@ A filter sidebar or bar sits alongside the list with controls for every dimensio
 
 **Deduplication and Goal promotion.** The `search_similar` call runs before any `extract_task` call. If a close match exists, the model updates the existing task rather than creating a duplicate. If the task aligns with an active Goal (configured in Settings > Advanced > Goals), it is promoted and linked to that goal so it appears in the Goals view as well.
 
-**Staging.** Extracted tasks land in `StagedTaskStorage` first. They are visible in your list immediately, flagged as AI-generated. You can keep, edit, or remove them. Removing a staged task sets the "Removed by AI" state rather than deleting the record, so the filter can surface it later if you want to review what the model dropped.
+**Staging.** Extracted tasks land in `StagedTaskStorage` first. They are visible in your list immediately, flagged as AI-generated. You can keep, edit, or remove them. Removing a staged task before it has been promoted is permanent — it is hard-deleted from the staging table and cannot be surfaced by the "Removed by AI" filter. The "Removed by AI" / "Removed by me" filter states only apply to tasks that have already been promoted into the main `action_items` table (where soft-delete columns exist).
 
 **Calendar-driven tasks.** Tasks with `calendar_driven` origin come from the local Calendar integration reading your events directly. The LLM does not extract these from a transcript; they arrive through a separate pipeline and are labeled accordingly.
 


### PR DESCRIPTION
## Summary
- Voice-extracted tasks resolve their source from `transcription_sessions.source`, mapping `omi`/`desktop` to `transcription:omi`/`transcription:desktop` so the Tasks UI's source filters surface them.
- Tasks extracted with no inferred deadline default to end-of-day instead of nil, matching the doc's promise that they land in *Today* (the unused `endOfToday()` helper is now wired up).
- `restoreTask` (undo) re-creates the backend row with the full payload (source/category/metadata/recurrenceRule), so undo no longer silently strips metadata or breaks recurring tasks.
- Tasks doc updated to match actual staged-task removal behavior (hard-delete, not "Removed by AI"); soft-delete migration on `staged_tasks` is out of scope here.

Fixes #120
Fixes #124
Fixes #127
Fixes #132

## Test plan
- [x] Local CI mirrored: `swift build`, `swift test` (485/485 pass), `cargo test -p infinite-recall-api` (with and without `activity_test_wiring`).
- [x] New unit tests in `PowerWorkBridgeTests` cover the omi/desktop/unknown source mapping and the end-to-end seam for #120.
- [ ] Manual: voice task appears in *Transcription Omi* / *Transcription Desktop* filter on TasksPage.
- [ ] Manual: extract a task with no inferred deadline → `dueAt` ≈ today 23:59 local.
- [ ] Manual: undo restores recurrenceRule/category/tags/metadata.
- [ ] Manual: removing a staged AI task no longer claims to surface under "Removed by AI" (doc-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tasks without specified deadlines now default to end of today, improving organization and visibility.
  * Restored tasks now preserve full task details (source, category, metadata, recurrence) for accurate recovery.
  * Action items now record correct source attribution instead of a generic default.

* **Documentation**
  * Clarified task removal/filter behavior and storage semantics.

* **Tests**
  * Added coverage for source-attribution mapping and end-to-end action item processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->