### PR TITLE
fix(conversations): batch fixes for #136 #138 #139 #140 #141 #142

### DIFF
--- a/Desktop/Sources/AppState.swift
+++ b/Desktop/Sources/AppState.swift
@@ -2147,6 +2147,7 @@ class AppState: ObservableObject {
       let localCount = try await TranscriptionStorage.shared.getLocalConversationsCount(
         starredOnly: showStarredOnly,
         discardedOnly: showDiscardedOnly,
+        folderId: selectedFolderId,
         startDate: filterStartDate,
         endDate: filterEndDate)
       totalConversationsCount = localCount

--- a/Desktop/Sources/AppState.swift
+++ b/Desktop/Sources/AppState.swift
@@ -2067,6 +2067,24 @@ class AppState: ObservableObject {
     isLoadingConversations = true
     conversationsError = nil
 
+    // Compute the date-filter window from `selectedDateFilter` once so both
+    // the conversations query and the count query see the same bounds.
+    // Calendar.startOfDay returns the beginning of the user's local day; the
+    // upper bound is the start of the next day, giving a half-open range
+    // [startOfDay, startOfNextDay) that the SQL filter compares against
+    // `startedAt`. (Issue #138)
+    let filterStartDate: Date?
+    let filterEndDate: Date?
+    if let filterDate = selectedDateFilter {
+      let calendar = Calendar.current
+      let start = calendar.startOfDay(for: filterDate)
+      filterStartDate = start
+      filterEndDate = calendar.date(byAdding: .day, value: 1, to: start)
+    } else {
+      filterStartDate = nil
+      filterEndDate = nil
+    }
+
     // Step 1: Load from local cache first (instant display)
     // Use timeout to avoid blocking UI if database is initializing (e.g. recovery)
     do {
@@ -2077,7 +2095,9 @@ class AppState: ObservableObject {
             limit: 50,
             starredOnly: self.showStarredOnly,
             folderId: self.selectedFolderId,
-            discardedOnly: self.showDiscardedOnly
+            discardedOnly: self.showDiscardedOnly,
+            startDate: filterStartDate,
+            endDate: filterEndDate
           )
         }
         group.addTask {
@@ -2089,60 +2109,65 @@ class AppState: ObservableObject {
         return result
       }
 
-      if !cachedConversations.isEmpty {
-        conversations = cachedConversations
-        log("Conversations: Loaded \(cachedConversations.count) from local cache (instant)")
+      // Always commit the local-cache result — even when empty — so that
+      // applying a filter that excludes every row clears the previous list
+      // state instead of leaving stale rows on screen. (Issues #138, #142)
+      conversations = cachedConversations
+      log("Conversations: Loaded \(cachedConversations.count) from local cache (instant)")
 
-        // Batch-fetch first-segment text per session for inline preview.
-        // Only need this for `local-N` ids (no overview yet); rows backed by
-        // a real backendId still benefit if their structured.overview is
-        // empty. Either way this is one SQL pass for the visible page.
-        let sessionIds: [Int64] = cachedConversations.compactMap { conv in
-          guard conv.id.hasPrefix("local-"),
-            let n = Int64(conv.id.dropFirst("local-".count))
-          else { return nil }
-          return n
-        }
-        if !sessionIds.isEmpty {
-          do {
-            let textsBySessionId = try await TranscriptionStorage.shared.getFirstSegmentTexts(
-              sessionIds: sessionIds)
-            var previews: [String: String] = [:]
-            for (sid, text) in textsBySessionId {
-              let preview = String(text.prefix(120))
-              previews["local-\(sid)"] = preview
-            }
-            conversationPreviews = previews
-          } catch {
-            logError("Conversations: Failed to load previews", error: error)
-          }
-        }
-
-        // Get local count (matches the active filter so the header total
-        // reflects what the user is currently looking at).
-        let localCount = try await TranscriptionStorage.shared.getLocalConversationsCount(
-          starredOnly: showStarredOnly,
-          discardedOnly: showDiscardedOnly)
-        totalConversationsCount = localCount
-
-        // Passive "(N hidden)" hint: count discarded rows separately so the
-        // Conversations header can offer a way to reach them via the chip.
-        // When the chip is ON the primary count above already counts the
-        // discarded rows, so skip the redundant query.
-        if !showDiscardedOnly {
-          do {
-            discardedConversationsCount = try await TranscriptionStorage.shared
-              .getLocalConversationsCount(discardedOnly: true)
-          } catch {
-            logError("Conversations: Failed to load discarded count", error: error)
-          }
-        }
-
-        // Stop loading state so UI shows cached data immediately
-        isLoadingConversations = false
-        // Notify sidebar immediately so loading indicator clears with cached data
-        NotificationCenter.default.post(name: .conversationsPageDidLoad, object: nil)
+      // Batch-fetch first-segment text per session for inline preview.
+      // Only need this for `local-N` ids (no overview yet); rows backed by
+      // a real backendId still benefit if their structured.overview is
+      // empty. Either way this is one SQL pass for the visible page.
+      let sessionIds: [Int64] = cachedConversations.compactMap { conv in
+        guard conv.id.hasPrefix("local-"),
+          let n = Int64(conv.id.dropFirst("local-".count))
+        else { return nil }
+        return n
       }
+      if !sessionIds.isEmpty {
+        do {
+          let textsBySessionId = try await TranscriptionStorage.shared.getFirstSegmentTexts(
+            sessionIds: sessionIds)
+          var previews: [String: String] = [:]
+          for (sid, text) in textsBySessionId {
+            let preview = String(text.prefix(120))
+            previews["local-\(sid)"] = preview
+          }
+          conversationPreviews = previews
+        } catch {
+          logError("Conversations: Failed to load previews", error: error)
+        }
+      } else {
+        conversationPreviews = [:]
+      }
+
+      // Get local count (matches the active filter so the header total
+      // reflects what the user is currently looking at).
+      let localCount = try await TranscriptionStorage.shared.getLocalConversationsCount(
+        starredOnly: showStarredOnly,
+        discardedOnly: showDiscardedOnly,
+        startDate: filterStartDate,
+        endDate: filterEndDate)
+      totalConversationsCount = localCount
+
+      // Passive "(N hidden)" hint: count discarded rows separately so the
+      // Conversations header can offer a way to reach them via the chip.
+      // When the chip is ON the primary count above already counts the
+      // discarded rows, so skip the redundant query.
+      if !showDiscardedOnly {
+        do {
+          discardedConversationsCount = try await TranscriptionStorage.shared
+            .getLocalConversationsCount(discardedOnly: true)
+        } catch {
+          logError("Conversations: Failed to load discarded count", error: error)
+        }
+      }
+
+      // Stop loading state so UI shows cached data immediately
+      isLoadingConversations = false
+      // Notify sidebar immediately so loading indicator clears with cached data
+      NotificationCenter.default.post(name: .conversationsPageDidLoad, object: nil)
     } catch {
       log("Conversations: Local cache unavailable, falling back to API")
       // Continue to API fetch even if local fails

--- a/Desktop/Sources/MainWindow/Components/ConversationListView.swift
+++ b/Desktop/Sources/MainWindow/Components/ConversationListView.swift
@@ -21,6 +21,22 @@ struct ConversationListView: View {
 
   var appState: AppState
 
+  /// True when any filter chip is active (issue #142). Used to show a
+  /// "no matching conversations" panel instead of the brand-new-user empty
+  /// state when a filter excludes every row.
+  private var hasActiveFilter: Bool {
+    appState.showStarredOnly
+      || appState.selectedDateFilter != nil
+      || appState.selectedFolderId != nil
+      || appState.showDiscardedOnly
+  }
+
+  /// Caller-action that clears all chip filters at once. Wired through
+  /// `appState.clearFilters()`; rendered only when a filter is active.
+  private func clearFilters() {
+    Task { await appState.clearFilters() }
+  }
+
   private static let groupDateFormatter: DateFormatter = {
     let f = DateFormatter()
     f.dateFormat = "MMM d, yyyy"
@@ -97,7 +113,13 @@ struct ConversationListView: View {
       } else if let error = error, conversations.isEmpty {
         errorView(error)
       } else if conversations.isEmpty {
-        emptyView
+        // Issue #142: distinguish a genuinely empty store from a filter
+        // that happens to match nothing.
+        if hasActiveFilter {
+          noFilterResultsView
+        } else {
+          emptyView
+        }
       } else {
         conversationList
       }
@@ -163,6 +185,63 @@ struct ConversationListView: View {
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .padding(32)
+  }
+
+  /// Shown when the store has rows but the active filter excludes all of
+  /// them (issue #142). Distinct from `emptyView` so the user knows the
+  /// list is filtered, not genuinely empty.
+  private var noFilterResultsView: some View {
+    VStack(spacing: 16) {
+      Image(systemName: "line.3.horizontal.decrease.circle")
+        .scaledFont(size: 48)
+        .foregroundColor(OmiColors.textTertiary)
+
+      Text("No matching conversations")
+        .scaledFont(size: 18, weight: .semibold)
+        .foregroundColor(OmiColors.textPrimary)
+
+      Text(activeFilterDescription)
+        .scaledFont(size: 14)
+        .foregroundColor(OmiColors.textTertiary)
+        .multilineTextAlignment(.center)
+
+      Button(action: clearFilters) {
+        Text("Clear filters")
+          .scaledFont(size: 13, weight: .medium)
+          .foregroundColor(OmiColors.textPrimary)
+          .padding(.horizontal, 16)
+          .padding(.vertical, 8)
+          .omiControlSurface(fill: OmiColors.userBubble, radius: OmiChrome.chipRadius)
+      }
+      .buttonStyle(.plain)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .padding(32)
+  }
+
+  /// Human-readable summary of the active filter chips for the no-results
+  /// panel. Reads `appState` rather than receiving the filter set as
+  /// parameters so the description stays in sync with `hasActiveFilter`.
+  private var activeFilterDescription: String {
+    var parts: [String] = []
+    if appState.showStarredOnly { parts.append("starred only") }
+    if appState.showDiscardedOnly { parts.append("discarded only") }
+    if let date = appState.selectedDateFilter {
+      let formatter = DateFormatter()
+      formatter.dateFormat = "MMM d, yyyy"
+      parts.append("on \(formatter.string(from: date))")
+    }
+    if let folderId = appState.selectedFolderId,
+       let folder = folders.first(where: { $0.id == folderId })
+    {
+      parts.append("in \"\(folder.name)\"")
+    } else if appState.selectedFolderId != nil {
+      parts.append("in selected folder")
+    }
+    if parts.isEmpty {
+      return "No conversations match the current filters."
+    }
+    return "No conversations match: " + parts.joined(separator: ", ") + "."
   }
 
   private var conversationListContent: some View {

--- a/Desktop/Sources/MainWindow/Components/ConversationRowView.swift
+++ b/Desktop/Sources/MainWindow/Components/ConversationRowView.swift
@@ -209,6 +209,12 @@ struct ConversationRowView: View {
       await MainActor.run {
         appState.setConversationStarred(conversation.id, starred: newStarred)
       }
+      // CodeRabbit feedback (PR #147): when the user unstars a row while the
+      // Starred-only chip is active the row no longer matches the filter, so
+      // reload the list to drop it instead of leaving a stale entry on screen.
+      if !newStarred && appState.showStarredOnly {
+        await appState.loadConversations()
+      }
     } catch {
       log("Failed to persist starred status locally: \(error)")
       isStarring = false

--- a/Desktop/Sources/MainWindow/Components/ConversationRowView.swift
+++ b/Desktop/Sources/MainWindow/Components/ConversationRowView.swift
@@ -199,18 +199,29 @@ struct ConversationRowView: View {
     isStarring = true
     let newStarred = !conversation.starred
 
+    // Local-first (issue #141): persist to SQLite FIRST. The API mutation
+    // throws `localOnlyMode` from `buildHeaders` before any HTTP call, which
+    // previously short-circuited the whole `do` block and left the star
+    // toggle silently reverting on every reload.
     do {
-      try await APIClient.shared.setConversationStarred(id: conversation.id, starred: newStarred)
-
-      // Sync to local SQLite cache so reload doesn't revert the change
       try await TranscriptionStorage.shared.updateStarredByBackendId(
         conversation.id, starred: newStarred)
-
       await MainActor.run {
         appState.setConversationStarred(conversation.id, starred: newStarred)
       }
     } catch {
-      log("Failed to update starred status: \(error)")
+      log("Failed to persist starred status locally: \(error)")
+      isStarring = false
+      return
+    }
+
+    // Best-effort remote sync (no-op in local-only mode).
+    do {
+      try await APIClient.shared.setConversationStarred(id: conversation.id, starred: newStarred)
+    } catch {
+      if !isLocalOnlyError(error) {
+        log("Failed to update starred status remotely: \(error)")
+      }
     }
 
     isStarring = false
@@ -281,19 +292,27 @@ struct ConversationRowView: View {
     guard !isUpdatingTitle, !editedTitle.isEmpty else { return }
     isUpdatingTitle = true
 
+    // Local-first (issue #141): persist to SQLite FIRST so the rename sticks
+    // even when the API mutation throws `localOnlyMode`.
     do {
-      try await APIClient.shared.updateConversationTitle(id: conversation.id, title: editedTitle)
-
-      // Sync to local SQLite cache so reload doesn't revert the change
       try await TranscriptionStorage.shared.updateTitleByBackendId(
         conversation.id, title: editedTitle)
-
       await MainActor.run {
         appState.updateConversationTitle(conversation.id, title: editedTitle)
       }
-      log("Updated conversation title to: \(editedTitle)")
+      log("Updated conversation title locally to: \(editedTitle)")
     } catch {
-      log("Failed to update title: \(error)")
+      log("Failed to persist title locally: \(error)")
+      isUpdatingTitle = false
+      return
+    }
+
+    do {
+      try await APIClient.shared.updateConversationTitle(id: conversation.id, title: editedTitle)
+    } catch {
+      if !isLocalOnlyError(error) {
+        log("Failed to update title remotely: \(error)")
+      }
     }
 
     isUpdatingTitle = false

--- a/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
+++ b/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
@@ -579,14 +579,28 @@ struct ConversationDetailView: View {
         isDeleting = true
         defer { isDeleting = false }
 
+        // Local-first: soft-delete in SQLite immediately so reload doesn't restore the row.
+        // Without this, `getLocalConversations` will re-surface the conversation on the
+        // next page revisit / app relaunch (the API delete is a no-op in local-only mode).
+        do {
+            try await TranscriptionStorage.shared.deleteByBackendId(conversation.id)
+        } catch {
+            log("Failed to soft-delete conversation locally: \(error)")
+        }
+
         do {
             try await APIClient.shared.deleteConversation(id: conversation.id)
-            await MainActor.run {
-                onDelete?()
-                onBack()
-            }
         } catch {
-            logError("Failed to delete conversation", error: error)
+            // localOnlyMode is expected here in the Infinite Recall fork; the SQLite
+            // soft-delete above is the source of truth. Surface only real failures.
+            if !isLocalOnlyError(error) {
+                logError("Failed to delete conversation", error: error)
+            }
+        }
+
+        await MainActor.run {
+            onDelete?()
+            onBack()
         }
     }
 

--- a/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
+++ b/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
@@ -567,11 +567,25 @@ struct ConversationDetailView: View {
         isUpdatingTitle = true
         defer { isUpdatingTitle = false }
 
+        // Local-first (issue #141): the detail-view rename had no SQLite path,
+        // so even when the API succeeded the title would be re-overwritten by
+        // the next local cache load. Persist to SQLite first; treat the API
+        // call as best-effort (no-op in local-only mode).
         do {
-            try await APIClient.shared.updateConversationTitle(id: conversation.id, title: editedTitle)
+            try await TranscriptionStorage.shared.updateTitleByBackendId(
+                conversation.id, title: editedTitle)
             onTitleUpdated?(editedTitle)
         } catch {
-            logError("Failed to update title", error: error)
+            logError("Failed to persist title locally", error: error)
+            return
+        }
+
+        do {
+            try await APIClient.shared.updateConversationTitle(id: conversation.id, title: editedTitle)
+        } catch {
+            if !isLocalOnlyError(error) {
+                logError("Failed to update title remotely", error: error)
+            }
         }
     }
 

--- a/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
+++ b/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
@@ -798,17 +798,18 @@ struct ConversationsPage: View {
 
     do {
       let ids = Array(selectedConversationIds)
-      let response = try await APIClient.shared.mergeConversations(ids: ids)
+      // Local-first (issue #140): perform the merge against on-device SQLite.
+      // Re-parents segments / audio_chunks / speaker_embeddings onto the
+      // earliest source, soft-deletes the others, and clears the target's
+      // title/overview so the LLM enrichment pipeline regenerates a fresh
+      // combined summary.
+      let mergedBackendId = try await TranscriptionStorage.shared
+        .mergeConversationsLocally(sourceBackendIds: ids)
+      log("Merge completed locally; target=\(mergedBackendId)")
 
-      log("Merge completed: \(response.message)")
-
-      // Show warning if there was one
-      if let warning = response.warning {
-        log("Merge warning: \(warning)")
-      }
-
-      // Refresh conversations to show the merged one
-      await appState.refreshConversations()
+      // Reload conversations from local cache so the merged row replaces
+      // the originals in the list.
+      await appState.loadConversations()
 
       // Exit multi-select mode
       withAnimation(.easeInOut(duration: 0.2)) {

--- a/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
+++ b/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
@@ -811,6 +811,15 @@ struct ConversationsPage: View {
       // the originals in the list.
       await appState.loadConversations()
 
+      // CodeRabbit feedback (PR #147): when merging from search mode the
+      // page renders `searchResults` (not `appState.conversations`), so the
+      // main-list reload above isn't enough — the merged-away source rows
+      // would stay visible until the user retypes. Re-run the active search
+      // so its snapshot reflects the post-merge store.
+      if !searchQuery.isEmpty {
+        performSearch(query: searchDebouncer.debouncedQuery)
+      }
+
       // Exit multi-select mode
       withAnimation(.easeInOut(duration: 0.2)) {
         isMultiSelectMode = false

--- a/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
+++ b/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
@@ -473,18 +473,19 @@ struct ConversationsPage: View {
 
     Task {
       do {
-        let result = try await APIClient.shared.searchConversations(
+        // Local-first (issue #139): the API path short-circuits to an empty
+        // result in local-only mode, so search the on-device SQLite store
+        // directly. Matches against title, overview, and segment text.
+        let results = try await TranscriptionStorage.shared.searchConversationsLocally(
           query: query,
-          page: 1,
-          perPage: 50,
+          limit: 50,
           includeDiscarded: false
         )
-        log("Search: Found \(result.items.count) results")
-        searchResults = result.items
+        log("Search: Found \(results.count) local results")
+        searchResults = results
         isSearching = false
       } catch {
         logError("Search: Failed", error: error)
-        // Infinite Recall fork: local-only mode — return empty result instead of throwing
         if !isLocalOnlyError(error) {
           searchError = error.localizedDescription
         }

--- a/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
+++ b/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
@@ -1089,7 +1089,9 @@ actor TranscriptionStorage {
         starredOnly: Bool = false,
         folderId: String? = nil,
         includeDiscarded: Bool = false,
-        discardedOnly: Bool = false
+        discardedOnly: Bool = false,
+        startDate: Date? = nil,
+        endDate: Date? = nil
     ) async throws -> [ServerConversation] {
         let db = try await ensureInitialized()
 
@@ -1120,6 +1122,17 @@ actor TranscriptionStorage {
                 query = query.filter(Column("folderId") == folderId)
             }
 
+            // Local-first date filter (issue #138): the calendar chip writes to
+            // `selectedDateFilter` but the row was never re-read here — every
+            // date selection returned the same 50-row window. Caller passes a
+            // half-open [startDate, endDate) window computed from the picker.
+            if let startDate = startDate {
+                query = query.filter(Column("startedAt") >= startDate)
+            }
+            if let endDate = endDate {
+                query = query.filter(Column("startedAt") < endDate)
+            }
+
             let sessions = try query
                 .order(Column("startedAt").desc)
                 .limit(limit, offset: offset)
@@ -1138,7 +1151,9 @@ actor TranscriptionStorage {
     func getLocalConversationsCount(
         starredOnly: Bool = false,
         includeDiscarded: Bool = false,
-        discardedOnly: Bool = false
+        discardedOnly: Bool = false,
+        startDate: Date? = nil,
+        endDate: Date? = nil
     ) async throws -> Int {
         let db = try await ensureInitialized()
 
@@ -1157,6 +1172,13 @@ actor TranscriptionStorage {
 
             if starredOnly {
                 query = query.filter(Column("starred") == true)
+            }
+
+            if let startDate = startDate {
+                query = query.filter(Column("startedAt") >= startDate)
+            }
+            if let endDate = endDate {
+                query = query.filter(Column("startedAt") < endDate)
             }
 
             return try query.fetchCount(database)

--- a/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
+++ b/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
@@ -1152,6 +1152,7 @@ actor TranscriptionStorage {
         starredOnly: Bool = false,
         includeDiscarded: Bool = false,
         discardedOnly: Bool = false,
+        folderId: String? = nil,
         startDate: Date? = nil,
         endDate: Date? = nil
     ) async throws -> Int {
@@ -1172,6 +1173,13 @@ actor TranscriptionStorage {
 
             if starredOnly {
                 query = query.filter(Column("starred") == true)
+            }
+
+            // Folder filter must mirror `getLocalConversations` so the header
+            // count doesn't drift from the visible list when a folder chip is
+            // active. (CodeRabbit feedback on PR #147)
+            if let folderId = folderId {
+                query = query.filter(Column("folderId") == folderId)
             }
 
             if let startDate = startDate {
@@ -1297,40 +1305,43 @@ actor TranscriptionStorage {
             let placeholders = sourceIds.map { _ in "?" }.joined(separator: ", ")
             let args = StatementArguments([targetId] + sourceIds)
 
-            // Re-parent transcription_segments. The merged session's segment
-            // ordering follows source-session start time then original
-            // segmentOrder; we renumber after re-parent so the detail view
-            // renders the combined transcript in chronological order.
+            // CodeRabbit feedback (PR #147): capture the cross-session
+            // chronology BEFORE re-parenting. Once every segment has
+            // `sessionId = targetId` we lose the per-session offset and
+            // can only sort by intra-session `startTime`, which resets near
+            // zero for each original recording — so a later conversation's
+            // segments would jump ahead of an earlier conversation's. Build
+            // the final ordering up front by joining each segment to its
+            // owning session's `startedAt`, sorting by
+            // (session.startedAt, segment.segmentOrder, segment.startTime, id),
+            // and use that to renumber after the UPDATE.
+            let allSessionIds: [Int64] = [targetId] + sourceIds
+            let allPlaceholders = allSessionIds.map { _ in "?" }.joined(separator: ", ")
+            let orderingRows = try Row.fetchAll(
+                database,
+                sql: """
+                    SELECT seg.id AS id
+                      FROM transcription_segments seg
+                      JOIN transcription_sessions sess ON sess.id = seg.sessionId
+                     WHERE seg.sessionId IN (\(allPlaceholders))
+                     ORDER BY sess.startedAt ASC,
+                              seg.segmentOrder ASC,
+                              seg.startTime ASC,
+                              seg.id ASC
+                    """,
+                arguments: StatementArguments(allSessionIds)
+            )
+            let orderedSegmentIds: [Int64] = orderingRows.compactMap { $0["id"] }
+
+            // Re-parent transcription_segments onto the target.
             try database.execute(
                 sql: "UPDATE transcription_segments SET sessionId = ? WHERE sessionId IN (\(placeholders))",
                 arguments: args
             )
 
-            // Renumber segmentOrder across the unioned set so the merged view
-            // shows segments in (sessionStartedAt, originalOrder) order.
-            // Because GRDB doesn't expose ROW_NUMBER cleanly across all SQLite
-            // builds we ship, we do it in Swift: fetch ids in the desired
-            // order, then write them back with sequential `segmentOrder`.
-            let allSessionIds: [Int64] = [targetId] + sourceIds
-            let allArgs = StatementArguments(allSessionIds)
-            let allPlaceholders = allSessionIds.map { _ in "?" }.joined(separator: ", ")
-            // Use the original session start time to order across the merged set.
-            // After re-parenting above all sessionIds are == targetId, so we can't
-            // recover original start order from the row itself. We already reset
-            // sessionId; segmentOrder is the only remaining ordering hint, so
-            // dedupe-renumber by (startTime, segmentOrder).
-            // Re-fetch in the desired order and renumber.
-            let segmentRows = try Row.fetchAll(
-                database,
-                sql: """
-                    SELECT id FROM transcription_segments
-                     WHERE sessionId IN (\(allPlaceholders))
-                     ORDER BY startTime ASC, segmentOrder ASC, id ASC
-                    """,
-                arguments: allArgs
-            )
-            for (idx, row) in segmentRows.enumerated() {
-                guard let sid: Int64 = row["id"] else { continue }
+            // Renumber using the pre-captured ordering so the merged
+            // transcript reads in true chronological order across sources.
+            for (idx, sid) in orderedSegmentIds.enumerated() {
                 try database.execute(
                     sql: "UPDATE transcription_segments SET segmentOrder = ? WHERE id = ?",
                     arguments: [idx, sid]

--- a/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
+++ b/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
@@ -1248,4 +1248,136 @@ actor TranscriptionStorage {
             return ids.compactMap { byId[$0]?.toServerConversation(segments: []) }
         }
     }
+
+    // MARK: - Local Merge
+
+    /// Locally merge multiple conversations into a single target session (issue #140).
+    ///
+    /// Picks the earliest `startedAt` row in `sourceBackendIds` as the target,
+    /// re-parents all `transcription_segments`, `audio_chunks`
+    /// (`transcriptionSessionId`), and `speaker_embeddings` rows from the
+    /// other sources onto the target, then soft-deletes the sources. Title
+    /// and overview are cleared so the LLM-enrichment pipeline can regenerate
+    /// a fresh combined summary.
+    ///
+    /// All work runs in a single GRDB write transaction so a failure leaves
+    /// the on-disk state untouched.
+    ///
+    /// - Returns: the backendId of the merged target session (caller can refresh).
+    @discardableResult
+    func mergeConversationsLocally(sourceBackendIds: [String]) async throws -> String {
+        guard sourceBackendIds.count >= 2 else {
+            throw TranscriptionStorageError.invalidState("Need at least 2 conversations to merge")
+        }
+
+        let db = try await ensureInitialized()
+
+        return try await db.write { database -> String in
+            // Resolve backendIds -> session rows. Ignore any backendIds that
+            // don't resolve (already-deleted, stale UI selection).
+            let sessions = try TranscriptionSessionRecord
+                .filter(sourceBackendIds.contains(Column("backendId")))
+                .filter(Column("deleted") == false)
+                .fetchAll(database)
+            guard sessions.count >= 2 else {
+                throw TranscriptionStorageError.invalidState("Fewer than 2 valid sessions to merge")
+            }
+
+            // Pick the earliest-started session as the merge target.
+            let sorted = sessions.sorted { $0.startedAt < $1.startedAt }
+            guard var target = sorted.first, let targetId = target.id else {
+                throw TranscriptionStorageError.invalidState("Target session has no id")
+            }
+            let sourceIds: [Int64] = sorted.dropFirst().compactMap { $0.id }
+            guard !sourceIds.isEmpty else {
+                throw TranscriptionStorageError.invalidState("No source sessions resolved")
+            }
+
+            // Build the IN-clause once.
+            let placeholders = sourceIds.map { _ in "?" }.joined(separator: ", ")
+            let args = StatementArguments([targetId] + sourceIds)
+
+            // Re-parent transcription_segments. The merged session's segment
+            // ordering follows source-session start time then original
+            // segmentOrder; we renumber after re-parent so the detail view
+            // renders the combined transcript in chronological order.
+            try database.execute(
+                sql: "UPDATE transcription_segments SET sessionId = ? WHERE sessionId IN (\(placeholders))",
+                arguments: args
+            )
+
+            // Renumber segmentOrder across the unioned set so the merged view
+            // shows segments in (sessionStartedAt, originalOrder) order.
+            // Because GRDB doesn't expose ROW_NUMBER cleanly across all SQLite
+            // builds we ship, we do it in Swift: fetch ids in the desired
+            // order, then write them back with sequential `segmentOrder`.
+            let allSessionIds: [Int64] = [targetId] + sourceIds
+            let allArgs = StatementArguments(allSessionIds)
+            let allPlaceholders = allSessionIds.map { _ in "?" }.joined(separator: ", ")
+            // Use the original session start time to order across the merged set.
+            // After re-parenting above all sessionIds are == targetId, so we can't
+            // recover original start order from the row itself. We already reset
+            // sessionId; segmentOrder is the only remaining ordering hint, so
+            // dedupe-renumber by (startTime, segmentOrder).
+            // Re-fetch in the desired order and renumber.
+            let segmentRows = try Row.fetchAll(
+                database,
+                sql: """
+                    SELECT id FROM transcription_segments
+                     WHERE sessionId IN (\(allPlaceholders))
+                     ORDER BY startTime ASC, segmentOrder ASC, id ASC
+                    """,
+                arguments: allArgs
+            )
+            for (idx, row) in segmentRows.enumerated() {
+                guard let sid: Int64 = row["id"] else { continue }
+                try database.execute(
+                    sql: "UPDATE transcription_segments SET segmentOrder = ? WHERE id = ?",
+                    arguments: [idx, sid]
+                )
+            }
+
+            // Re-parent always-on audio_chunks (transcriptionSessionId).
+            try database.execute(
+                sql: "UPDATE audio_chunks SET transcriptionSessionId = ? WHERE transcriptionSessionId IN (\(placeholders))",
+                arguments: args
+            )
+
+            // Re-parent speaker_embeddings (sessionId).
+            try database.execute(
+                sql: "UPDATE speaker_embeddings SET sessionId = ? WHERE sessionId IN (\(placeholders))",
+                arguments: args
+            )
+
+            // Sum durations onto the target. We treat finishedAt as the merged
+            // session's last finishedAt across the set so the duration math in
+            // the detail view stays in range.
+            let latestFinishedAt = sorted.compactMap { $0.finishedAt }.max()
+
+            // Mark sources as soft-deleted so they disappear from the list but
+            // don't break any persisted FK references.
+            try database.execute(
+                sql: "UPDATE transcription_sessions SET deleted = 1, updatedAt = ? WHERE id IN (\(placeholders))",
+                arguments: StatementArguments([Date()] + sourceIds)
+            )
+
+            // Reset target metadata so a fresh enrichment pass picks up the
+            // newly combined transcript and rewrites title/overview/etc.
+            target.title = nil
+            target.overview = nil
+            target.emoji = nil
+            target.category = nil
+            target.actionItemsJson = nil
+            target.eventsJson = nil
+            target.summaryState = "unavailable"
+            if let finished = latestFinishedAt {
+                target.finishedAt = finished
+            }
+            target.updatedAt = Date()
+            try target.update(database)
+
+            log("TranscriptionStorage: Merged \(sourceIds.count) source sessions into target \(targetId)")
+            return target.backendId ?? "local-\(targetId)"
+        }
+    }
 }

--- a/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
+++ b/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
@@ -1184,4 +1184,68 @@ actor TranscriptionStorage {
             return try query.fetchCount(database)
         }
     }
+
+    // MARK: - Local Search
+
+    /// Search conversations against local SQLite storage (issue #139).
+    ///
+    /// Matches against the session's `title`, `overview`, and any segment text
+    /// in `transcription_segments`. Case-insensitive substring search via SQL
+    /// LIKE — sufficient for the single-user, on-device dataset and avoids
+    /// adding an FTS5 mirror to the migration chain. Returns sessions sorted
+    /// by `startedAt` desc with a single de-dup pass so a session that matches
+    /// in both the title and a segment only appears once.
+    func searchConversationsLocally(
+        query: String,
+        limit: Int = 50,
+        includeDiscarded: Bool = false
+    ) async throws -> [ServerConversation] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
+
+        let db = try await ensureInitialized()
+
+        // Escape SQL LIKE wildcards so a literal `%foo` doesn't behave magically.
+        let escaped = trimmed
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "%", with: "\\%")
+            .replacingOccurrences(of: "_", with: "\\_")
+        let pattern = "%\(escaped)%"
+
+        let discardedClause = includeDiscarded ? "" : "AND s.discarded = 0"
+
+        return try await db.read { database -> [ServerConversation] in
+            let sql = """
+                SELECT DISTINCT s.id
+                  FROM transcription_sessions s
+                  LEFT JOIN transcription_segments seg ON seg.sessionId = s.id
+                 WHERE s.deleted = 0
+                   \(discardedClause)
+                   AND (
+                        s.title    LIKE ? ESCAPE '\\'
+                     OR s.overview LIKE ? ESCAPE '\\'
+                     OR seg.text   LIKE ? ESCAPE '\\'
+                   )
+                 ORDER BY s.startedAt DESC
+                 LIMIT ?
+                """
+            let rows = try Row.fetchAll(
+                database,
+                sql: sql,
+                arguments: [pattern, pattern, pattern, limit]
+            )
+            let ids: [Int64] = rows.compactMap { $0["id"] }
+            guard !ids.isEmpty else { return [] }
+
+            // Fetch full session records preserving the ordering above.
+            let sessions = try TranscriptionSessionRecord
+                .filter(ids.contains(Column("id")))
+                .fetchAll(database)
+            let byId = Dictionary(uniqueKeysWithValues: sessions.compactMap { s -> (Int64, TranscriptionSessionRecord)? in
+                guard let sid = s.id else { return nil }
+                return (sid, s)
+            })
+            return ids.compactMap { byId[$0]?.toServerConversation(segments: []) }
+        }
+    }
 }

--- a/Desktop/Tests/ConversationsClusterRegressionTests.swift
+++ b/Desktop/Tests/ConversationsClusterRegressionTests.swift
@@ -1,0 +1,346 @@
+import XCTest
+import GRDB
+@testable import Omi_Computer
+
+/// Regression coverage for the local-first Conversations fixes shipped in the
+/// `gh-conversations-cluster` PR (#136 #138 #139 #140 #141 #142).
+///
+/// We mirror the production SQL inline rather than driving the full
+/// `TranscriptionStorage` singleton + `RewindDatabase` migration chain — the
+/// same approach taken by `TranscriptionStorageDiscardedFilterTests`. This
+/// keeps the test suite hermetic and pins the row-level invariants that each
+/// issue's fix relies on.
+///
+/// Sources of truth (keep in sync):
+///   - `getLocalConversations` / `getLocalConversationsCount` startDate/endDate
+///     filter (issue #138)
+///   - `searchConversationsLocally` LIKE join over segments (issue #139)
+///   - `mergeConversationsLocally` re-parent + soft-delete (issue #140)
+///   - `deleteByBackendId` soft-delete write (issue #136)
+///     in `Desktop/Sources/Rewind/Core/TranscriptionStorage.swift`.
+final class ConversationsClusterRegressionTests: XCTestCase {
+
+    // MARK: - Harness
+
+    /// Minimal in-memory schema covering only the columns the cluster fixes
+    /// touch. Production schema has many more columns; we only need what the
+    /// SQL under test reads/writes.
+    private func makeQueue() throws -> DatabaseQueue {
+        let queue = try DatabaseQueue()
+        try queue.write { db in
+            try db.execute(sql: """
+                CREATE TABLE transcription_sessions (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    backendId TEXT,
+                    title TEXT,
+                    overview TEXT,
+                    deleted INTEGER NOT NULL DEFAULT 0,
+                    discarded INTEGER NOT NULL DEFAULT 0,
+                    startedAt DATETIME NOT NULL,
+                    finishedAt DATETIME,
+                    updatedAt DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+                )
+                """)
+            try db.execute(sql: """
+                CREATE TABLE transcription_segments (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    sessionId INTEGER NOT NULL,
+                    text TEXT NOT NULL,
+                    segmentOrder INTEGER NOT NULL DEFAULT 0,
+                    startTime DOUBLE NOT NULL DEFAULT 0
+                )
+                """)
+        }
+        return queue
+    }
+
+    @discardableResult
+    private func insertSession(
+        _ queue: DatabaseQueue,
+        backendId: String? = nil,
+        title: String? = nil,
+        overview: String? = nil,
+        deleted: Bool = false,
+        discarded: Bool = false,
+        startedAt: Date,
+        finishedAt: Date? = nil
+    ) throws -> Int64 {
+        try queue.write { db -> Int64 in
+            try db.execute(
+                sql: """
+                    INSERT INTO transcription_sessions
+                        (backendId, title, overview, deleted, discarded, startedAt, finishedAt, updatedAt)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                arguments: [
+                    backendId, title, overview, deleted, discarded,
+                    startedAt, finishedAt, Date(),
+                ]
+            )
+            return db.lastInsertedRowID
+        }
+    }
+
+    @discardableResult
+    private func insertSegment(
+        _ queue: DatabaseQueue,
+        sessionId: Int64,
+        text: String,
+        order: Int = 0,
+        startTime: Double = 0
+    ) throws -> Int64 {
+        try queue.write { db -> Int64 in
+            try db.execute(
+                sql: """
+                    INSERT INTO transcription_segments
+                        (sessionId, text, segmentOrder, startTime)
+                    VALUES (?, ?, ?, ?)
+                    """,
+                arguments: [sessionId, text, order, startTime]
+            )
+            return db.lastInsertedRowID
+        }
+    }
+
+    // MARK: - Issue #138 — date-filter window
+
+    /// Mirrors the production `getLocalConversations` date predicate:
+    /// `startedAt >= startDate AND startedAt < endDate`. Half-open window.
+    private func fetchInDateWindow(
+        _ queue: DatabaseQueue,
+        startDate: Date?,
+        endDate: Date?
+    ) throws -> Set<Int64> {
+        try queue.read { db in
+            var sql = "SELECT id FROM transcription_sessions WHERE deleted = 0 AND discarded = 0"
+            var args: [DatabaseValueConvertible?] = []
+            if let s = startDate {
+                sql += " AND startedAt >= ?"
+                args.append(s)
+            }
+            if let e = endDate {
+                sql += " AND startedAt < ?"
+                args.append(e)
+            }
+            sql += " ORDER BY startedAt DESC"
+            let ids = try Int64.fetchAll(db, sql: sql, arguments: StatementArguments(args))
+            return Set(ids)
+        }
+    }
+
+    /// A date filter for "today" must return only today's session even when
+    /// other sessions exist in the store. This is the exact scenario from
+    /// issue #138 — picking a date in the chip before the fix returned the
+    /// most-recent N rows ignoring the date entirely.
+    func testDateFilter_OnlyReturnsRowsInWindow() throws {
+        let queue = try makeQueue()
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date())
+        let yesterday = calendar.date(byAdding: .day, value: -1, to: today)!
+        let twoDaysAgo = calendar.date(byAdding: .day, value: -2, to: today)!
+
+        let todayId = try insertSession(queue, startedAt: today.addingTimeInterval(3600))
+        _ = try insertSession(queue, startedAt: yesterday.addingTimeInterval(3600))
+        _ = try insertSession(queue, startedAt: twoDaysAgo.addingTimeInterval(3600))
+
+        let endOfToday = calendar.date(byAdding: .day, value: 1, to: today)!
+        let ids = try fetchInDateWindow(queue, startDate: today, endDate: endOfToday)
+
+        XCTAssertEqual(ids, [todayId], "date-filter must restrict to the picked day")
+    }
+
+    /// Picking a date with no recordings must yield an empty result, NOT the
+    /// fallback "most recent rows" the pre-fix behavior returned.
+    func testDateFilter_EmptyForDayWithNoRecordings() throws {
+        let queue = try makeQueue()
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date())
+        _ = try insertSession(queue, startedAt: today.addingTimeInterval(3600))
+
+        let twoDaysAgo = calendar.date(byAdding: .day, value: -2, to: today)!
+        let dayAfter = calendar.date(byAdding: .day, value: 1, to: twoDaysAgo)!
+        let ids = try fetchInDateWindow(queue, startDate: twoDaysAgo, endDate: dayAfter)
+
+        XCTAssertTrue(ids.isEmpty, "filter on a day with no rows must yield zero results")
+    }
+
+    /// Nil window means no date filter — every active row surfaces.
+    func testDateFilter_NilWindowReturnsAllActiveRows() throws {
+        let queue = try makeQueue()
+        let now = Date()
+        let a = try insertSession(queue, startedAt: now)
+        let b = try insertSession(queue, startedAt: now.addingTimeInterval(-86_400))
+
+        let ids = try fetchInDateWindow(queue, startDate: nil, endDate: nil)
+
+        XCTAssertEqual(ids, [a, b])
+    }
+
+    // MARK: - Issue #139 — local search
+
+    /// Mirrors the production `searchConversationsLocally` SQL.
+    private func searchLocally(
+        _ queue: DatabaseQueue,
+        query: String,
+        includeDiscarded: Bool = false
+    ) throws -> [Int64] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
+
+        let escaped = trimmed
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "%", with: "\\%")
+            .replacingOccurrences(of: "_", with: "\\_")
+        let pattern = "%\(escaped)%"
+        let discardedClause = includeDiscarded ? "" : "AND s.discarded = 0"
+
+        return try queue.read { db in
+            let sql = """
+                SELECT DISTINCT s.id
+                  FROM transcription_sessions s
+                  LEFT JOIN transcription_segments seg ON seg.sessionId = s.id
+                 WHERE s.deleted = 0
+                   \(discardedClause)
+                   AND (
+                        s.title    LIKE ? ESCAPE '\\'
+                     OR s.overview LIKE ? ESCAPE '\\'
+                     OR seg.text   LIKE ? ESCAPE '\\'
+                   )
+                 ORDER BY s.startedAt DESC
+                """
+            return try Int64.fetchAll(db, sql: sql, arguments: [pattern, pattern, pattern])
+        }
+    }
+
+    /// Search must match a word that lives only inside a segment, not in the
+    /// session's title/overview. This is the exact repro from issue #139.
+    func testSearch_MatchesWordInSegment() throws {
+        let queue = try makeQueue()
+        let now = Date()
+        let target = try insertSession(queue, title: "Catch-up", startedAt: now)
+        try insertSegment(queue, sessionId: target, text: "Discussed mortgage rates today")
+
+        let other = try insertSession(queue, title: "Standup", startedAt: now.addingTimeInterval(-3600))
+        try insertSegment(queue, sessionId: other, text: "Talked about deploys")
+
+        let ids = try searchLocally(queue, query: "mortgage")
+        XCTAssertEqual(ids, [target])
+    }
+
+    /// Search should also match against title and overview directly.
+    func testSearch_MatchesTitleAndOverview() throws {
+        let queue = try makeQueue()
+        let now = Date()
+        let titleHit = try insertSession(queue, title: "Mortgage discussion", startedAt: now)
+        let overviewHit = try insertSession(
+            queue,
+            title: "Q3 plan",
+            overview: "Includes mortgage strategy",
+            startedAt: now.addingTimeInterval(-3600)
+        )
+        let miss = try insertSession(queue, title: "Standup", startedAt: now.addingTimeInterval(-7200))
+        try insertSegment(queue, sessionId: miss, text: "no relevant text")
+
+        let ids = try searchLocally(queue, query: "mortgage")
+        XCTAssertEqual(Set(ids), [titleHit, overviewHit])
+    }
+
+    /// Empty / whitespace queries must short-circuit to no results, never
+    /// "match every row" (which would happen if `%%` were passed to LIKE).
+    func testSearch_EmptyQueryReturnsNothing() throws {
+        let queue = try makeQueue()
+        _ = try insertSession(queue, title: "Catch-up", startedAt: Date())
+
+        XCTAssertTrue(try searchLocally(queue, query: "").isEmpty)
+        XCTAssertTrue(try searchLocally(queue, query: "   ").isEmpty)
+    }
+
+    /// Soft-deleted rows must never appear in search results.
+    func testSearch_IgnoresDeletedRows() throws {
+        let queue = try makeQueue()
+        let now = Date()
+        _ = try insertSession(
+            queue,
+            title: "Mortgage",
+            deleted: true,
+            startedAt: now
+        )
+
+        let ids = try searchLocally(queue, query: "mortgage")
+        XCTAssertTrue(ids.isEmpty)
+    }
+
+    // MARK: - Issue #136 — soft-delete by backendId
+
+    /// `deleteByBackendId` is implemented as a single UPDATE — assert the
+    /// invariant: row stays in the table but `deleted == 1`, and is therefore
+    /// no longer surfaced by the conversation list query.
+    func testDeleteByBackendId_FlipsDeletedFlag() throws {
+        let queue = try makeQueue()
+        let now = Date()
+        let id = try insertSession(queue, backendId: "local-1", startedAt: now)
+
+        try queue.write { db in
+            try db.execute(
+                sql: "UPDATE transcription_sessions SET deleted = 1, updatedAt = ? WHERE backendId = ?",
+                arguments: [Date(), "local-1"]
+            )
+        }
+
+        // Row still exists in the table…
+        let stillExists = try queue.read { db in
+            try Int.fetchOne(
+                db,
+                sql: "SELECT COUNT(*) FROM transcription_sessions WHERE id = ?",
+                arguments: [id]
+            ) ?? 0
+        }
+        XCTAssertEqual(stillExists, 1)
+
+        // …but is filtered out of the active conversation list.
+        let visible = try fetchInDateWindow(queue, startDate: nil, endDate: nil)
+        XCTAssertFalse(visible.contains(id))
+    }
+
+    // MARK: - Issue #140 — local merge
+
+    /// Re-parent semantics: every segment from the source sessions must end
+    /// up pointing at the target sessionId, and the source sessions must be
+    /// soft-deleted. This is the only invariant the production code relies on
+    /// to keep the merged transcript intact and the originals out of the list.
+    func testMerge_ReparentsSegmentsAndSoftDeletesSources() throws {
+        let queue = try makeQueue()
+        let now = Date()
+        let earlier = now.addingTimeInterval(-3600)
+
+        let target = try insertSession(queue, backendId: "local-1", startedAt: earlier)
+        let source = try insertSession(queue, backendId: "local-2", startedAt: now)
+        try insertSegment(queue, sessionId: target, text: "first half")
+        try insertSegment(queue, sessionId: source, text: "second half")
+
+        // Mirror the merge SQL: re-parent then soft-delete the source.
+        try queue.write { db in
+            try db.execute(
+                sql: "UPDATE transcription_segments SET sessionId = ? WHERE sessionId IN (?)",
+                arguments: [target, source]
+            )
+            try db.execute(
+                sql: "UPDATE transcription_sessions SET deleted = 1, updatedAt = ? WHERE id IN (?)",
+                arguments: [Date(), source]
+            )
+        }
+
+        let segCount = try queue.read { db in
+            try Int.fetchOne(
+                db,
+                sql: "SELECT COUNT(*) FROM transcription_segments WHERE sessionId = ?",
+                arguments: [target]
+            ) ?? 0
+        }
+        XCTAssertEqual(segCount, 2, "all segments must re-parent onto target")
+
+        // Source no longer surfaces; target still does.
+        let visible = try fetchInDateWindow(queue, startDate: nil, endDate: nil)
+        XCTAssertEqual(visible, [target])
+    }
+}

--- a/Desktop/Tests/ConversationsClusterRegressionTests.swift
+++ b/Desktop/Tests/ConversationsClusterRegressionTests.swift
@@ -343,4 +343,80 @@ final class ConversationsClusterRegressionTests: XCTestCase {
         let visible = try fetchInDateWindow(queue, startDate: nil, endDate: nil)
         XCTAssertEqual(visible, [target])
     }
+
+    /// Cross-session chronology must be preserved during merge (CodeRabbit
+    /// feedback on PR #147). Prior to the fix, the renumber step ran AFTER
+    /// the re-parent UPDATE, so every segment had `sessionId = targetId` and
+    /// the only remaining ordering signal was per-session `startTime`, which
+    /// resets near zero for each recording. This let later sessions jump
+    /// ahead of earlier ones in the merged transcript.
+    ///
+    /// Regression: capture the ordering keys (session.startedAt, segmentOrder)
+    /// BEFORE the UPDATE and renumber from that pre-captured order.
+    func testMerge_PreservesCrossSessionChronology() throws {
+        let queue = try makeQueue()
+        let now = Date()
+        let earlier = now.addingTimeInterval(-3600)
+
+        let earlySess = try insertSession(queue, backendId: "local-1", startedAt: earlier)
+        let lateSess = try insertSession(queue, backendId: "local-2", startedAt: now)
+        // Each session's segments have intra-session startTime starting near 0.
+        // Without preserving session.startedAt, sorting by segment.startTime
+        // alone would interleave them by startTime, dropping cross-session
+        // chronology.
+        let earlySegA = try insertSegment(queue, sessionId: earlySess, text: "early-A", order: 0, startTime: 0)
+        let earlySegB = try insertSegment(queue, sessionId: earlySess, text: "early-B", order: 1, startTime: 5)
+        let lateSegA = try insertSegment(queue, sessionId: lateSess, text: "late-A", order: 0, startTime: 0)
+        let lateSegB = try insertSegment(queue, sessionId: lateSess, text: "late-B", order: 1, startTime: 5)
+
+        // Mirror production merge: capture ordering keys BEFORE re-parent,
+        // then renumber from that captured order.
+        let allSessionIds: [Int64] = [earlySess, lateSess]
+        let orderedIds: [Int64] = try queue.read { db in
+            try Int64.fetchAll(
+                db,
+                sql: """
+                    SELECT seg.id AS id
+                      FROM transcription_segments seg
+                      JOIN transcription_sessions sess ON sess.id = seg.sessionId
+                     WHERE seg.sessionId IN (?, ?)
+                     ORDER BY sess.startedAt ASC,
+                              seg.segmentOrder ASC,
+                              seg.startTime ASC,
+                              seg.id ASC
+                    """,
+                arguments: StatementArguments(allSessionIds)
+            )
+        }
+        XCTAssertEqual(
+            orderedIds,
+            [earlySegA, earlySegB, lateSegA, lateSegB],
+            "pre-capture must order by session.startedAt then segmentOrder"
+        )
+
+        try queue.write { db in
+            try db.execute(
+                sql: "UPDATE transcription_segments SET sessionId = ? WHERE sessionId IN (?)",
+                arguments: [earlySess, lateSess]
+            )
+            for (idx, sid) in orderedIds.enumerated() {
+                try db.execute(
+                    sql: "UPDATE transcription_segments SET segmentOrder = ? WHERE id = ?",
+                    arguments: [idx, sid]
+                )
+            }
+        }
+
+        let postOrder: [Int64] = try queue.read { db in
+            try Int64.fetchAll(
+                db,
+                sql: "SELECT id FROM transcription_segments ORDER BY segmentOrder ASC"
+            )
+        }
+        XCTAssertEqual(
+            postOrder,
+            [earlySegA, earlySegB, lateSegA, lateSegB],
+            "merged transcript must read earlier session in full before later session"
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- Local-first conversation operations (delete, merge, search, star/rename) now work without backend.
- UI now distinguishes empty list from no-filter-results.
- Date filter chip is wired through to query.

Fixes #136
Fixes #138
Fixes #139
Fixes #140
Fixes #141
Fixes #142

## Per-issue notes
- **#136** — Detail-view trash now calls `TranscriptionStorage.deleteByBackendId` before the (no-op) API call so the soft-deleted row stops resurfacing on reload.
- **#138** — `getLocalConversations` / `getLocalConversationsCount` accept `startDate` / `endDate`; `loadConversations` computes a half-open day window from `selectedDateFilter` once and passes it to both queries. Empty filter result now commits an empty list instead of leaving stale rows on screen.
- **#139** — Local SQLite search via `searchConversationsLocally` (LIKE join over `transcription_sessions.title/overview` + `transcription_segments.text`, with SQL ESCAPE for user input).
- **#140** — `mergeConversationsLocally` re-parents segments / `audio_chunks` / `speaker_embeddings` onto the earliest source, soft-deletes the others, and clears the target metadata so enrichment regenerates a combined summary. All in one GRDB write transaction.
- **#141** — Star and rename callsites in `ConversationRowView` and the detail-view rename now persist to SQLite first; the API mutation is best-effort and `localOnlyMode` is treated as success.
- **#142** — `ConversationListView` now reads filter state from `appState`; when filters are active the empty path renders a "No matching conversations" panel with a clear-filters button instead of the brand-new-user copy.

## Test plan
- [x] `xcrun swift build -c debug --package-path Desktop` — clean
- [x] `xcrun swift test --package-path Desktop` — 490 tests pass (includes 9 new `ConversationsClusterRegressionTests`)
- [x] `cargo test --locked -p infinite-recall-api` — green
- [x] `cargo test --locked -p infinite-recall-api --features activity_test_wiring` — green
- [ ] Manual: delete a conversation, reload, confirm it stays deleted
- [ ] Manual: search returns local matches (title + segment text)
- [ ] Manual: star/rename persists across relaunch
- [ ] Manual: merge two conversations, confirm transcript combines and originals disappear
- [ ] Manual: pick a date with no recordings, confirm "No matching conversations" panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local-first search for faster, offline results.
  * On-device conversation merge capability.
  * Edits (title/star/delete) now persist locally immediately, with background remote sync.

* **Bug Fixes**
  * Prevent stale list rows and ensure counts refresh when date/folder filters change.
  * Improved empty-state: distinguishes empty store vs. no filter matches and offers "Clear filters".

* **Tests**
  * Added regression tests validating local date-windowing, search, soft-delete, and merge behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->