### PR TITLE
fix(rewind): batch fixes for #117 #119 #123 #129

### DIFF
--- a/Desktop/Sources/MainWindow/Components/LiveTranscriptView.swift
+++ b/Desktop/Sources/MainWindow/Components/LiveTranscriptView.swift
@@ -86,7 +86,16 @@ struct HistoricalTranscriptPanel: View {
                 )
             }
         }
-        .task(id: frameTimestamp) { await reload() }
+        .task(id: frameTimestamp) {
+            // Clear previous content before each refetch so a slow query
+            // can't leave stale segments visible (and tappable) while the
+            // user is scrubbing through frames.
+            await MainActor.run {
+                didLoad = false
+                segments = []
+            }
+            await reload()
+        }
     }
 
     private func reload() async {

--- a/Desktop/Sources/MainWindow/Components/LiveTranscriptView.swift
+++ b/Desktop/Sources/MainWindow/Components/LiveTranscriptView.swift
@@ -39,6 +39,75 @@ struct LiveTranscriptPanel: View {
     }
 }
 
+/// Historical transcript panel — renders the words spoken at the moment
+/// `frameTimestamp` was captured. Reads from `transcription_segments` via
+/// `RewindDatabase.transcriptSegments(around:window:)`.
+///
+/// Rewind doc promises: "A transcript area (expandable) showing what was
+/// being said at the moment the current frame was captured." The Live
+/// panel cannot do this — it always shows the in-progress capture. This
+/// panel is the historical counterpart used when the user scrolls back
+/// to a frame that no longer corresponds to the live recording. (#123)
+struct HistoricalTranscriptPanel: View {
+    let frameTimestamp: Date
+    var window: TimeInterval = 5
+    var speakerNames: [Int: String] = [:]
+    var onSpeakerTapped: ((SpeakerSegment) -> Void)? = nil
+
+    @State private var segments: [SpeakerSegment] = []
+    @State private var didLoad = false
+
+    var body: some View {
+        Group {
+            if !didLoad {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if segments.isEmpty {
+                VStack(spacing: 16) {
+                    Image(systemName: "text.bubble")
+                        .scaledFont(size: 48)
+                        .foregroundColor(OmiColors.textTertiary)
+                        .opacity(0.5)
+                    Text("No transcript for this moment")
+                        .scaledFont(size: 16, weight: .medium)
+                        .foregroundColor(OmiColors.textSecondary)
+                    Text("Nothing was being recorded when this frame was captured.")
+                        .scaledFont(size: 13)
+                        .foregroundColor(OmiColors.textTertiary)
+                        .multilineTextAlignment(.center)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .padding(32)
+            } else {
+                LiveTranscriptView(
+                    segments: segments,
+                    speakerNames: speakerNames,
+                    onSpeakerTapped: onSpeakerTapped
+                )
+            }
+        }
+        .task(id: frameTimestamp) { await reload() }
+    }
+
+    private func reload() async {
+        do {
+            let fetched = try await RewindDatabase.shared.transcriptSegments(
+                around: frameTimestamp,
+                window: window
+            )
+            await MainActor.run {
+                segments = fetched
+                didLoad = true
+            }
+        } catch {
+            await MainActor.run {
+                segments = []
+                didLoad = true
+            }
+        }
+    }
+}
+
 /// Self-contained audio level waveforms that observe AudioLevelMonitor internally,
 /// so the parent view does NOT need to observe audio level changes.
 struct RecordingBarAudioLevels: View {

--- a/Desktop/Sources/Rewind/Core/RewindDatabase.swift
+++ b/Desktop/Sources/Rewind/Core/RewindDatabase.swift
@@ -2680,6 +2680,54 @@ actor RewindDatabase {
             }
         }
 
+        // Migration: full-text-search index over transcription_segments.text so
+        // Rewind search can match phrases that only occur in spoken transcript
+        // (issue #119). External-content FTS5 with triggers keeps storage flat
+        // and stays in sync with `transcription_segments`. The index is
+        // populated on first migration with whatever rows already exist.
+        migrator.registerMigration("createTranscriptionSegmentsFTS") { db in
+            try db.execute(sql: """
+                CREATE VIRTUAL TABLE IF NOT EXISTS transcription_segments_fts USING fts5(
+                    text,
+                    content='transcription_segments',
+                    content_rowid='id',
+                    tokenize='unicode61'
+                )
+                """)
+
+            // Backfill with any segments that already exist.
+            try db.execute(sql: """
+                INSERT INTO transcription_segments_fts(rowid, text)
+                SELECT id, text FROM transcription_segments
+                """)
+
+            try db.execute(sql: """
+                CREATE TRIGGER IF NOT EXISTS transcription_segments_ai
+                AFTER INSERT ON transcription_segments BEGIN
+                    INSERT INTO transcription_segments_fts(rowid, text)
+                    VALUES (new.id, new.text);
+                END
+                """)
+
+            try db.execute(sql: """
+                CREATE TRIGGER IF NOT EXISTS transcription_segments_ad
+                AFTER DELETE ON transcription_segments BEGIN
+                    INSERT INTO transcription_segments_fts(transcription_segments_fts, rowid, text)
+                    VALUES ('delete', old.id, old.text);
+                END
+                """)
+
+            try db.execute(sql: """
+                CREATE TRIGGER IF NOT EXISTS transcription_segments_au
+                AFTER UPDATE ON transcription_segments BEGIN
+                    INSERT INTO transcription_segments_fts(transcription_segments_fts, rowid, text)
+                    VALUES ('delete', old.id, old.text);
+                    INSERT INTO transcription_segments_fts(rowid, text)
+                    VALUES (new.id, new.text);
+                END
+                """)
+        }
+
         try migrator.migrate(queue)
     }
 
@@ -3311,35 +3359,122 @@ actor RewindDatabase {
         }
 
         return try dbQueue.read { db in
-            var sql = """
-                SELECT screenshots.* FROM screenshots
-                JOIN screenshots_fts ON screenshots.id = screenshots_fts.rowid
-                WHERE screenshots_fts MATCH ?
-                """
-            var arguments: [DatabaseValueConvertible] = [expandedQuery]
+            // Issue #119: search is supposed to span OCR/title/app text,
+            // vision-model summaries (visual_activity_fts), and spoken
+            // transcript text (transcription_segments_fts). We collect
+            // matching screenshot ids from each lane, then return the
+            // unioned screenshots ordered by timestamp DESC. BM25 ranking
+            // across heterogeneous FTS tables isn't comparable, so we use
+            // recency as the merge key — same as the existing OCR + vector
+            // merge in `RewindViewModel.performSearch`.
 
-            // App filter (exact match, separate from FTS)
+            // Build the optional filter clause shared by all three lanes.
+            // Lane queries reference `screenshots.<col>` on the joined table.
+            var filterSQL = ""
+            var filterArgs: [DatabaseValueConvertible] = []
             if let app = appFilter {
-                sql += " AND screenshots.appName = ?"
-                arguments.append(app)
+                filterSQL += " AND screenshots.appName = ?"
+                filterArgs.append(app)
             }
-
-            // Time range filtering
             if let start = startDate {
-                sql += " AND screenshots.timestamp >= ?"
-                arguments.append(start)
+                filterSQL += " AND screenshots.timestamp >= ?"
+                filterArgs.append(start)
             }
-
             if let end = endDate {
-                sql += " AND screenshots.timestamp <= ?"
-                arguments.append(end)
+                filterSQL += " AND screenshots.timestamp <= ?"
+                filterArgs.append(end)
             }
 
-            // Order by relevance (BM25) then by timestamp
-            sql += " ORDER BY bm25(screenshots_fts) ASC, screenshots.timestamp DESC LIMIT ?"
-            arguments.append(limit)
+            var matchedIds = Set<Int64>()
 
-            return try Screenshot.fetchAll(db, sql: sql, arguments: StatementArguments(arguments))
+            // Lane 1: OCR / appName / windowTitle (existing behavior).
+            do {
+                var sql = """
+                    SELECT screenshots.id FROM screenshots
+                    JOIN screenshots_fts ON screenshots.id = screenshots_fts.rowid
+                    WHERE screenshots_fts MATCH ?
+                    """
+                sql += filterSQL
+                sql += " LIMIT ?"
+                var args: [DatabaseValueConvertible] = [expandedQuery]
+                args.append(contentsOf: filterArgs)
+                args.append(limit)
+                let ids = try Int64.fetchAll(db, sql: sql, arguments: StatementArguments(args))
+                matchedIds.formUnion(ids)
+            }
+
+            // Lane 2: vision-model summary / uiState / OCR snapshot via
+            // visual_activity_fts. The FTS table has existed since migration
+            // #createVisualActivityFTS but no production search path used it.
+            do {
+                var sql = """
+                    SELECT screenshots.id FROM screenshots
+                    JOIN visual_activity ON visual_activity.screenshotId = screenshots.id
+                    JOIN visual_activity_fts ON visual_activity.id = visual_activity_fts.rowid
+                    WHERE visual_activity_fts MATCH ?
+                    """
+                sql += filterSQL
+                sql += " LIMIT ?"
+                var args: [DatabaseValueConvertible] = [expandedQuery]
+                args.append(contentsOf: filterArgs)
+                args.append(limit)
+                let ids = try Int64.fetchAll(db, sql: sql, arguments: StatementArguments(args))
+                matchedIds.formUnion(ids)
+            }
+
+            // Lane 3: spoken transcript via transcription_segments_fts. Each
+            // matching segment maps to an absolute time window
+            // [session.startedAt + segment.startTime, session.startedAt + segment.endTime];
+            // we surface every screenshot whose timestamp falls inside that
+            // window (with a small ±1s pad so frames captured near the
+            // boundary still match). `unixepoch(s.startedAt)` is used so the
+            // arithmetic works regardless of how GRDB stores the column.
+            do {
+                let pad = 1.0
+                var sql = """
+                    SELECT screenshots.id FROM screenshots
+                    JOIN transcription_segments seg
+                      ON unixepoch(screenshots.timestamp)
+                         BETWEEN unixepoch(
+                             (SELECT s.startedAt FROM transcription_sessions s WHERE s.id = seg.sessionId)
+                         ) + seg.startTime - ?
+                         AND unixepoch(
+                             (SELECT s.startedAt FROM transcription_sessions s WHERE s.id = seg.sessionId)
+                         ) + seg.endTime + ?
+                    JOIN transcription_segments_fts ON seg.id = transcription_segments_fts.rowid
+                    WHERE transcription_segments_fts MATCH ?
+                    """
+                sql += filterSQL
+                sql += " LIMIT ?"
+                var args: [DatabaseValueConvertible] = [pad, pad, expandedQuery]
+                args.append(contentsOf: filterArgs)
+                args.append(limit)
+                // Transcript FTS is best-effort: a missing/old DB without the
+                // table or a bad MATCH expression should not poison the
+                // OCR + visual lanes.
+                if let ids = try? Int64.fetchAll(db, sql: sql, arguments: StatementArguments(args)) {
+                    matchedIds.formUnion(ids)
+                }
+            }
+
+            guard !matchedIds.isEmpty else { return [] }
+
+            // Resolve to Screenshot rows ordered by recency, capped at `limit`.
+            let idList = Array(matchedIds)
+            let placeholders = Array(repeating: "?", count: idList.count).joined(separator: ",")
+            var resolveArgs: [DatabaseValueConvertible] = idList
+            resolveArgs.append(limit)
+            let resolveSQL = """
+                SELECT * FROM screenshots
+                WHERE id IN (\(placeholders))
+                ORDER BY timestamp DESC
+                LIMIT ?
+                """
+            return try Screenshot.fetchAll(
+                db,
+                sql: resolveSQL,
+                arguments: StatementArguments(resolveArgs)
+            )
         }
     }
 

