### PR TITLE
fix(apps): batch fixes for #122 #126 #131 #135

### DIFF
--- a/Desktop/Sources/APIClient.swift
+++ b/Desktop/Sources/APIClient.swift
@@ -1490,6 +1490,35 @@ extension APIClient {
       windowTitle: windowTitle,
       headline: headline
     )
+    // Infinite Recall fork: in local-only mode the cloud /v3/memories endpoint
+    // is unreachable, and the generic post() short-circuit can't synthesize a
+    // non-optional `id` for CreateMemoryResponse, so it would throw
+    // localOnlyMode and every Imports / Reader / Assistant caller would catch
+    // it and report `saved=0`. Instead, persist the memory to the local GRDB
+    // store (the same table MemoryAssistant already writes to via
+    // MemoryStorage.insertLocalMemory), then return a synthetic
+    // CreateMemoryResponse keyed off the local row id.
+    if isLocalOnlyMode {
+      let record = MemoryRecord(
+        backendSynced: false,
+        content: content,
+        category: category?.rawValue ?? "system",
+        manuallyAdded: source == nil && sourceApp == nil,
+        source: source,
+        confidence: confidence,
+        reasoning: reasoning,
+        sourceApp: sourceApp,
+        windowTitle: windowTitle,
+        contextSummary: contextSummary,
+        currentActivity: currentActivity,
+        headline: headline
+      )
+      var withTags = record
+      withTags.setTags(tags)
+      let inserted = try await MemoryStorage.shared.insertLocalMemory(withTags)
+      let localID = inserted.id.map { "local-\($0)" } ?? "local-\(UUID().uuidString)"
+      return CreateMemoryResponse(id: localID, message: "Saved locally")
+    }
     return try await post("v3/memories", body: body)
   }
 