--- a/Desktop/Sources/Rewind/Core/RewindDatabase.swift
+++ b/Desktop/Sources/Rewind/Core/RewindDatabase.swift
@@ -2695,9 +2695,11 @@ actor RewindDatabase {
                 )
                 """)
 
-            // Backfill with any segments that already exist.
+            // Backfill with any segments that already exist. INSERT OR IGNORE
+            // keeps the migration idempotent if a partial backfill ever ran
+            // (e.g. via manual intervention or a future migration replay).
             try db.execute(sql: """
-                INSERT INTO transcription_segments_fts(rowid, text)
+                INSERT OR IGNORE INTO transcription_segments_fts(rowid, text)
                 SELECT id, text FROM transcription_segments
                 """)
 
@@ -3388,6 +3390,9 @@ actor RewindDatabase {
             var matchedIds = Set<Int64>()
 
             // Lane 1: OCR / appName / windowTitle (existing behavior).
+            // ORDER BY timestamp DESC ensures that when the lane has more
+            // than `limit` matches, we keep the newest ones — recency is
+            // the merge key for the final union.
             do {
                 var sql = """
                     SELECT screenshots.id FROM screenshots
@@ -3395,7 +3400,7 @@ actor RewindDatabase {
                     WHERE screenshots_fts MATCH ?
                     """
                 sql += filterSQL
-                sql += " LIMIT ?"
+                sql += " ORDER BY screenshots.timestamp DESC LIMIT ?"
                 var args: [DatabaseValueConvertible] = [expandedQuery]
                 args.append(contentsOf: filterArgs)
                 args.append(limit)
@@ -3414,7 +3419,7 @@ actor RewindDatabase {
                     WHERE visual_activity_fts MATCH ?
                     """
                 sql += filterSQL
-                sql += " LIMIT ?"
+                sql += " ORDER BY screenshots.timestamp DESC LIMIT ?"
                 var args: [DatabaseValueConvertible] = [expandedQuery]
                 args.append(contentsOf: filterArgs)
                 args.append(limit)
@@ -3427,25 +3432,33 @@ actor RewindDatabase {
             // [session.startedAt + segment.startTime, session.startedAt + segment.endTime];
             // we surface every screenshot whose timestamp falls inside that
             // window (with a small ±1s pad so frames captured near the
-            // boundary still match). `unixepoch(s.startedAt)` is used so the
-            // arithmetic works regardless of how GRDB stores the column.
+            // boundary still match). The session is joined directly (no
+            // correlated subquery), and the date arithmetic is moved to the
+            // RHS via `datetime(..., 'unixepoch')` so SQLite can still use
+            // the index on `screenshots.timestamp`.
             do {
                 let pad = 1.0
+                // Join transcription_sessions / transcription_segments by their
+                // FK; the screenshots table is joined-by-time via the BETWEEN
+                // clause. The date-arithmetic has been moved to the right-hand
+                // side via `datetime(..., 'unixepoch')` so SQLite can use the
+                // `screenshots.timestamp` index instead of full-scanning.
+                //
+                // NOTE: the FTS5 table is referenced unaliased — FTS5 expects
+                // the MATCH operator's LHS to name the virtual table itself,
+                // not a SELECT-alias.
                 var sql = """
-                    SELECT screenshots.id FROM screenshots
-                    JOIN transcription_segments seg
-                      ON unixepoch(screenshots.timestamp)
-                         BETWEEN unixepoch(
-                             (SELECT s.startedAt FROM transcription_sessions s WHERE s.id = seg.sessionId)
-                         ) + seg.startTime - ?
-                         AND unixepoch(
-                             (SELECT s.startedAt FROM transcription_sessions s WHERE s.id = seg.sessionId)
-                         ) + seg.endTime + ?
-                    JOIN transcription_segments_fts ON seg.id = transcription_segments_fts.rowid
+                    SELECT screenshots.id FROM transcription_segments_fts
+                    JOIN transcription_segments seg ON seg.id = transcription_segments_fts.rowid
+                    JOIN transcription_sessions s ON s.id = seg.sessionId
+                    JOIN screenshots
+                      ON screenshots.timestamp BETWEEN
+                          datetime(unixepoch(s.startedAt) + seg.startTime - ?, 'unixepoch')
+                          AND datetime(unixepoch(s.startedAt) + seg.endTime + ?, 'unixepoch')
                     WHERE transcription_segments_fts MATCH ?
                     """
                 sql += filterSQL
-                sql += " LIMIT ?"
+                sql += " ORDER BY screenshots.timestamp DESC LIMIT ?"
                 var args: [DatabaseValueConvertible] = [pad, pad, expandedQuery]
                 args.append(contentsOf: filterArgs)
                 args.append(limit)

--- a/Desktop/Sources/Rewind/Core/RewindDatabase.swift
+++ b/Desktop/Sources/Rewind/Core/RewindDatabase.swift
@@ -3478,6 +3478,54 @@ actor RewindDatabase {
         }
     }
 
+    // MARK: - Per-Frame Transcript Context (issue #123)
+
+    /// Fetch transcript segments whose absolute time window
+    /// `[session.startedAt + startTime, session.startedAt + endTime]`
+    /// overlaps `[timestamp - window, timestamp + window]`.
+    ///
+    /// Returns segments shaped as `SpeakerSegment` so the existing
+    /// `LiveTranscriptView` UI can render them directly. `start`/`end`
+    /// in the returned segments are kept as relative-to-session seconds
+    /// (matching what the live monitor produces) so the time labels keep
+    /// the same MM:SS format the user sees during live recording.
+    func transcriptSegments(
+        around timestamp: Date,
+        window: TimeInterval = 5
+    ) throws -> [SpeakerSegment] {
+        guard let dbQueue = dbQueue else {
+            throw RewindError.databaseNotInitialized
+        }
+
+        return try dbQueue.read { db in
+            let sql = """
+                SELECT seg.segmentId, seg.speaker, seg.text, seg.startTime,
+                       seg.endTime, seg.isUser, seg.personId
+                FROM transcription_segments seg
+                JOIN transcription_sessions s ON s.id = seg.sessionId
+                WHERE unixepoch(s.startedAt) + seg.endTime   >= unixepoch(?) - ?
+                  AND unixepoch(s.startedAt) + seg.startTime <= unixepoch(?) + ?
+                ORDER BY s.startedAt ASC, seg.segmentOrder ASC
+                """
+            let rows = try Row.fetchAll(
+                db,
+                sql: sql,
+                arguments: [timestamp, window, timestamp, window]
+            )
+            return rows.map { row in
+                SpeakerSegment(
+                    segmentId: row["segmentId"],
+                    speaker: row["speaker"] ?? 0,
+                    text: row["text"] ?? "",
+                    start: row["startTime"] ?? 0,
+                    end: row["endTime"] ?? 0,
+                    isUser: row["isUser"] ?? false,
+                    personId: row["personId"]
+                )
+            }
+        }
+    }
+
     // MARK: - Delete Result Types
 
     /// Result of bulk screenshot deletion (for cleanup)

--- a/Desktop/Sources/Rewind/Core/RewindStorage.swift
+++ b/Desktop/Sources/Rewind/Core/RewindStorage.swift
@@ -534,7 +534,9 @@ actor RewindStorage {
 
         var chunks: [VideoChunkInfo] = []
 
-        // Enumerate all .hevc files in videos directory (including subdirectories)
+        // Enumerate all chunk files in videos directory (including subdirectories).
+        // VideoChunkEncoder writes fragmented MP4 (.mp4) — historical builds may
+        // have shipped .hevc, so accept both for robustness across upgrades.
         let enumerator = fileManager.enumerator(
             at: videosDirectory,
             includingPropertiesForKeys: [.isRegularFileKey, .creationDateKey],
@@ -542,7 +544,8 @@ actor RewindStorage {
         )
 
         while let fileURL = enumerator?.nextObject() as? URL {
-            guard fileURL.pathExtension == "hevc" else { continue }
+            let ext = fileURL.pathExtension.lowercased()
+            guard ext == "mp4" || ext == "hevc" else { continue }
 
             // Get relative path from videos directory
             let relativePath = fileURL.path.replacingOccurrences(of: videosDirectory.path + "/", with: "")

--- a/Desktop/Sources/Rewind/Services/RewindIndexer.swift
+++ b/Desktop/Sources/Rewind/Services/RewindIndexer.swift
@@ -747,6 +747,20 @@ actor RewindIndexer {
         return frames
     }
 
+    /// Cached DateFormatter for `parseChunkTimestamp`. `DateFormatter` is
+    /// expensive to construct, and rebuild loops over every on-disk chunk,
+    /// so we keep one instance pinned to a fixed POSIX locale to avoid
+    /// user-locale calendar drift on a fixed-format input. `nonisolated(unsafe)`
+    /// is safe here: `DateFormatter` is documented as thread-safe for
+    /// reads on macOS 10.9+, and we only ever read `.date(from:)` after
+    /// configuring it once at file-scope initialization.
+    nonisolated(unsafe) private static let chunkTimestampFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HHmmss"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        return formatter
+    }()
+
     /// Parse timestamp from chunk filename + parent day directory.
     ///
     /// Authoritative on-disk layout (see `VideoChunkEncoder.generateChunkPath`):
@@ -778,12 +792,7 @@ actor RewindIndexer {
         guard ext == "mp4" || ext == "hevc" else { return nil }
         guard timeStr.count == 6, timeStr.allSatisfy({ $0.isNumber }) else { return nil }
 
-        let formatter = DateFormatter()
-        // Match the encoder's formatter (no timezone/locale overrides — interprets
-        // wall-clock components in the device's current calendar/timezone, which
-        // is what the encoder used when it wrote the path).
-        formatter.dateFormat = "yyyy-MM-dd HHmmss"
-        return formatter.date(from: "\(yyyy)-\(mm)-\(dd) \(timeStr)")
+        return chunkTimestampFormatter.date(from: "\(yyyy)-\(mm)-\(dd) \(timeStr)")
     }
 
     /// Get frame count from video file using AVFoundation

--- a/Desktop/Sources/Rewind/Services/RewindIndexer.swift
+++ b/Desktop/Sources/Rewind/Services/RewindIndexer.swift
@@ -715,9 +715,17 @@ actor RewindIndexer {
 
     /// Extract frame metadata from a video chunk
     private func extractFramesFromChunk(_ chunkInfo: VideoChunkInfo) async throws -> [FrameMetadata] {
-        // Parse the chunk filename to extract timestamp info
-        // Format: chunk_YYYYMMDD_HHMMSS.hevc
-        guard let timestamp = parseChunkTimestamp(chunkInfo.filename) else {
+        // Parse the chunk filename + parent day directory to extract timestamp.
+        // Encoder writes chunks at: <videosDir>/YYYY-MM-DD/chunk_HHmmss.mp4
+        // (See VideoChunkEncoder.generateChunkPath.) The parent directory of
+        // the chunk file carries the date; the filename carries the time.
+        let dayDirectory = chunkInfo.fullPath
+            .deletingLastPathComponent()
+            .lastPathComponent
+        guard let timestamp = Self.parseChunkTimestamp(
+            filename: chunkInfo.filename,
+            dayDirectory: dayDirectory
+        ) else {
             return []
         }
 
@@ -739,28 +747,43 @@ actor RewindIndexer {
         return frames
     }
 
-    /// Parse timestamp from chunk filename
-    private func parseChunkTimestamp(_ filename: String) -> Date? {
-        // Expected format: chunk_YYYYMMDD_HHMMSS.hevc
-        guard filename.hasPrefix("chunk_"),
-              filename.hasSuffix(".hevc"),
-              filename.count == 26 else { return nil }  // "chunk_" (6) + 8 + "_" (1) + 6 + ".hevc" (5) = 26
+    /// Parse timestamp from chunk filename + parent day directory.
+    ///
+    /// Authoritative on-disk layout (see `VideoChunkEncoder.generateChunkPath`):
+    ///   <videosDirectory>/YYYY-MM-DD/chunk_HHmmss.mp4
+    ///
+    /// The date comes from the parent directory ("2026-05-04"); the time
+    /// comes from the filename ("chunk_153012.mp4"). A historical `.hevc`
+    /// extension is accepted so a rebuild of older installs still works.
+    ///
+    /// Internal so unit tests can drive it directly.
+    static func parseChunkTimestamp(filename: String, dayDirectory: String) -> Date? {
+        // Day directory: "YYYY-MM-DD" (10 chars, two dashes).
+        guard dayDirectory.count == 10 else { return nil }
+        let dateChars = Array(dayDirectory)
+        guard dateChars[4] == "-", dateChars[7] == "-" else { return nil }
+        let yyyy = String(dateChars[0..<4])
+        let mm = String(dateChars[5..<7])
+        let dd = String(dateChars[8..<10])
+        guard yyyy.allSatisfy({ $0.isNumber }),
+              mm.allSatisfy({ $0.isNumber }),
+              dd.allSatisfy({ $0.isNumber }) else { return nil }
 
-        let startIndex = filename.index(filename.startIndex, offsetBy: 6)
-        let dateEndIndex = filename.index(startIndex, offsetBy: 8)
-        let timeStartIndex = filename.index(dateEndIndex, offsetBy: 1)
-        let timeEndIndex = filename.index(timeStartIndex, offsetBy: 6)
-
-        let dateStr = String(filename[startIndex..<dateEndIndex])
-        let timeStr = String(filename[timeStartIndex..<timeEndIndex])
-
-        // Validate that both parts are numeric
-        guard dateStr.allSatisfy({ $0.isNumber }),
-              timeStr.allSatisfy({ $0.isNumber }) else { return nil }
+        // Filename: "chunk_HHmmss.<ext>" — accept .mp4 (current) or .hevc (legacy).
+        guard filename.hasPrefix("chunk_") else { return nil }
+        let nameNoPrefix = filename.dropFirst("chunk_".count)
+        guard let dotIndex = nameNoPrefix.firstIndex(of: ".") else { return nil }
+        let timeStr = String(nameNoPrefix[..<dotIndex])
+        let ext = String(nameNoPrefix[nameNoPrefix.index(after: dotIndex)...]).lowercased()
+        guard ext == "mp4" || ext == "hevc" else { return nil }
+        guard timeStr.count == 6, timeStr.allSatisfy({ $0.isNumber }) else { return nil }
 
         let formatter = DateFormatter()
-        formatter.dateFormat = "yyyyMMddHHmmss"
-        return formatter.date(from: dateStr + timeStr)
+        // Match the encoder's formatter (no timezone/locale overrides — interprets
+        // wall-clock components in the device's current calendar/timezone, which
+        // is what the encoder used when it wrote the path).
+        formatter.dateFormat = "yyyy-MM-dd HHmmss"
+        return formatter.date(from: "\(yyyy)-\(mm)-\(dd) \(timeStr)")
     }
 
     /// Get frame count from video file using AVFoundation

--- a/Desktop/Sources/Rewind/UI/RewindPage.swift
+++ b/Desktop/Sources/Rewind/UI/RewindPage.swift
@@ -84,6 +84,23 @@ struct RewindPage: View {
         return names
     }
 
+    /// Timestamp to feed to `HistoricalTranscriptPanel` when the user is
+    /// browsing a frame whose moment-in-time has already passed. Returns
+    /// `nil` to mean "show the live panel": no frame selected, OR the
+    /// selected frame is the most-recent loaded frame AND audio capture
+    /// is currently active (so the live panel is the right surface for
+    /// what's being said right now). See issue #123 for the doc promise
+    /// this implements.
+    private var historicalTranscriptTimestamp: Date? {
+        guard let selected = viewModel.selectedScreenshot else { return nil }
+        let isLiveCapturing = appState?.isTranscribing == true
+        let isLatestLoaded = viewModel.screenshots.first?.id == selected.id
+        if isLiveCapturing && isLatestLoaded {
+            return nil
+        }
+        return selected.timestamp
+    }
+
     var body: some View {
         ZStack {
             // Background
@@ -1201,14 +1218,32 @@ struct RewindPage: View {
                 let notesWidth = max(minPanelWidth, totalWidth - transcriptWidth - 1)
 
                 HStack(spacing: 0) {
-                    // Left: Live transcript
+                    // Left: Transcript pane.
+                    //
+                    // Issue #123: when the user is looking at a historical
+                    // frame, surface the words spoken at that frame's
+                    // timestamp (RewindDatabase.transcriptSegments). Fall
+                    // back to the Live panel only when the user is on the
+                    // newest frame and audio capture is currently active —
+                    // matches the doc promise that the transcript area
+                    // tracks the "current frame".
                     VStack(spacing: 0) {
-                        LiveTranscriptPanel(
-                            speakerNames: speakerNames,
-                            onSpeakerTapped: { segment in
-                                selectedSpeakerSegment = segment
-                            }
-                        )
+                        if let frameTimestamp = historicalTranscriptTimestamp {
+                            HistoricalTranscriptPanel(
+                                frameTimestamp: frameTimestamp,
+                                speakerNames: speakerNames,
+                                onSpeakerTapped: { segment in
+                                    selectedSpeakerSegment = segment
+                                }
+                            )
+                        } else {
+                            LiveTranscriptPanel(
+                                speakerNames: speakerNames,
+                                onSpeakerTapped: { segment in
+                                    selectedSpeakerSegment = segment
+                                }
+                            )
+                        }
                     }
                     .frame(width: transcriptWidth)
                     .background(OmiColors.backgroundPrimary)

--- a/Desktop/Sources/Rewind/UI/RewindPage.swift
+++ b/Desktop/Sources/Rewind/UI/RewindPage.swift
@@ -94,8 +94,14 @@ struct RewindPage: View {
     private var historicalTranscriptTimestamp: Date? {
         guard let selected = viewModel.selectedScreenshot else { return nil }
         let isLiveCapturing = appState?.isTranscribing == true
-        let isLatestLoaded = viewModel.screenshots.first?.id == selected.id
-        if isLiveCapturing && isLatestLoaded {
+        // `getScreenshotsSampled` returns rows in ascending order, so the
+        // newest loaded frame is `.last`, not `.first`. Combine with an
+        // isToday check so the newest frame on a *previous* day (still
+        // historical) doesn't get mistaken for the live frame whenever
+        // capture happens to be active.
+        let isLatestLoaded = viewModel.screenshots.last?.id == selected.id
+        let isToday = Calendar.current.isDateInToday(selected.timestamp)
+        if isLiveCapturing && isToday && isLatestLoaded {
             return nil
         }
         return selected.timestamp

--- a/Desktop/Tests/RewindChunkTimestampParseTests.swift
+++ b/Desktop/Tests/RewindChunkTimestampParseTests.swift
@@ -1,0 +1,127 @@
+import XCTest
+@testable import Omi_Computer
+
+/// Regression tests for #117 / #129.
+///
+/// `VideoChunkEncoder.generateChunkPath` writes chunks as
+/// `<videosDir>/YYYY-MM-DD/chunk_HHmmss.mp4`. The rebuild path
+/// (`RewindIndexer.rebuildFromVideoFiles` →
+/// `RewindStorage.getAllVideoChunks` → `extractFramesFromChunk`) used to
+/// expect `chunk_YYYYMMDD_HHMMSS.hevc` (a format that never shipped) and
+/// silently skipped every real chunk. These tests pin the parser to the
+/// encoder's actual output so that drift breaks the build, not the rebuild.
+final class RewindChunkTimestampParseTests: XCTestCase {
+
+    // MARK: - Happy path: encoder format
+
+    func testParsesEncoderProducedFilename() {
+        // Encoder format: yyyy-MM-dd / chunk_HHmmss.mp4
+        let date = RewindIndexer.parseChunkTimestamp(
+            filename: "chunk_153012.mp4",
+            dayDirectory: "2026-05-04"
+        )
+        XCTAssertNotNil(date, "Encoder-format chunk path must parse")
+
+        let comps = Calendar.current.dateComponents(
+            [.year, .month, .day, .hour, .minute, .second],
+            from: try! XCTUnwrap(date)
+        )
+        XCTAssertEqual(comps.year, 2026)
+        XCTAssertEqual(comps.month, 5)
+        XCTAssertEqual(comps.day, 4)
+        XCTAssertEqual(comps.hour, 15)
+        XCTAssertEqual(comps.minute, 30)
+        XCTAssertEqual(comps.second, 12)
+    }
+
+    func testParsesLegacyHEVCExtension() {
+        // Older installs may have .hevc on disk — rebuild should still recover them.
+        XCTAssertNotNil(RewindIndexer.parseChunkTimestamp(
+            filename: "chunk_000000.hevc",
+            dayDirectory: "2024-01-01"
+        ))
+    }
+
+    func testParsesMidnight() {
+        XCTAssertNotNil(RewindIndexer.parseChunkTimestamp(
+            filename: "chunk_000000.mp4",
+            dayDirectory: "2026-12-31"
+        ))
+    }
+
+    // MARK: - Rejection cases
+
+    func testRejectsLegacyHypotheticalFormat() {
+        // The format the old parser was looking for never shipped. Make sure
+        // the new parser doesn't accidentally re-introduce support for it.
+        XCTAssertNil(RewindIndexer.parseChunkTimestamp(
+            filename: "chunk_20260504_153012.hevc",
+            dayDirectory: "2026-05-04"
+        ))
+    }
+
+    func testRejectsMissingPrefix() {
+        XCTAssertNil(RewindIndexer.parseChunkTimestamp(
+            filename: "153012.mp4",
+            dayDirectory: "2026-05-04"
+        ))
+    }
+
+    func testRejectsBadExtension() {
+        XCTAssertNil(RewindIndexer.parseChunkTimestamp(
+            filename: "chunk_153012.txt",
+            dayDirectory: "2026-05-04"
+        ))
+    }
+
+    func testRejectsNonNumericTime() {
+        XCTAssertNil(RewindIndexer.parseChunkTimestamp(
+            filename: "chunk_abcdef.mp4",
+            dayDirectory: "2026-05-04"
+        ))
+    }
+
+    func testRejectsMalformedDayDirectory() {
+        // Wrong length / missing dashes.
+        XCTAssertNil(RewindIndexer.parseChunkTimestamp(
+            filename: "chunk_153012.mp4",
+            dayDirectory: "20260504"
+        ))
+        XCTAssertNil(RewindIndexer.parseChunkTimestamp(
+            filename: "chunk_153012.mp4",
+            dayDirectory: "2026/05/04"
+        ))
+    }
+
+    func testRejectsShortTime() {
+        XCTAssertNil(RewindIndexer.parseChunkTimestamp(
+            filename: "chunk_15301.mp4",
+            dayDirectory: "2026-05-04"
+        ))
+    }
+
+    // MARK: - Round-trip with the encoder's path generator
+
+    /// If the encoder ever changes its filename scheme, this test will fail
+    /// loudly instead of silently swallowing all chunks during rebuild.
+    func testRoundTripWithEncoderFormatter() {
+        // Mirror VideoChunkEncoder.generateChunkPath exactly.
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let dayFormatter = DateFormatter()
+        dayFormatter.dateFormat = "yyyy-MM-dd"
+        let timeFormatter = DateFormatter()
+        timeFormatter.dateFormat = "HHmmss"
+
+        let dayDirectory = dayFormatter.string(from: now)
+        let filename = "chunk_\(timeFormatter.string(from: now)).mp4"
+
+        let parsed = RewindIndexer.parseChunkTimestamp(
+            filename: filename,
+            dayDirectory: dayDirectory
+        )
+        XCTAssertNotNil(
+            parsed,
+            "Round-trip from VideoChunkEncoder's path format must parse — \(dayDirectory)/\(filename)"
+        )
+    }
+}

--- a/Desktop/Tests/RewindHistoricalTranscriptTests.swift
+++ b/Desktop/Tests/RewindHistoricalTranscriptTests.swift
@@ -1,0 +1,138 @@
+import GRDB
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression tests for #123 — historical frames must surface the
+/// transcript that was being recorded at their timestamp. Pre-fix, the
+/// expanded transcript area always showed the live monitor and never
+/// loaded by-timestamp segments.
+final class RewindHistoricalTranscriptTests: XCTestCase {
+    private var testUserId = ""
+
+    override func setUp() async throws {
+        try await super.setUp()
+        testUserId = "test-historical-transcript-\(UUID().uuidString)"
+        await RewindDatabase.shared.configure(userId: testUserId)
+        try await RewindDatabase.shared.initialize()
+    }
+
+    override func tearDown() async throws {
+        await RewindDatabase.shared.close()
+        try await super.tearDown()
+    }
+
+    func testReturnsSegmentsOverlappingFrameTimestamp() async throws {
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+            throw XCTSkip("database queue unavailable")
+        }
+
+        // Session begins at t=0. Three segments cover 0..5, 6..10, 12..15.
+        // A frame at sessionStart + 8 should match only the middle segment
+        // when window is small (1s).
+        let sessionStart = Date(timeIntervalSince1970: 1_700_000_000)
+        let sessionId = try await insertSession(dbQueue: dbQueue, startedAt: sessionStart)
+        try await insertSegment(
+            dbQueue: dbQueue, sessionId: sessionId, order: 0,
+            text: "first", startTime: 0, endTime: 5
+        )
+        try await insertSegment(
+            dbQueue: dbQueue, sessionId: sessionId, order: 1,
+            text: "middle", startTime: 6, endTime: 10
+        )
+        try await insertSegment(
+            dbQueue: dbQueue, sessionId: sessionId, order: 2,
+            text: "third", startTime: 12, endTime: 15
+        )
+
+        let segments = try await RewindDatabase.shared.transcriptSegments(
+            around: sessionStart.addingTimeInterval(8),
+            window: 1
+        )
+        XCTAssertEqual(segments.map(\.text), ["middle"])
+    }
+
+    func testReturnsAdjacentSegmentsWithinWindow() async throws {
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+            throw XCTSkip("database queue unavailable")
+        }
+
+        let sessionStart = Date(timeIntervalSince1970: 1_700_001_000)
+        let sessionId = try await insertSession(dbQueue: dbQueue, startedAt: sessionStart)
+        try await insertSegment(
+            dbQueue: dbQueue, sessionId: sessionId, order: 0,
+            text: "before", startTime: 0, endTime: 5
+        )
+        try await insertSegment(
+            dbQueue: dbQueue, sessionId: sessionId, order: 1,
+            text: "after", startTime: 12, endTime: 18
+        )
+
+        // Frame at t=8: with window=10 both segments overlap.
+        let segments = try await RewindDatabase.shared.transcriptSegments(
+            around: sessionStart.addingTimeInterval(8),
+            window: 10
+        )
+        XCTAssertEqual(Set(segments.map(\.text)), Set(["before", "after"]))
+    }
+
+    func testEmptyWhenNoOverlap() async throws {
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+            throw XCTSkip("database queue unavailable")
+        }
+
+        let sessionStart = Date(timeIntervalSince1970: 1_700_002_000)
+        let sessionId = try await insertSession(dbQueue: dbQueue, startedAt: sessionStart)
+        try await insertSegment(
+            dbQueue: dbQueue, sessionId: sessionId, order: 0,
+            text: "lonely", startTime: 0, endTime: 5
+        )
+
+        // Frame far outside any segment.
+        let segments = try await RewindDatabase.shared.transcriptSegments(
+            around: sessionStart.addingTimeInterval(60 * 60),
+            window: 5
+        )
+        XCTAssertEqual(segments.count, 0)
+    }
+
+    // MARK: - Helpers
+
+    private func insertSession(dbQueue: DatabasePool, startedAt: Date) async throws -> Int64 {
+        try await dbQueue.write { db -> Int64 in
+            try db.execute(
+                sql: """
+                    INSERT INTO transcription_sessions(
+                        startedAt, source, language, timezone, status, retryCount,
+                        backendSynced, createdAt, updatedAt, summary_state
+                    )
+                    VALUES (?, 'desktop', 'en', 'UTC', 'recording', 0, 0, ?, ?, 'pending')
+                    """,
+                arguments: [startedAt, startedAt, startedAt]
+            )
+            return db.lastInsertedRowID
+        }
+    }
+
+    private func insertSegment(
+        dbQueue: DatabasePool,
+        sessionId: Int64,
+        order: Int,
+        text: String,
+        startTime: Double,
+        endTime: Double
+    ) async throws {
+        try await dbQueue.write { db in
+            try db.execute(
+                sql: """
+                    INSERT INTO transcription_segments(
+                        sessionId, speaker, text, startTime, endTime,
+                        segmentOrder, createdAt
+                    )
+                    VALUES (?, 0, ?, ?, ?, ?, ?)
+                    """,
+                arguments: [sessionId, text, startTime, endTime, order, Date()]
+            )
+        }
+    }
+}

--- a/Desktop/Tests/RewindSearchMultiLaneTests.swift
+++ b/Desktop/Tests/RewindSearchMultiLaneTests.swift
@@ -24,33 +24,44 @@ final class RewindSearchMultiLaneTests: XCTestCase {
     }
 
     func testSearchMatchesViaOCRTextLane() async throws {
-        let now = Date()
-        let id = try await RewindDatabase.shared.insertScreenshot(Screenshot(
+        let now = Date(timeIntervalSince1970: 1_700_100_000)
+        try await RewindDatabase.shared.insertScreenshot(Screenshot(
             timestamp: now,
             appName: "Safari",
             windowTitle: "Tab",
             imagePath: "",
-            ocrText: "tutorial bingo zebra",
+            ocrText: "tutorial flamingoOCR zebra",
             isIndexed: true
-        )).id
+        ))
 
-        let results = try await RewindDatabase.shared.search(query: "bingo")
-        XCTAssertTrue(results.contains(where: { $0.id == id }), "OCR-text match must surface")
+        let results = try await RewindDatabase.shared.search(query: "flamingoOCR")
+        XCTAssertTrue(
+            results.contains(where: { abs($0.timestamp.timeIntervalSince(now)) < 1 }),
+            "OCR-text match must surface"
+        )
     }
 
     func testSearchMatchesViaVisualActivitySummary() async throws {
         guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
             throw XCTSkip("database queue unavailable")
         }
-        let now = Date()
-        let id = try await RewindDatabase.shared.insertScreenshot(Screenshot(
+        let now = Date(timeIntervalSince1970: 1_700_200_000)
+        try await RewindDatabase.shared.insertScreenshot(Screenshot(
             timestamp: now,
             appName: "Safari",
             windowTitle: "Tab",
             imagePath: "",
             ocrText: nil,
             isIndexed: true
-        )).id!
+        ))
+        let id: Int64 = try await dbQueue.read { db in
+            try Int64.fetchOne(
+                db,
+                sql: "SELECT id FROM screenshots WHERE timestamp = ?",
+                arguments: [now]
+            ) ?? 0
+        }
+        XCTAssertNotEqual(id, 0, "screenshot row should have been inserted")
 
         // Insert a visual_activity row whose summary contains a unique token
         // that is NOT present anywhere in the screenshots table — only the
@@ -85,14 +96,22 @@ final class RewindSearchMultiLaneTests: XCTestCase {
         let sessionStart = Date(timeIntervalSince1970: 1_700_000_000)
         let frameTime = sessionStart.addingTimeInterval(10)
 
-        let id = try await RewindDatabase.shared.insertScreenshot(Screenshot(
+        try await RewindDatabase.shared.insertScreenshot(Screenshot(
             timestamp: frameTime,
             appName: "Zoom",
             windowTitle: "Standup",
             imagePath: "",
             ocrText: nil,
             isIndexed: true
-        )).id!
+        ))
+        let id: Int64 = try await dbQueue.read { db in
+            try Int64.fetchOne(
+                db,
+                sql: "SELECT id FROM screenshots WHERE timestamp = ?",
+                arguments: [frameTime]
+            ) ?? 0
+        }
+        XCTAssertNotEqual(id, 0)
 
         let sessionId = try await dbQueue.write { db -> Int64 in
             try db.execute(

--- a/Desktop/Tests/RewindSearchMultiLaneTests.swift
+++ b/Desktop/Tests/RewindSearchMultiLaneTests.swift
@@ -1,0 +1,129 @@
+import GRDB
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression tests for #119 — Rewind search must span OCR text,
+/// vision-model summaries (`visual_activity.visualSummary`), and spoken
+/// transcript text (`transcription_segments.text`). Pre-fix the search
+/// path joined only `screenshots_fts`, leaving VLM and transcript hits
+/// invisible despite the doc promising all three.
+final class RewindSearchMultiLaneTests: XCTestCase {
+    private var testUserId = ""
+
+    override func setUp() async throws {
+        try await super.setUp()
+        testUserId = "test-rewind-search-\(UUID().uuidString)"
+        await RewindDatabase.shared.configure(userId: testUserId)
+        try await RewindDatabase.shared.initialize()
+    }
+
+    override func tearDown() async throws {
+        await RewindDatabase.shared.close()
+        try await super.tearDown()
+    }
+
+    func testSearchMatchesViaOCRTextLane() async throws {
+        let now = Date()
+        let id = try await RewindDatabase.shared.insertScreenshot(Screenshot(
+            timestamp: now,
+            appName: "Safari",
+            windowTitle: "Tab",
+            imagePath: "",
+            ocrText: "tutorial bingo zebra",
+            isIndexed: true
+        )).id
+
+        let results = try await RewindDatabase.shared.search(query: "bingo")
+        XCTAssertTrue(results.contains(where: { $0.id == id }), "OCR-text match must surface")
+    }
+
+    func testSearchMatchesViaVisualActivitySummary() async throws {
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+            throw XCTSkip("database queue unavailable")
+        }
+        let now = Date()
+        let id = try await RewindDatabase.shared.insertScreenshot(Screenshot(
+            timestamp: now,
+            appName: "Safari",
+            windowTitle: "Tab",
+            imagePath: "",
+            ocrText: nil,
+            isIndexed: true
+        )).id!
+
+        // Insert a visual_activity row whose summary contains a unique token
+        // that is NOT present anywhere in the screenshots table — only the
+        // visual_activity_fts lane can find it.
+        try await dbQueue.write { db in
+            try db.execute(
+                sql: """
+                    INSERT INTO visual_activity(
+                        screenshotId, sampledAt, appName, windowTitle,
+                        visualSummary, uiState, ocrTextSnapshot, perceptualHash, createdAt
+                    )
+                    VALUES (?, ?, 'Safari', 'Tab', ?, NULL, NULL, NULL, ?)
+                    """,
+                arguments: [id, now, "User watching swiftui flamingotutorial on screen", now]
+            )
+        }
+
+        let results = try await RewindDatabase.shared.search(query: "flamingotutorial")
+        XCTAssertTrue(
+            results.contains(where: { $0.id == id }),
+            "Vision-model summary match must surface — visual_activity_fts lane"
+        )
+    }
+
+    func testSearchMatchesViaTranscriptSegmentText() async throws {
+        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+            throw XCTSkip("database queue unavailable")
+        }
+        // Frame at t=10 inside a session that started at t=0; a segment
+        // covering 5..15 says "quokka roadmap" — the screenshot must show
+        // up when searching for "quokka".
+        let sessionStart = Date(timeIntervalSince1970: 1_700_000_000)
+        let frameTime = sessionStart.addingTimeInterval(10)
+
+        let id = try await RewindDatabase.shared.insertScreenshot(Screenshot(
+            timestamp: frameTime,
+            appName: "Zoom",
+            windowTitle: "Standup",
+            imagePath: "",
+            ocrText: nil,
+            isIndexed: true
+        )).id!
+
+        let sessionId = try await dbQueue.write { db -> Int64 in
+            try db.execute(
+                sql: """
+                    INSERT INTO transcription_sessions(
+                        startedAt, source, language, timezone, status, retryCount,
+                        backendSynced, createdAt, updatedAt, summary_state
+                    )
+                    VALUES (?, 'desktop', 'en', 'UTC', 'recording', 0, 0, ?, ?, 'pending')
+                    """,
+                arguments: [sessionStart, sessionStart, sessionStart]
+            )
+            return db.lastInsertedRowID
+        }
+
+        try await dbQueue.write { db in
+            try db.execute(
+                sql: """
+                    INSERT INTO transcription_segments(
+                        sessionId, speaker, text, startTime, endTime, segmentOrder, createdAt
+                    )
+                    VALUES (?, 0, ?, 5.0, 15.0, 0, ?)
+                    """,
+                arguments: [sessionId, "let's lock the quokka roadmap", sessionStart]
+            )
+        }
+
+        let results = try await RewindDatabase.shared.search(query: "quokka")
+        XCTAssertTrue(
+            results.contains(where: { $0.id == id }),
+            "Transcript-text match must surface — transcription_segments_fts lane"
+        )
+    }
+}

--- a/docs/features/rewind.md
+++ b/docs/features/rewind.md
@@ -36,13 +36,15 @@ Rewind is a visual timeline of your screen activity. Scrub through screenshots c
 
 ### Screen capture
 
-Every approximately one second, the app uses macOS `ScreenCaptureKit` to capture the visible window at up to 3000×3000 px. Each frame is JPEG-encoded at 80% quality and written to disk under:
+Every approximately one second, the app uses macOS `ScreenCaptureKit` to capture the visible window at up to 3000×3000 px. Frames are not written individually as JPEGs; instead they are appended to a rolling H.265 fragmented-MP4 chunk by `VideoChunkEncoder` at ~1 fps. Each chunk caps at 60 seconds and is then finalized to disk under:
 
 ```
-~/Library/Application Support/Omi/users/{userId}/Screenshots/YYYY-MM-DD/screenshot_HHmmss_SSS.jpg
+~/Library/Application Support/Omi/users/{userId}/Videos/YYYY-MM-DD/chunk_HHmmss.mp4
 ```
 
-Date-bucketed folders keep the directory tree manageable and make retention cleanup efficient. Capture automatically pauses for any app on Rewind's excluded list (Settings → Rewind → Excluded Apps). Password managers and incognito windows are excluded by default.
+Per-frame metadata (timestamp, app name, window title, OCR results) is written to the SQLite `screenshots` table with `videoChunkPath` pointing at the chunk file and `frameOffset` selecting the frame inside it. Date-bucketed folders keep the directory tree manageable and make retention cleanup efficient. Capture automatically pauses for any app on Rewind's excluded list (Settings → Rewind → Excluded Apps). Password managers and incognito windows are excluded by default.
+
+A legacy single-JPEG path (`RewindStorage.saveScreenshot`, `screenshots.imagePath`) remains in the codebase for older databases that still reference per-frame JPEGs on disk; the live capture pipeline does not exercise it.
 
 ### OCR
 
@@ -66,7 +68,7 @@ Each sampled frame produces a row in the `visual_activity` table (backed by GRDB
 
 ### Retention
 
-On app launch, screenshots and `visual_activity` rows older than the configured retention window are pruned (Settings → Rewind → Data Retention; default 7 days, with options up to 30). There is also a soft cap of 30,000 rows in `visual_activity`; rows above that threshold are trimmed oldest-first automatically. Image files on disk are removed alongside their corresponding database rows.
+On app launch, screenshots and `visual_activity` rows older than the configured retention window are pruned (Settings → Rewind → Data Retention; default 7 days, with options up to 30). There is also a soft cap of 30,000 rows in `visual_activity`; rows above that threshold are trimmed oldest-first automatically. When every frame referencing a given video chunk has been deleted, the orphaned `Videos/YYYY-MM-DD/chunk_HHmmss.mp4` file is removed from disk as well (`RewindIndexer.runCleanup` → `RewindStorage.deleteVideoChunk`). Any legacy per-frame JPEGs still referenced by `screenshots.imagePath` are deleted alongside their rows.
 
 ### Transcript context
 
@@ -80,9 +82,12 @@ The on/off switch on the Rewind page calls into the same capture service used at
 
 - `Desktop/Sources/Rewind/UI/RewindPage.swift`
 - `Desktop/Sources/ScreenCaptureService.swift`
+- `Desktop/Sources/Rewind/Core/VideoChunkEncoder.swift`
 - `Desktop/Sources/Rewind/Core/RewindOCRService.swift`
 - `Desktop/Sources/AI/VisionLLMClient.swift`
 - `Desktop/Sources/Rewind/Services/VisualActivitySampler.swift`
 - `Desktop/Sources/Rewind/Services/VisualActivityIndexer.swift`
+- `Desktop/Sources/Rewind/Services/RewindIndexer.swift`
 - `Desktop/Sources/Rewind/Core/RewindDatabase.swift`
+- `Desktop/Sources/Rewind/Core/RewindStorage.swift`
 - `Desktop/Sources/Power/BatteryAwareScheduler.swift`

--- a/docs/features/rewind.md
+++ b/docs/features/rewind.md
@@ -38,7 +38,7 @@ Rewind is a visual timeline of your screen activity. Scrub through screenshots c
 
 Every approximately one second, the app uses macOS `ScreenCaptureKit` to capture the visible window at up to 3000×3000 px. Frames are not written individually as JPEGs; instead they are appended to a rolling H.265 fragmented-MP4 chunk by `VideoChunkEncoder` at ~1 fps. Each chunk caps at 60 seconds and is then finalized to disk under:
 
-```
+```text
 ~/Library/Application Support/Omi/users/{userId}/Videos/YYYY-MM-DD/chunk_HHmmss.mp4
 ```
 


### PR DESCRIPTION
## Summary
- Video chunk rebuild now matches the actual on-disk format (`.mp4` chunks under `Videos/YYYY-MM-DD/chunk_HHmmss.mp4`); the recovery banner's "Rebuild Index" can finally pick up real footage.
- Rewind search now covers all three lanes the doc promised: OCR (`screenshots_fts`), vision-model summaries (`visual_activity_fts`), and spoken transcripts (new `transcription_segments_fts` index, joined by absolute time window).
- Expanded transcript area now loads per-frame transcript context for historical frames via a new `RewindDatabase.transcriptSegments(around:window:)` + `HistoricalTranscriptPanel`. Live panel still wins when capture is active and the user is on the latest frame.
- `docs/features/rewind.md` "Screen capture", "Retention", and Source list now describe the actual H.265 fragmented-MP4 chunk pipeline.

Fixes #117
Fixes #119
Fixes #123
Fixes #129

## Test plan
- [x] `xcrun swift build -c debug --package-path Desktop` (clean)
- [x] `xcrun swift test --package-path Desktop` (497/497 passing, including new `RewindChunkTimestampParseTests`, `RewindSearchMultiLaneTests`, `RewindHistoricalTranscriptTests`)
- [x] `cargo test --locked -p infinite-recall-api` (green)
- [ ] Manual: with a populated `Videos/YYYY-MM-DD/chunk_HHmmss.mp4` directory, trigger Rewind's recovery banner "Rebuild Index" and confirm rows are inserted.
- [ ] Manual: search Rewind for a phrase that only appears in a vision-model summary or a transcript segment; confirm the matching frame appears.
- [ ] Manual: scrub Rewind back to a frame from a previous conversation and expand the transcript area; confirm it shows the words spoken at that frame's timestamp, not the live monitor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * View historical transcripts for a selected past screenshot, with loading state and a “No transcript for this moment” empty state.

* **Improvements**
  * Search now returns results from screen text, visual summaries, and transcription text.
  * Playback/storage now supports MP4 video chunks in addition to legacy format.

* **Documentation**
  * Rewind docs updated to reflect current video storage and retention behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->