--- a/Desktop/Sources/APIClient.swift
+++ b/Desktop/Sources/APIClient.swift
@@ -1502,7 +1502,7 @@ extension APIClient {
       let record = MemoryRecord(
         backendSynced: false,
         content: content,
-        category: category?.rawValue ?? "system",
+        category: category?.rawValue ?? MemoryCategory.system.rawValue,
         manuallyAdded: source == nil && sourceApp == nil,
         source: source,
         confidence: confidence,

--- a/Desktop/Sources/MainWindow/Pages/AppsPage.swift
+++ b/Desktop/Sources/MainWindow/Pages/AppsPage.swift
@@ -586,6 +586,11 @@ final class ImportConnectorStatusStore: ObservableObject {
         var lastSyncedAt: Date?
         var lastDeltaCount: Int?
         var availabilityText: String?
+        /// Set when the connector's most recent read or sync failed. When
+        /// non-nil, `snapshot()` flips `isConnected = false` so the UI can
+        /// surface a re-grant / repair affordance instead of falsely
+        /// claiming the integration is healthy. Cleared on successful sync.
+        var lastError: String?
     }
 
     struct Snapshot {
@@ -593,6 +598,7 @@ final class ImportConnectorStatusStore: ObservableObject {
         let actionTitle: String
         let primaryText: String
         let secondaryText: String?
+        let errorMessage: String?
     }
 
     @Published private var metricsByID: [String: ConnectorMetrics] = [:]
@@ -615,13 +621,21 @@ final class ImportConnectorStatusStore: ObservableObject {
 
     func snapshot(for connector: ImportConnector) -> Snapshot {
         let metrics = metricsByID[connector.id] ?? ConnectorMetrics()
+        // A latching `lastError` flips the connector to a re-grant state
+        // even if previous successful syncs left memory/source counts behind.
+        // Without this gate the card showed "Connected" forever after the
+        // first read failure (#126).
+        let hasError = metrics.lastError != nil
         let isConnected =
-            metrics.memoryCount.map { $0 > 0 } ?? false
-            || metrics.sourceCount.map { $0 > 0 } ?? false
-            || metrics.availabilityText != nil
-            || connector.id == "local-files"
+            !hasError
+            && (metrics.memoryCount.map { $0 > 0 } ?? false
+                || metrics.sourceCount.map { $0 > 0 } ?? false
+                || metrics.availabilityText != nil
+                || connector.id == "local-files")
         let actionTitle: String
-        if manualConnectorIDs.contains(connector.id) {
+        if hasError {
+            actionTitle = "Reconnect"
+        } else if manualConnectorIDs.contains(connector.id) {
             actionTitle = isConnected ? "Update" : "Connect"
         } else {
             actionTitle = isConnected ? "Sync now" : "Connect"
@@ -631,7 +645,8 @@ final class ImportConnectorStatusStore: ObservableObject {
             isConnected: isConnected,
             actionTitle: actionTitle,
             primaryText: primaryText(for: connector, metrics: metrics, isConnected: isConnected),
-            secondaryText: secondaryText(for: connector, metrics: metrics, isConnected: isConnected)
+            secondaryText: secondaryText(for: connector, metrics: metrics, isConnected: isConnected),
+            errorMessage: metrics.lastError
         )
     }
 
@@ -664,7 +679,49 @@ final class ImportConnectorStatusStore: ObservableObject {
         if let availabilityText {
             metrics.availabilityText = availabilityText
         }
+        // A successful sync invalidates any latched error from a previous
+        // failed read; re-rendering as "Connected" requires this to be cleared
+        // (otherwise `snapshot()` keeps the card pinned in the error state).
+        metrics.lastError = nil
         metricsByID[connectorID] = metrics
+    }
+
+    /// Latches an error state for a connector. The next `snapshot()` will
+    /// report `isConnected = false` and surface `errorMessage` in the UI.
+    /// Cleared by the next successful `markSynced` for the same connector.
+    func markFailed(connectorID: String, error: String) {
+        var metrics = metricsByID[connectorID] ?? ConnectorMetrics()
+        metrics.lastError = error
+        // Also drop stale availability text so the primary line doesn't keep
+        // claiming "Folder granted" / "Private notes accessible" while the
+        // read path is broken (#126).
+        metrics.availabilityText = nil
+        metricsByID[connectorID] = metrics
+    }
+
+    /// Disconnect flow (#131): clears every UserDefaults key this store ever
+    /// writes for `connectorID`, plus connector-specific extras (Apple Notes
+    /// folder grant, legacy onboarding paste counts). After this call the
+    /// connector card renders the same as a fresh install.
+    func clear(connectorID: String) {
+        defaults.removeObject(forKey: sourceCountKeyPrefix + connectorID)
+        defaults.removeObject(forKey: memoryCountKeyPrefix + connectorID)
+        defaults.removeObject(forKey: lastSyncedAtKeyPrefix + connectorID)
+        defaults.removeObject(forKey: lastDeltaCountKeyPrefix + connectorID)
+        defaults.removeObject(forKey: hasLastDeltaKeyPrefix + connectorID)
+
+        switch connectorID {
+        case "apple-notes":
+            defaults.removeObject(forKey: appleNotesFolderDefaultsKey)
+        case "chatgpt":
+            defaults.removeObject(forKey: onboardingChatGPTImportedMemoriesKey)
+        case "claude":
+            defaults.removeObject(forKey: onboardingClaudeImportedMemoriesKey)
+        default:
+            break
+        }
+
+        metricsByID[connectorID] = ConnectorMetrics()
     }
 
     func refresh() async {
@@ -754,17 +811,34 @@ final class ImportConnectorStatusStore: ObservableObject {
     private func refreshAppleNotesMetrics() async {
         do {
             let notes = try await AppleNotesReaderService.shared.readRecentNotes(maxResults: 250)
-            guard !notes.isEmpty else { return }
+            guard !notes.isEmpty else {
+                // Empty result with no thrown error is still a healthy state —
+                // clear any stale error from a previous broken read.
+                if metricsByID["apple-notes"]?.lastError != nil {
+                    var metrics = metricsByID["apple-notes"] ?? ConnectorMetrics()
+                    metrics.lastError = nil
+                    metricsByID["apple-notes"] = metrics
+                }
+                return
+            }
 
             var metrics = metricsByID["apple-notes"] ?? ConnectorMetrics()
             metrics.sourceCount = notes.count
             metrics.availabilityText = "Private notes accessible"
+            metrics.lastError = nil
             metricsByID["apple-notes"] = metrics
         } catch {
+            // #126: Previously this catch unconditionally re-asserted
+            // `availabilityText = "Folder granted"` whenever a folder path was
+            // remembered, which made the card render "Connected / Sync now"
+            // even after the underlying NoteStore read failed (schema upgrade,
+            // file moved, Full Disk Access revoked). Surface the real error so
+            // the user can re-grant access instead of silently failing.
             let folderPath = defaults.string(forKey: appleNotesFolderDefaultsKey) ?? ""
             guard !folderPath.isEmpty else { return }
             var metrics = metricsByID["apple-notes"] ?? ConnectorMetrics()
-            metrics.availabilityText = "Folder granted"
+            metrics.availabilityText = nil
+            metrics.lastError = "Apple Notes read failed: \(error.localizedDescription). Re-grant access to repair."
             metricsByID["apple-notes"] = metrics
         }
     }
@@ -1263,10 +1337,32 @@ struct ImportConnectorSheet: View {
 
             statusSection
 
+            disconnectSection
+
             Spacer(minLength: 0)
         }
         .padding(24)
         .background(OmiColors.backgroundPrimary)
+    }
+
+    /// Disconnect affordance (#131). Shown whenever the connector has any
+    /// persisted state — either a healthy connection, a latched error, or
+    /// stale onboarding paste counts. `local-files` is excluded because the
+    /// on-device index is the data itself, not a connection that can be
+    /// "forgotten" without separately wiping the index.
+    @ViewBuilder
+    private var disconnectSection: some View {
+        let hasState =
+            snapshot.isConnected
+            || snapshot.errorMessage != nil
+            || snapshot.secondaryText != nil
+        if hasState && connector.id != "local-files" {
+            Button("Disconnect \(connector.title)") {
+                statusStore.clear(connectorID: connector.id)
+            }
+            .buttonStyle(OnboardingCardButtonStyle(isPrimary: false))
+            .disabled(model.isRunning)
+        }
     }
 
     private var connectorActionContent: some View {
@@ -1442,6 +1538,13 @@ struct ImportConnectorSheet: View {
             Text(errorMessage)
                 .scaledFont(size: 12, weight: .medium)
                 .foregroundColor(OmiColors.warning)
+        } else if let storedError = snapshot.errorMessage {
+            // Surface the latched store-level error (#126). Distinct from
+            // model.errorMessage which only covers the in-flight import.
+            Text(storedError)
+                .scaledFont(size: 12, weight: .medium)
+                .foregroundColor(OmiColors.warning)
+                .fixedSize(horizontal: false, vertical: true)
         } else if snapshot.isConnected || snapshot.secondaryText != nil {
             statusCard {
                 VStack(alignment: .leading, spacing: 6) {

--- a/Desktop/Sources/MainWindow/Pages/AppsPage.swift
+++ b/Desktop/Sources/MainWindow/Pages/AppsPage.swift
@@ -811,17 +811,10 @@ final class ImportConnectorStatusStore: ObservableObject {
     private func refreshAppleNotesMetrics() async {
         do {
             let notes = try await AppleNotesReaderService.shared.readRecentNotes(maxResults: 250)
-            guard !notes.isEmpty else {
-                // Empty result with no thrown error is still a healthy state —
-                // clear any stale error from a previous broken read.
-                if metricsByID["apple-notes"]?.lastError != nil {
-                    var metrics = metricsByID["apple-notes"] ?? ConnectorMetrics()
-                    metrics.lastError = nil
-                    metricsByID["apple-notes"] = metrics
-                }
-                return
-            }
-
+            // A successful read — even one that returns zero notes — proves
+            // the integration is healthy. Normalize to a "0 notes / accessible"
+            // snapshot so a previous error or stale source count can't keep
+            // the card pinned in a reconnect / out-of-date state.
             var metrics = metricsByID["apple-notes"] ?? ConnectorMetrics()
             metrics.sourceCount = notes.count
             metrics.availabilityText = "Private notes accessible"
@@ -834,9 +827,22 @@ final class ImportConnectorStatusStore: ObservableObject {
             // even after the underlying NoteStore read failed (schema upgrade,
             // file moved, Full Disk Access revoked). Surface the real error so
             // the user can re-grant access instead of silently failing.
-            let folderPath = defaults.string(forKey: appleNotesFolderDefaultsKey) ?? ""
-            guard !folderPath.isEmpty else { return }
+            //
+            // We only surface the error if the connector had prior state —
+            // a fresh-install user who has never connected Apple Notes
+            // shouldn't see a permission error on every page open. "Prior
+            // state" includes both a remembered folder grant AND any
+            // metrics from a Full-Disk-Access read path (which never sets
+            // the folder grant key), so the gate must check both.
             var metrics = metricsByID["apple-notes"] ?? ConnectorMetrics()
+            let folderPath = defaults.string(forKey: appleNotesFolderDefaultsKey) ?? ""
+            let hadPriorState =
+                metrics.sourceCount != nil
+                || metrics.memoryCount != nil
+                || metrics.lastSyncedAt != nil
+                || metrics.availabilityText != nil
+                || !folderPath.isEmpty
+            guard hadPriorState else { return }
             metrics.availabilityText = nil
             metrics.lastError = "Apple Notes read failed: \(error.localizedDescription). Re-grant access to repair."
             metricsByID["apple-notes"] = metrics

--- a/Desktop/Sources/MainWindow/Pages/AppsPage.swift
+++ b/Desktop/Sources/MainWindow/Pages/AppsPage.swift
@@ -1297,6 +1297,7 @@ struct ImportConnectorSheet: View {
     let onDismiss: () -> Void
 
     @StateObject private var model = ImportConnectorSheetModel()
+    @State private var showDisconnectConfirmation = false
 
     private var snapshot: ImportConnectorStatusStore.Snapshot {
         statusStore.snapshot(for: connector)
@@ -1356,6 +1357,10 @@ struct ImportConnectorSheet: View {
     /// stale onboarding paste counts. `local-files` is excluded because the
     /// on-device index is the data itself, not a connection that can be
     /// "forgotten" without separately wiping the index.
+    ///
+    /// Disconnect is destructive (it wipes UserDefaults state and the Apple
+    /// Notes folder grant), so it goes through a confirmation alert to
+    /// prevent accidental clicks.
     @ViewBuilder
     private var disconnectSection: some View {
         let hasState =
@@ -1364,10 +1369,21 @@ struct ImportConnectorSheet: View {
             || snapshot.secondaryText != nil
         if hasState && connector.id != "local-files" {
             Button("Disconnect \(connector.title)") {
-                statusStore.clear(connectorID: connector.id)
+                showDisconnectConfirmation = true
             }
             .buttonStyle(OnboardingCardButtonStyle(isPrimary: false))
             .disabled(model.isRunning)
+            .alert(
+                "Disconnect \(connector.title)?",
+                isPresented: $showDisconnectConfirmation
+            ) {
+                Button("Disconnect", role: .destructive) {
+                    statusStore.clear(connectorID: connector.id)
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text("This clears the saved connection state for \(connector.title). Memories already imported from this source are kept; you can prune them from the Memories page if you want.")
+            }
         }
     }
 

--- a/Desktop/Tests/AppsImportsRegressionTests.swift
+++ b/Desktop/Tests/AppsImportsRegressionTests.swift
@@ -1,0 +1,191 @@
+import XCTest
+@testable import Omi_Computer
+
+/// Regression tests for the Apps cluster batch fix (issues #122, #126, #131).
+///
+/// - #122: APIClient.createMemory short-circuited in local-only mode and every
+///   Imports / Reader / Assistant caller reported "saved=0".
+/// - #126: ImportConnectorStatusStore kept Apple Notes pinned to "Connected /
+///   Folder granted" after the underlying NoteStore read failed.
+/// - #131: There was no Disconnect flow; UserDefaults state for connectors
+///   accumulated forever.
+@MainActor
+final class AppsImportsRegressionTests: XCTestCase {
+
+    // MARK: - #122: createMemory persists locally instead of throwing
+
+    /// In the bug, `APIClient.createMemory` ran the generic `post()`
+    /// short-circuit, `synthesizeEmpty()` failed because `CreateMemoryResponse`
+    /// requires a non-optional `id`, and the call threw `APIError.localOnlyMode`.
+    /// After the fix, the call must return a synthetic response keyed off the
+    /// local row id without ever attempting a network request.
+    ///
+    /// Note: this test points the shared `RewindDatabase` at a unique
+    /// per-test user id and invalidates the `MemoryStorage` cache so the
+    /// memory write goes to a sandboxed DB and never collides with the
+    /// `anonymous` DB used by sibling test suites (e.g.
+    /// `LocalIntegrationDispatcherTests`).
+    func testCreateMemoryPersistsLocallyInLocalOnlyMode() async throws {
+        let testUserId = "test-apps-imports-122-\(UUID().uuidString)"
+        await RewindDatabase.shared.configure(userId: testUserId)
+        try await RewindDatabase.shared.initialize()
+        await MemoryStorage.shared.invalidateCache()
+        defer {
+            Task { await RewindDatabase.shared.close() }
+        }
+
+        let client = APIClient.shared  // no testAuthHeader → isLocalOnlyMode == true
+
+        let unique = "regression-122-\(UUID().uuidString)"
+        let response = try await client.createMemory(
+            content: unique,
+            tags: ["test", "regression"],
+            source: "apps_import_regression_test",
+            headline: "Regression #122"
+        )
+
+        // Must come back with a non-empty synthetic id; the fork prefixes
+        // local rows with "local-" so this is the contract callers can rely on.
+        XCTAssertFalse(response.id.isEmpty,
+                       "createMemory must return a non-empty id even in local-only mode")
+        XCTAssertTrue(response.id.hasPrefix("local-"),
+                      "Local-only createMemory must return a synthetic 'local-' prefixed id")
+    }
+
+    // MARK: - #126: Apple Notes connector reflects read failure
+
+    /// In the bug, `snapshot()` returned `isConnected = true` purely because
+    /// `availabilityText` was non-nil, even after a downstream read had thrown.
+    /// After the fix, a latched `lastError` must flip the snapshot to a
+    /// reconnect state regardless of any leftover availability/source counts.
+    func testAppleNotesSnapshotReflectsLatchedError() {
+        let suiteName = "AppsImportsRegressionTests.AppleNotesError-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let store = ImportConnectorStatusStore(defaults: defaults)
+        let appleNotes = ImportConnector.all.first(where: { $0.id == "apple-notes" })!
+
+        // Seed a previously-successful sync: source count, availability text.
+        store.markSynced(
+            connectorID: appleNotes.id,
+            sourceCount: 42,
+            availabilityText: "Private notes accessible"
+        )
+        let healthy = store.snapshot(for: appleNotes)
+        XCTAssertTrue(healthy.isConnected,
+                      "Sanity check: a successful sync must render as Connected")
+
+        // Subsequent read fails — latch the error.
+        store.markFailed(
+            connectorID: appleNotes.id,
+            error: "NoteStore.sqlite is unreadable"
+        )
+
+        let snap = store.snapshot(for: appleNotes)
+        XCTAssertFalse(snap.isConnected,
+                       "A latched lastError must override stale availability text")
+        XCTAssertEqual(snap.actionTitle, "Reconnect",
+                       "Error state must surface a Reconnect affordance")
+        XCTAssertNotNil(snap.errorMessage,
+                        "Snapshot must propagate the error message to the UI")
+    }
+
+    /// A successful `markSynced` must clear any latched error from a prior
+    /// failed read so the card returns to a healthy state.
+    func testMarkSyncedClearsLatchedError() {
+        let suiteName = "AppsImportsRegressionTests.ClearError-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let store = ImportConnectorStatusStore(defaults: defaults)
+        let appleNotes = ImportConnector.all.first(where: { $0.id == "apple-notes" })!
+
+        store.markFailed(connectorID: appleNotes.id, error: "boom")
+        XCTAssertFalse(store.snapshot(for: appleNotes).isConnected)
+
+        store.markSynced(
+            connectorID: appleNotes.id,
+            sourceCount: 7,
+            availabilityText: "Private notes accessible"
+        )
+        let snap = store.snapshot(for: appleNotes)
+        XCTAssertTrue(snap.isConnected,
+                      "Successful sync must clear latched error and return to Connected")
+        XCTAssertNil(snap.errorMessage)
+    }
+
+    // MARK: - #131: Disconnect flow clears persisted state
+
+    /// `clear(connectorID:)` must remove every UserDefaults key the store ever
+    /// writes for the connector plus connector-specific extras. After clearing,
+    /// the snapshot must look exactly like a fresh-install state.
+    func testClearRemovesAllConnectorState() {
+        let suiteName = "AppsImportsRegressionTests.Clear-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        // Seed every UserDefaults key the store ever writes for apple-notes,
+        // plus the connector-specific Apple Notes folder grant.
+        defaults.set(42, forKey: "appsImportConnectorSourceCount.apple-notes")
+        defaults.set(7, forKey: "appsImportConnectorMemoryCount.apple-notes")
+        defaults.set(Date().timeIntervalSince1970,
+                     forKey: "appsImportConnectorLastSyncedAt.apple-notes")
+        defaults.set(3, forKey: "appsImportConnectorLastDeltaCount.apple-notes")
+        defaults.set(true, forKey: "appsImportConnectorHasLastDelta.apple-notes")
+        defaults.set("/Users/test/group.com.apple.notes",
+                     forKey: "onboardingAppleNotesFolderPath")
+
+        let store = ImportConnectorStatusStore(defaults: defaults)
+        let appleNotes = ImportConnector.all.first(where: { $0.id == "apple-notes" })!
+
+        // Sanity: the store hydrated the seeded state.
+        XCTAssertTrue(store.snapshot(for: appleNotes).isConnected,
+                      "Sanity check: hydrated state must render as Connected")
+
+        store.clear(connectorID: appleNotes.id)
+
+        // All UserDefaults keys are gone.
+        XCTAssertNil(defaults.object(forKey: "appsImportConnectorSourceCount.apple-notes"))
+        XCTAssertNil(defaults.object(forKey: "appsImportConnectorMemoryCount.apple-notes"))
+        XCTAssertNil(defaults.object(forKey: "appsImportConnectorLastSyncedAt.apple-notes"))
+        XCTAssertNil(defaults.object(forKey: "appsImportConnectorLastDeltaCount.apple-notes"))
+        XCTAssertNil(defaults.object(forKey: "appsImportConnectorHasLastDelta.apple-notes"))
+        XCTAssertNil(defaults.object(forKey: "onboardingAppleNotesFolderPath"),
+                     "clear() for apple-notes must also drop the folder grant key")
+
+        // Snapshot reflects the fresh-install state.
+        let snap = store.snapshot(for: appleNotes)
+        XCTAssertFalse(snap.isConnected,
+                       "After clear() the connector must not render as Connected")
+        XCTAssertEqual(snap.actionTitle, "Connect",
+                       "After clear() the action title must revert to Connect")
+        XCTAssertNil(snap.errorMessage)
+    }
+
+    /// `clear(connectorID:)` for the manual paste connectors (chatgpt, claude)
+    /// must also wipe the legacy onboarding paste-count keys, otherwise
+    /// `hydrateLegacyManualImports` will resurrect "Imported during onboarding"
+    /// the next time the store is constructed.
+    func testClearChatGPTRemovesLegacyOnboardingCount() {
+        let suiteName = "AppsImportsRegressionTests.ClearChatGPT-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(12, forKey: "onboardingChatGPTImportedMemoriesCount")
+
+        let store = ImportConnectorStatusStore(defaults: defaults)
+        let chatgpt = ImportConnector.all.first(where: { $0.id == "chatgpt" })!
+
+        XCTAssertTrue(store.snapshot(for: chatgpt).isConnected,
+                      "Legacy onboarding count must hydrate as Connected")
+
+        store.clear(connectorID: chatgpt.id)
+
+        XCTAssertNil(defaults.object(forKey: "onboardingChatGPTImportedMemoriesCount"))
+        // Reconstruct the store to verify hydration doesn't bring it back.
+        let reborn = ImportConnectorStatusStore(defaults: defaults)
+        XCTAssertFalse(reborn.snapshot(for: chatgpt).isConnected,
+                       "After clear() a freshly hydrated store must show Not connected")
+    }
+}

--- a/docs/features/apps.md
+++ b/docs/features/apps.md
@@ -30,7 +30,7 @@ The Apps page is how you connect Infinite Recall to other data sources on your M
 
 ## Behind the scenes
 
-**Local-first by design.** Infinite Recall does not talk to a remote app marketplace. The Featured section exists for a future catalog; in the current build it is always empty. The real work happens in Imports and My Apps. Every memory that an Imports connector creates is written to the local GRDB store via `MemoryStorage.insertLocalMemory` — nothing leaves the device.
+**Local-first by design.** Infinite Recall does not talk to a remote app marketplace. The Featured section exists for a future catalog; in the current build it is always empty. The real work happens in Imports and My Apps. Every memory that an Imports connector creates is written to the local GRDB store via `MemoryStorage.insertLocalMemory` first; if you have My Apps export destinations configured (webhook URLs or filesystem folders), the local write can then be mirrored to those user-chosen destinations. Nothing is sent to a marketplace, telemetry endpoint, or Anthropic/Google/Apple cloud — only to the destinations you explicitly enable.
 
 ### Imports connectors
 

--- a/docs/features/apps.md
+++ b/docs/features/apps.md
@@ -6,18 +6,19 @@ The Apps page is how you connect Infinite Recall to other data sources on your M
 
 - A search bar at the top for filtering by name or category.
 - A **Featured apps** section. The remote catalogue is empty in this build by design — Infinite Recall is local-first and does not talk to a remote app marketplace. The section is a placeholder for a future catalogue.
-- A **My Apps** section listing connectors you have already configured locally.
+- An **Imports** section with six built-in connectors (Calendar, Email/Gmail, Local files, Apple Notes, ChatGPT, Claude) — these import data from outside the app into the local memory store.
+- A **My Apps** section listing the local export integrations you have configured (webhook destinations and filesystem export folders).
 - Category filters and infinite scroll for browsing available apps.
-- Tapping any app opens its detail view: a full description, configuration controls, and any active toggles.
-- Export destinations appear here when an integration supports writing data back (for example, creating a note for a daily summary).
+- Tapping any connector opens its detail sheet: a description, the connect/sync action, current status, latched error state when a previous read failed, and a Disconnect button when the connector has any persisted state.
 
 ## What you can do
 
 - Search apps by name or keyword.
 - Filter the list by category.
-- Tap into any app to read its description and configure it.
-- Set up local integrations — Apple Notes and Google Calendar are the primary two — so their data feeds into Tasks, Memories, and Focus.
-- Configure export destinations for features like daily summaries.
+- Tap into any connector to read its description and configure it.
+- Set up Imports — Calendar, Gmail, Apple Notes, Local files, ChatGPT, Claude — so their data feeds into Tasks, Memories, and Focus.
+- Configure local export destinations (webhooks and filesystem folders) under My Apps so your captured memories can flow out to the rest of your toolchain.
+- Disconnect a connector to clear its persisted state and remove it from the connected list.
 
 ## States
 
@@ -25,21 +26,49 @@ The Apps page is how you connect Infinite Recall to other data sources on your M
 - **Filter loading state** when a category filter is being applied.
 - **Empty state** when the remote catalog returns nothing (the expected state in local-first mode).
 - **No results** when a search or filter combination yields no matches.
+- **Error / re-grant** state on a connector card when the most recent read failed (for example, Apple Notes after the user revoked Full Disk Access). The card surfaces the error message and switches the action to Reconnect.
 
 ## Behind the scenes
 
-**Local-first by design.** Infinite Recall does not talk to a remote app marketplace. The Featured section exists for a future catalog; in the current build it is always empty. The real work happens in My Apps — the local connectors you configure here.
+**Local-first by design.** Infinite Recall does not talk to a remote app marketplace. The Featured section exists for a future catalog; in the current build it is always empty. The real work happens in Imports and My Apps. Every memory that an Imports connector creates is written to the local GRDB store via `MemoryStorage.insertLocalMemory` — nothing leaves the device.
 
-**Apple Notes integration.** `AppleNotesReaderService` opens a read-only connection to the macOS Notes SQLite store and queries notes by folder. Those notes become context available across the app: the Task extraction pipeline can surface a project deadline mentioned in a note as a task with `external_system` origin, and the chat panel can reference recent notes directly.
+### Imports connectors
 
-**Google Calendar integration.** `CalendarReaderService` reads your Google Calendar events by decrypting your existing browser cookies — no separate OAuth flow or credential entry required. A small Python helper extracts upcoming events and caches them locally. Calendar events are a primary source of `calendar_driven` tasks: when the extraction pipeline sees an event that implies a commitment or deadline, it creates or updates the corresponding task automatically.
+**Calendar (Google Calendar).** `CalendarReaderService` reads your Google Calendar events by decrypting your existing browser cookies — no separate OAuth flow or credential entry required. A small Python helper extracts upcoming events and caches them locally. Calendar events are a primary source of `calendar_driven` tasks: when the extraction pipeline sees an event that implies a commitment or deadline, it creates or updates the corresponding task automatically.
 
-**Where the data goes.** Configured integrations are not siloed on this page. Their data is wired into the rest of the app's context pipeline. The Focus and Task assistants (see [tasks.md](tasks.md)) include calendar events and recent notes when querying the local LLM for action items. The chat panel can reference them in responses.
+**Email (Gmail).** `GmailReaderService` follows the same browser-cookie + SAPISID auth pattern as Calendar — it decrypts Chromium cookies via Keychain and uses them to read up to 365 days of email through the Gmail HTTP endpoints, no Google OAuth required. This is the most invasive integration in the catalog: it scans every Chromium-based browser profile on the machine looking for valid Gmail sessions. Each email becomes a memory tagged `gmail`/`email` with the subject as the headline.
 
-**Export destinations.** When an integration supports writing back — for example, creating an Apple Note for the day's summary — it registers itself as an export destination and appears in this section.
+**Local files.** Always available on this device. Hooks into the on-device file indexer (`FileIndexerService` and friends) to rescan documents, code, and working folders. Indexed files become searchable context — they are not stored as discrete memories but the indexer is part of the same local subsystem the memory store uses.
+
+**Apple Notes.** `AppleNotesReaderService` opens a read-only connection to the macOS Notes SQLite store at `~/Library/Group Containers/group.com.apple.notes/NoteStore.sqlite` and queries notes by folder. Requires Full Disk Access or an explicit folder grant. Notes become memories tagged `apple_notes`/`note`/`import`. If the read fails (schema migration, file moved, permission revoked), the card switches to a Reconnect state and surfaces the underlying error instead of falsely reporting "Connected".
+
+**ChatGPT memory paste.** Manual import flow via `OnboardingMemoryLogImportService`. The connector opens ChatGPT, copies a memory-export prompt to the clipboard, and provides a text area where the user pastes the response. The local LLM then extracts durable memories from the pasted conversation.
+
+**Claude memory paste.** Same `OnboardingMemoryLogImportService` flow as ChatGPT, but targeting Claude's web UI.
+
+### Disconnect flow
+
+Every connector except Local files exposes a Disconnect button in its detail sheet. Disconnect calls `ImportConnectorStatusStore.clear(connectorID:)` which removes every UserDefaults key the store ever wrote for that connector — source counts, memory counts, sync timestamps, delta counts, plus connector-specific extras (Apple Notes folder grant, legacy onboarding paste counts). After disconnecting, the card renders the same as a fresh install. Memories already saved from a connector are not retroactively deleted; they keep their `source` tag so the user can prune them from the Memories page if they want.
+
+### My Apps (local export integrations)
+
+The My Apps section is separate from Imports — it covers data flowing **out** of Infinite Recall to local destinations:
+
+- **Webhook destinations.** A user-configured HTTP endpoint that receives a JSON payload every time a memory is created. Backed by `LocalIntegrationStorage` (config) and `LocalIntegrationDrainService` (delivery + retry). Useful for piping memories into Obsidian, a personal Slack, a homelab logger, etc.
+- **Filesystem export folders.** A user-configured directory that receives a file per memory. Same backend — `LocalIntegrationStorage` keeps the destination, `LocalIntegrationDrainService` writes the files and retries on transient errors.
+
+Both export types are dispatched fire-and-forget from `MemoryStorage.insertLocalMemory` so they never block the memory write path.
+
+**Where the data goes.** Imports data lands in the local memory store and is wired into the rest of the app's context pipeline. The Focus and Task assistants (see [tasks.md](tasks.md)) include calendar events, recent notes, and Gmail history when querying the local LLM for action items. The chat panel can reference them in responses.
 
 ## Source
 
 - `Desktop/Sources/MainWindow/Pages/AppsPage.swift`
 - `Desktop/Sources/AppleNotesReaderService.swift`
 - `Desktop/Sources/CalendarReaderService.swift`
+- `Desktop/Sources/GmailReaderService.swift`
+- `Desktop/Sources/OnboardingMemoryLogImportService.swift`
+- `Desktop/Sources/MainWindow/Pages/LocalIntegrations/MyAppsSection.swift`
+- `Desktop/Sources/LocalIntegrations/LocalIntegrationStorage.swift`
+- `Desktop/Sources/LocalIntegrations/LocalIntegrationDrainService.swift`
+- `Desktop/Sources/Rewind/Core/MemoryStorage.swift`


### PR DESCRIPTION
## Summary
- **#122**: `APIClient.createMemory` now writes through to `MemoryStorage.insertLocalMemory` in local-only mode and returns a synthetic `local-…` id, so Imports actually save memories instead of reporting `saved=0`.
- **#126**: Connector cards no longer claim "Connected / Folder granted" after a failed read. `ConnectorMetrics` now carries a latching `lastError`; `snapshot()` flips to a Reconnect state and surfaces the error inline.
- **#131**: Imports support a Disconnect flow. New `ImportConnectorStatusStore.clear(connectorID:)` wipes every UserDefaults key the store writes, plus connector-specific extras (`onboardingAppleNotesFolderPath`, legacy ChatGPT/Claude paste counts). `ImportConnectorSheet` shows a Disconnect button for every connector except `local-files`.
- **#135**: `docs/features/apps.md` now documents all six Imports (Calendar, Gmail, Local files, Apple Notes, ChatGPT, Claude), the disconnect flow, the error/re-grant state, and the My Apps section (`LocalIntegrationStorage` + `LocalIntegrationDrainService`).

Fixes #122
Fixes #126
Fixes #131
Fixes #135

## Test plan
- [x] `xcrun swift build -c debug --package-path Desktop` clean
- [x] `xcrun swift test --package-path Desktop` — 486 tests pass (5 new)
- [x] `cargo test --locked -p infinite-recall-api` (with and without `activity_test_wiring`) pass
- [ ] Manual: import in local-only mode → memories appear on Memories page
- [ ] Manual: revoke FDA / move NoteStore → Apple Notes card shows Reconnect + error message
- [ ] Manual: Disconnect a connector → state cleared, card reverts to "Not connected"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Memories can be saved locally when cloud is unavailable, preserving data and UX continuity and returning a local saved confirmation.
  * A Disconnect option for import connectors lets users reset a connector and clear its persisted state.

* **Bug Fixes**
  * Better detection and surfacing of connector errors, including latched error states that force reconnect prompts and clearer messages.
  * Successful syncs now clear previously latched errors.

* **Documentation**
  * Expanded Apps docs with import connector details and the disconnect workflow.

* **Tests**
  * Added regression tests for local persistence and connector error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->