### PR TITLE
fix(activity): batch fixes for #128 #134 #137

### DIFF
--- a/Backend-Rust/api/src/activity/contract.md
+++ b/Backend-Rust/api/src/activity/contract.md
@@ -111,7 +111,7 @@ so the field is silently absent when the daemon doesn't know the kind.
 
 `GateState` is an internally-tagged sum on the `state` field. The pre-#35
 flat shape (`{allowed: bool, reason: enum, waiting_for: string?}`) is gone:
-it permitted illegal combinations like `{allowed: true, reason: "manual_pause"}`
+it permitted illegal combinations like `{allowed: true, reason: "locked"}`
 and a stringly-typed `waiting_for`.
 
 ```json
@@ -148,7 +148,7 @@ and a stringly-typed `waiting_for`.
 | `ResourceSample.thermal_state` / `ThermalState` | `nominal`, `fair`, `serious`, `critical` |
 | `ProcessBreakdown.kind` / `ProcessKind` (optional) | `core`, `local_model`, `unknown` (field omitted when daemon doesn't classify; both Rust and Swift decoders fold any future wire value into `unknown` for forward-compat) |
 | `GateState` (variant tag on `state`) | `allowed`, `blocked` |
-| `GateState.reason` / `BlockReason` (only when `state="blocked"`) | `device_active`, `on_battery`, `thermal`, `locked`, `manual_pause`, `initializing` |
+| `GateState.reason` / `BlockReason` (only when `state="blocked"`) | `device_active`, `on_battery`, `thermal`, `locked`, `initializing` (issue #128: `manual_pause` pruned — no producer existed) |
 
 ### `PauseRequest` / `ResumeRequest`
 

--- a/Backend-Rust/api/src/activity/types.rs
+++ b/Backend-Rust/api/src/activity/types.rs
@@ -103,6 +103,12 @@ pub enum ThermalState {
 /// `GateState::Blocked` — the `Allowed` variant doesn't carry one,
 /// because "we're allowed to drain" doesn't have a sub-reason
 /// (issue #35: collapse `{allowed: bool, reason: enum}` into a sum).
+///
+/// Issue #128: `ManualPause` was pruned. There is no whole-pipeline pause
+/// in IR — pausing is per-kind or per-capture (`CapturePauseGate` +
+/// `paused_until` on the row, NOT the gate state). The wire variant had
+/// no Swift producer and the corresponding banner / `disablesRunNowOverride`
+/// branches were dead code.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum BlockReason {
@@ -114,8 +120,6 @@ pub enum BlockReason {
     Thermal,
     /// Screen locked / session inactive.
     Locked,
-    /// User manually paused via the Activity tab.
-    ManualPause,
     /// Initial state before the first gate-state report from Swift
     /// arrives. Should only be observed during the brief boot window
     /// (~3s — one `ProcessingGateReporter` poll cycle). External POSTs
@@ -245,7 +249,7 @@ pub struct ResourceSample {
 /// Snapshot of the idle/processing gate at sample time.
 ///
 /// Issue #35: was a `{allowed: bool, reason: enum, waiting_for: Option<String>}`
-/// struct that permitted illegal states like `{allowed: true, reason: ManualPause}`
+/// struct that permitted illegal states like `{allowed: true, reason: Locked}`
 /// or `Blocked` with no `waiting_for`. Now a sum type — each variant carries
 /// exactly the data that's meaningful for it.
 ///
@@ -437,12 +441,12 @@ mod tests {
 
     #[test]
     fn block_reason_every_variant_round_trips() {
+        // Issue #128: `ManualPause` pruned — see `BlockReason` docstring.
         for (r, wire) in [
             (BlockReason::DeviceActive, "device_active"),
             (BlockReason::OnBattery, "on_battery"),
             (BlockReason::Thermal, "thermal"),
             (BlockReason::Locked, "locked"),
-            (BlockReason::ManualPause, "manual_pause"),
             (BlockReason::Initializing, "initializing"),
         ] {
             assert_eq!(serde_json::to_string(&r).unwrap(), format!("\"{wire}\""));

--- a/Backend-Rust/api/src/routes/activity.rs
+++ b/Backend-Rust/api/src/routes/activity.rs
@@ -68,12 +68,9 @@ pub struct QueueDepth {
     pub failed: u32,
 }
 
-/// Body for `POST /v1/activity/_internal/queue-depth`. Matches frozen
-/// interface I1; the entire `depths` map replaces the previous state.
-#[derive(Debug, Clone, Deserialize)]
-pub struct QueueDepthUpdate {
-    pub depths: HashMap<String, QueueDepth>,
-}
+// Issue #137: `QueueDepthUpdate` (the body type for the legacy
+// `_internal/queue-depth` POST) was pruned. Activity snapshots are
+// DB-authoritative; no Swift producer ever pushed to the route.
 
 fn is_missing_pending_work_table_error(error: &RusqliteError) -> bool {
     matches!(
@@ -319,18 +316,10 @@ pub async fn inflight(
     Ok(StatusCode::NO_CONTENT)
 }
 
-/// `POST /v1/activity/_internal/queue-depth` — legacy Swift → Rust loopback.
-///
-/// Activity snapshots are now DB-authoritative and do not read this payload.
-/// Keep accepting the old route as a compatibility no-op so older Swift builds
-/// do not fail their internal reporter while users upgrade both processes.
-pub async fn internal_queue_depth(
-    State(_state): State<AppState>,
-    Json(body): Json<QueueDepthUpdate>,
-) -> StatusCode {
-    let _ = body.depths.len();
-    StatusCode::NO_CONTENT
-}
+// Issue #137: `internal_queue_depth` handler pruned. Activity snapshots are
+// DB-authoritative (see `pending_work_depths_by_kind` above) and no Swift
+// build ever produces this POST in the IR app — Swift's
+// `InternalPostFailureTracker` no longer carries a `queue-depth` category.
 
 /// `POST /v1/activity/_internal/gate-state` — Swift → Rust loopback.
 ///

--- a/Backend-Rust/api/src/routes/mod.rs
+++ b/Backend-Rust/api/src/routes/mod.rs
@@ -51,10 +51,8 @@ pub fn router(state: AppState) -> Router {
         .route("/v1/activity/pause", post(activity::pause))
         .route("/v1/activity/resume", post(activity::resume))
         .route("/v1/activity/_internal/inflight", post(activity::inflight))
-        .route(
-            "/v1/activity/_internal/queue-depth",
-            post(activity::internal_queue_depth),
-        )
+        // Issue #137: `_internal/queue-depth` route pruned — Activity
+        // snapshots are DB-authoritative; no Swift producer exists.
         // === /activity:A ===
         // === activity:32 ===
         // Swift→Rust loopback for the processing gate (issue #32).

--- a/Backend-Rust/api/tests/activity_endpoints.rs
+++ b/Backend-Rust/api/tests/activity_endpoints.rs
@@ -686,8 +686,10 @@ async fn inflight_loopback_round_trip() {
 }
 
 /// Activity queue counts are DB-authoritative: `/snapshot` reads
-/// `pending_work` directly and ignores the legacy `_internal/queue-depth`
-/// push payload.
+/// `pending_work` directly. Issue #137: the legacy
+/// `POST /v1/activity/_internal/queue-depth` route was pruned (no Swift
+/// producer); the test now also asserts the route is gone (404) so a
+/// future re-introduction is caught.
 #[tokio::test]
 async fn queue_depth_snapshot_reads_pending_work_not_loopback_cache() {
     let state = make_state(
@@ -716,7 +718,9 @@ async fn queue_depth_snapshot_reads_pending_work_not_loopback_cache() {
     let app = routes::router(state);
     let (k, v) = auth_header();
 
-    // Legacy push is accepted but must not override DB truth.
+    // Issue #137: the legacy `_internal/queue-depth` route is gone. POSTing
+    // to it must return 404 — a regression that re-adds the handler will
+    // fail this assertion.
     let body = json!({
         "depths": {
             "transcribe": { "queued": 99, "failed": 99 },
@@ -731,7 +735,11 @@ async fn queue_depth_snapshot_reads_pending_work_not_loopback_cache() {
         .body(Body::from(body.to_string()))
         .unwrap();
     let resp = app.clone().oneshot(req).await.unwrap();
-    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "legacy `_internal/queue-depth` route must stay pruned (issue #137)"
+    );
 
     let snap_req = Request::builder()
         .method(Method::GET)

--- a/Backend-Rust/api/tests/activity_endpoints.rs
+++ b/Backend-Rust/api/tests/activity_endpoints.rs
@@ -990,12 +990,12 @@ async fn enum_round_trip_via_wire() {
 
     // Issue #35: `GateReason` is gone, replaced by `BlockReason` (only
     // the Blocked variant carries one — Allowed has no sub-reason).
+    // Issue #128: `ManualPause` pruned — see `BlockReason` docstring.
     for (reason, wire) in [
         (t::BlockReason::DeviceActive, "device_active"),
         (t::BlockReason::OnBattery, "on_battery"),
         (t::BlockReason::Thermal, "thermal"),
         (t::BlockReason::Locked, "locked"),
-        (t::BlockReason::ManualPause, "manual_pause"),
         (t::BlockReason::Initializing, "initializing"),
     ] {
         let s = serde_json::to_string(&reason).unwrap();

--- a/Desktop/Sources/Activity/ActivityModels.swift
+++ b/Desktop/Sources/Activity/ActivityModels.swift
@@ -110,16 +110,22 @@ public enum ProcessKind: String, Codable, Hashable {
 }
 
 /// Issue #35: the pre-#35 `GateReason` (`idle/device_active/on_battery/
-/// thermal/locked/manual_pause/none/stub`) was a stringly-typed enum that
-/// existed alongside an `allowed: Bool` permitting illegal combos like
-/// `{allowed: true, reason: .manualPause}`. Replaced by `GateState`
-/// (sum type) + `BlockReason` (only meaningful when blocked).
+/// thermal/locked/none/stub`) was a stringly-typed enum that
+/// existed alongside an `allowed: Bool` permitting illegal combos.
+/// Replaced by `GateState` (sum type) + `BlockReason` (only meaningful
+/// when blocked).
+///
+/// Issue #128: the `manualPause` case was pruned. The doc lists seven gate
+/// states but no Swift code path ever produced `Blocked(.manualPause, ...)`
+/// — there is no "pause all processing" toggle, only per-kind/per-capture
+/// pauses (which flow through `CapturePauseGate` and the snapshot's
+/// `paused_until` field, not the gate state). The wire enum, banner copy,
+/// and `disablesRunNowOverride` predicate were dead branches.
 public enum BlockReason: String, Codable, Hashable, CaseIterable {
     case deviceActive = "device_active"
     case onBattery = "on_battery"
     case thermal
     case locked
-    case manualPause = "manual_pause"
     /// Initial state before the first gate-state report from Swift
     /// arrives. Should only be observed during the brief boot window
     /// (~3s — one `ProcessingGateReporter` poll cycle). External POSTs

--- a/Desktop/Sources/Activity/ActivityModels.swift
+++ b/Desktop/Sources/Activity/ActivityModels.swift
@@ -25,6 +25,24 @@ public enum WorkKind: String, Codable, CaseIterable, Hashable {
     /// kind was scheduler-internal only, producing the count mismatch
     /// reported in the bug.
     case extractKG = "extract_kg"
+
+    /// Issue #134: kinds that need both AC power AND user idle to run.
+    /// `BatteryAwareScheduler.drain()` only releases-back-to-queue rows
+    /// whose kind returns `true` here when `allowAutonomousAIWork` is
+    /// false; transcribe / OCR / extractMemory / extractActionItems run
+    /// on AC even while the user is actively typing.
+    ///
+    /// Single source of truth — `BatteryAwareScheduler` delegates to this
+    /// at the `PendingWork.Kind` boundary. The Activity-page banner reads
+    /// it directly so the two cannot drift.
+    public var requiresAutonomousReadiness: Bool {
+        switch self {
+        case .summarize, .extractKG:
+            return true
+        case .transcribe, .ocr, .extractMemory, .extractActionItems:
+            return false
+        }
+    }
 }
 
 public enum CaptureKind: String, Codable, CaseIterable, Hashable {

--- a/Desktop/Sources/Activity/ActivityMonitorService.swift
+++ b/Desktop/Sources/Activity/ActivityMonitorService.swift
@@ -179,9 +179,11 @@ public final class ActivityMonitorService: ObservableObject, InternalPostFailure
         await fetchOnce()
     }
 
-    /// Surface a banner when `_internal/*` POSTs (inflight, queue-depth,
-    /// gate-state) have failed `consecutive` times in a row. Routed through
+    /// Surface a banner when `_internal/*` POSTs (inflight, gate-state) have
+    /// failed `consecutive` times in a row. Routed through
     /// `InternalPostFailureTracker` so duplicate counters don't drift.
+    /// (Issue #137: queue-depth was pruned — Activity snapshots are now
+    /// DB-authoritative via `snapshotWithAuthoritativeQueueDepth`.)
     func reportInternalPostFailure(category: String, consecutive: Int) {
         lastError = "Internal reporting failing: \(category) (\(consecutive) consecutive failures)"
     }

--- a/Desktop/Sources/Activity/ActivityPage.swift
+++ b/Desktop/Sources/Activity/ActivityPage.swift
@@ -115,10 +115,18 @@ private let activityCorrectedGateLog = Logger(
 /// idle" while transcribe / OCR / extractMemory / extractActionItems are
 /// actively running. Pure helper; tests live in
 /// `Desktop/Tests/ActivityPagePowerGateTests.swift`.
-func activityLightweightWorkActive(kinds: [KindRow]) -> Bool {
+///
+/// CodeRabbit (PR #149): a paused lightweight kind still has `queued > 0`
+/// but the scheduler will stop at the per-kind pause gate, so the banner
+/// must NOT flip to "Idle processing — running" on the strength of those
+/// queued rows alone. In-flight work always counts (the row is already
+/// running); queued rows count only when not currently paused.
+func activityLightweightWorkActive(kinds: [KindRow], now: Date = Date()) -> Bool {
     kinds.contains { row in
-        row.kind.requiresAutonomousReadiness == false
-            && (row.queued > 0 || row.inFlight != nil)
+        guard row.kind.requiresAutonomousReadiness == false else { return false }
+        if row.inFlight != nil { return true }
+        let isPaused = (row.pausedUntil ?? .distantPast) > now
+        return !isPaused && row.queued > 0
     }
 }
 

--- a/Desktop/Sources/Activity/ActivityPage.swift
+++ b/Desktop/Sources/Activity/ActivityPage.swift
@@ -108,6 +108,20 @@ private let activityCorrectedGateLog = Logger(
     category: "ActivityCorrectedGate"
 )
 
+/// Issue #134: true when at least one lightweight (non-autonomous) work
+/// kind has queued or in-flight rows. The `BatteryAwareScheduler` drains
+/// these on AC even when `Blocked(.deviceActive)` (only `.summarize` and
+/// `.extractKG` need user-idle), so the banner must not say "Waiting for
+/// idle" while transcribe / OCR / extractMemory / extractActionItems are
+/// actively running. Pure helper; tests live in
+/// `Desktop/Tests/ActivityPagePowerGateTests.swift`.
+func activityLightweightWorkActive(kinds: [KindRow]) -> Bool {
+    kinds.contains { row in
+        row.kind.requiresAutonomousReadiness == false
+            && (row.queued > 0 || row.inFlight != nil)
+    }
+}
+
 func activityShouldShowRunNowButton(
     snapshotGate: GateState?,
     correctedGate: GateState?,
@@ -405,7 +419,7 @@ struct ActivityPage: View {
     // MARK: - Banner
 
     private var gateBanner: some View {
-        let info = bannerInfo(for: gate, queued: totalQueued)
+        let info = bannerInfo(for: gate, queued: totalQueued, kinds: kinds)
         return HStack(alignment: .top, spacing: 12) {
             Image(systemName: info.icon)
                 .scaledFont(size: 20)
@@ -477,7 +491,11 @@ struct ActivityPage: View {
         let color: Color
     }
 
-    private func bannerInfo(for gate: GateState?, queued: UInt32) -> BannerInfo {
+    private func bannerInfo(
+        for gate: GateState?,
+        queued: UInt32,
+        kinds: [KindRow]
+    ) -> BannerInfo {
         guard let gate = gate else {
             return BannerInfo(
                 icon: "ellipsis.circle",
@@ -506,18 +524,38 @@ struct ActivityPage: View {
                 color: OmiColors.textSecondary
             )
         case .blocked(let reason, _, let waitingFor):
-            return blockedBannerInfo(reason: reason, waitingFor: waitingFor, queued: queued)
+            return blockedBannerInfo(
+                reason: reason,
+                waitingFor: waitingFor,
+                queued: queued,
+                kinds: kinds
+            )
         }
     }
 
     private func blockedBannerInfo(
         reason: BlockReason,
         waitingFor: WaitCondition,
-        queued: UInt32
+        queued: UInt32,
+        kinds: [KindRow]
     ) -> BannerInfo {
         let detail = waitingForDescription(waitingFor)
         switch reason {
         case .deviceActive:
+            // Issue #134: only `.summarize` / `.extractKG` actually wait for
+            // idle; lightweight kinds (transcribe / OCR / extractMemory /
+            // extractActionItems) drain on AC even while typing. If any
+            // lightweight row has queued or in-flight work, the banner must
+            // reflect that the queue is actively draining instead of
+            // contradicting the In-flight section with "Waiting for idle".
+            if activityLightweightWorkActive(kinds: kinds) {
+                return BannerInfo(
+                    icon: "checkmark.circle.fill",
+                    title: "Idle processing — running",
+                    detail: "\(queued) item\(queued == 1 ? "" : "s") in queue. Heavy work waits for \(detail).",
+                    color: OmiColors.success
+                )
+            }
             return BannerInfo(
                 icon: "keyboard.fill",
                 title: "Waiting for idle — \(queued) item\(queued == 1 ? "" : "s") queued",

--- a/Desktop/Sources/Activity/ActivityPage.swift
+++ b/Desktop/Sources/Activity/ActivityPage.swift
@@ -25,7 +25,7 @@ extension BlockReason {
     /// masked by battery state.
     var outranksOnBattery: Bool {
         switch self {
-        case .thermal, .locked, .deviceActive, .manualPause: return true
+        case .thermal, .locked, .deviceActive: return true
         case .onBattery, .initializing: return false
         }
     }
@@ -37,7 +37,7 @@ extension BlockReason {
     /// pressure (`ProcessingGateReporter.swift:120`).
     var disablesRunNowOverride: Bool {
         switch self {
-        case .thermal, .locked, .manualPause: return true
+        case .thermal, .locked: return true
         case .deviceActive, .onBattery, .initializing: return false
         }
     }
@@ -558,13 +558,6 @@ struct ActivityPage: View {
                 title: "Screen locked — \(queued) item\(queued == 1 ? "" : "s") queued",
                 detail: detail,
                 color: OmiColors.warning
-            )
-        case .manualPause:
-            return BannerInfo(
-                icon: "pause.circle.fill",
-                title: "Manually paused",
-                detail: detail,
-                color: OmiColors.error
             )
         case .initializing:
             // Issue #32: with the Swift→Rust gate-state bridge live, the
@@ -1122,7 +1115,6 @@ struct ActivityPage: View {
             return "Waiting for AC power."
         case .thermal:      return "Waiting for thermal cooldown."
         case .locked:       return "Resumes when you unlock."
-        case .manualPause:  return "Manually paused."
         case .initializing: return "Reading idle / power / thermal state."
         }
     }

--- a/Desktop/Sources/Activity/InternalPostFailureTracker.swift
+++ b/Desktop/Sources/Activity/InternalPostFailureTracker.swift
@@ -11,12 +11,18 @@ protocol InternalPostFailureReporter: AnyObject {
     func reportInternalPostFailure(category: String, consecutive: Int)
 }
 
-/// Tracks consecutive failures of `_internal/*` POSTs (inflight, queue-depth,
-/// gate-state) so the user gets a banner when internal reporting is silently
-/// broken. Each category has its own counter; hitting `escalationThreshold`
+/// Tracks consecutive failures of `_internal/*` POSTs (inflight, gate-state)
+/// so the user gets a banner when internal reporting is silently broken.
+/// Each category has its own counter; hitting `escalationThreshold`
 /// consecutive failures fires once into the attached
 /// `InternalPostFailureReporter` (`ActivityMonitorService` in production).
 /// A subsequent success resets the counter and re-arms escalation.
+///
+/// Issue #137: the `queueDepth` category was pruned. Activity snapshots are
+/// now DB-authoritative (`snapshotWithAuthoritativeQueueDepth` reads
+/// `pending_work` directly), so the legacy Swift→Rust queue-depth POST has
+/// no producer and the legacy Rust `_internal/queue-depth` route was
+/// removed alongside it.
 @MainActor
 final class InternalPostFailureTracker {
     static let shared = InternalPostFailureTracker()
@@ -32,7 +38,6 @@ final class InternalPostFailureTracker {
 
     enum Category: String, CaseIterable {
         case inflight
-        case queueDepth = "queue-depth"
         case gateState = "gate-state"
     }
 

--- a/Desktop/Sources/Power/BatteryAwareScheduler.swift
+++ b/Desktop/Sources/Power/BatteryAwareScheduler.swift
@@ -590,14 +590,13 @@ public final class BatteryAwareScheduler: ObservableObject {
   }
 
   /// Returns true for kinds gated by `allowAutonomousAIWork`.
-  /// Currently: `.summarize`. Future autonomous-LLM kinds should be added here.
+  /// Currently: `.summarize` and `.extractKG`. Issue #134: delegates to
+  /// `WorkKind.requiresAutonomousReadiness` so the Activity-page banner
+  /// (`ActivityPage.swift`) and the scheduler's drain loop cannot drift
+  /// — the doc paragraph at `docs/features/activity.md` "What runs on AC
+  /// vs. idle+AC" is anchored by the `WorkKind` extension.
   fileprivate static func requiresAutonomousReadiness(_ kind: PendingWork.Kind) -> Bool {
-    switch kind {
-    case .summarize, .extractKG:
-      return true
-    case .transcribe, .ocr, .extractMemory, .extractActionItems:
-      return false
-    }
+    toWireWorkKind(kind)?.requiresAutonomousReadiness ?? true
   }
 
   /// Map the scheduler's local `PendingWork.Kind` to the wire-level

--- a/Desktop/Sources/Power/BatteryAwareScheduler.swift
+++ b/Desktop/Sources/Power/BatteryAwareScheduler.swift
@@ -295,7 +295,8 @@ public final class BatteryAwareScheduler: ObservableObject {
     self.lastAutonomousAllow = self.allowAutonomousAIWork
 
     // Queue depth is read from `pending_work` by Activity snapshots; no
-    // Swift→Rust queue-depth bridge is needed here.
+    // Swift→Rust queue-depth bridge exists. Issue #137: the legacy
+    // `_internal/queue-depth` route + tracker category were pruned.
   }
 
   /// Stop watching for transitions. Mainly for tests.

--- a/Desktop/Tests/ActivityModelsTests.swift
+++ b/Desktop/Tests/ActivityModelsTests.swift
@@ -308,12 +308,13 @@ final class ActivityModelsTests: XCTestCase {
         // before the first `ProcessingGateReporter` POST arrives — it MUST
         // decode + encode like every other variant so the UI can render an
         // honest "initializing" banner.
+        // Issue #128: `manual_pause` pruned — no Swift producer ever
+        // emitted `Blocked(.manualPause, ...)`. See `BlockReason` docstring.
         let cases: [(String, BlockReason)] = [
             ("device_active", .deviceActive),
             ("on_battery",    .onBattery),
             ("thermal",       .thermal),
             ("locked",        .locked),
-            ("manual_pause",  .manualPause),
             ("initializing",  .initializing),
         ]
         for (wire, expected) in cases {

--- a/Desktop/Tests/ActivityPagePowerGateTests.swift
+++ b/Desktop/Tests/ActivityPagePowerGateTests.swift
@@ -314,7 +314,8 @@ final class ActivityPagePowerGateTests: XCTestCase {
     private func kindRow(
         _ kind: WorkKind,
         queued: UInt32 = 0,
-        inFlight: InFlight? = nil
+        inFlight: InFlight? = nil,
+        pausedUntil: Date? = nil
     ) -> KindRow {
         KindRow(
             kind: kind,
@@ -322,7 +323,7 @@ final class ActivityPagePowerGateTests: XCTestCase {
             queued: queued,
             failed: 0,
             lastDoneAt: nil,
-            pausedUntil: nil
+            pausedUntil: pausedUntil
         )
     }
 
@@ -363,6 +364,43 @@ final class ActivityPagePowerGateTests: XCTestCase {
     /// Empty kinds list — no work of any sort active.
     func test_lightweightActive_falseForEmpty() {
         XCTAssertFalse(activityLightweightWorkActive(kinds: []))
+    }
+
+    /// CodeRabbit (PR #149): a paused lightweight kind still has
+    /// `queued > 0`, but the scheduler will stop at the user's per-kind
+    /// pause gate, so the banner must not flip to "Idle processing —
+    /// running" on the strength of those queued rows alone.
+    func test_lightweightActive_falseForPausedTranscribeWithQueued() {
+        let pausedUntil = now.addingTimeInterval(60)
+        let kinds = [
+            kindRow(.transcribe, queued: 5, pausedUntil: pausedUntil),
+        ]
+        XCTAssertFalse(activityLightweightWorkActive(kinds: kinds, now: now))
+    }
+
+    /// In-flight work counts even on a paused kind — the row is already
+    /// running; the pause only stops the next dequeue.
+    func test_lightweightActive_trueForInFlightOnPausedKind() {
+        let pausedUntil = now.addingTimeInterval(60)
+        let kinds = [
+            kindRow(
+                .ocr,
+                queued: 5,
+                inFlight: InFlight(label: "OCR", startedAt: now),
+                pausedUntil: pausedUntil
+            ),
+        ]
+        XCTAssertTrue(activityLightweightWorkActive(kinds: kinds, now: now))
+    }
+
+    /// An *expired* pause (`pausedUntil < now`) must NOT suppress the
+    /// banner — the scheduler treats those rows as eligible.
+    func test_lightweightActive_trueForExpiredPause() {
+        let expired = now.addingTimeInterval(-60)
+        let kinds = [
+            kindRow(.transcribe, queued: 1, pausedUntil: expired),
+        ]
+        XCTAssertTrue(activityLightweightWorkActive(kinds: kinds, now: now))
     }
 
     /// Pin the kind classification: only `.summarize` / `.extractKG`

--- a/Desktop/Tests/ActivityPagePowerGateTests.swift
+++ b/Desktop/Tests/ActivityPagePowerGateTests.swift
@@ -308,4 +308,73 @@ final class ActivityPagePowerGateTests: XCTestCase {
             "Non-onBattery snapshot blocks must pass through unchanged regardless of resources."
         )
     }
+
+    // MARK: - Issue #134: lightweight-work-active predicate
+
+    private func kindRow(
+        _ kind: WorkKind,
+        queued: UInt32 = 0,
+        inFlight: InFlight? = nil
+    ) -> KindRow {
+        KindRow(
+            kind: kind,
+            inFlight: inFlight,
+            queued: queued,
+            failed: 0,
+            lastDoneAt: nil,
+            pausedUntil: nil
+        )
+    }
+
+    /// Issue #134 regression: with `Blocked(.deviceActive)` and a queued
+    /// `transcribe` row (a non-autonomous kind), the helper must report
+    /// "lightweight active" so the banner doesn't say "Waiting for idle"
+    /// while the In-flight section shows transcribe running.
+    func test_lightweightActive_trueForQueuedTranscribe() {
+        let kinds = [
+            kindRow(.transcribe, queued: 1),
+            kindRow(.summarize, queued: 5),
+        ]
+        XCTAssertTrue(activityLightweightWorkActive(kinds: kinds))
+    }
+
+    /// In-flight (not just queued) lightweight work must also count.
+    func test_lightweightActive_trueForInFlightOcr() {
+        let kinds = [
+            kindRow(
+                .ocr,
+                queued: 0,
+                inFlight: InFlight(label: "OCR", startedAt: now)
+            ),
+        ]
+        XCTAssertTrue(activityLightweightWorkActive(kinds: kinds))
+    }
+
+    /// Heavy-only queues (`.summarize` / `.extractKG`) must NOT trigger
+    /// the lightweight banner copy — those genuinely wait for idle.
+    func test_lightweightActive_falseWhenOnlyHeavyKindsQueued() {
+        let kinds = [
+            kindRow(.summarize, queued: 3),
+            kindRow(.extractKG, queued: 2),
+        ]
+        XCTAssertFalse(activityLightweightWorkActive(kinds: kinds))
+    }
+
+    /// Empty kinds list — no work of any sort active.
+    func test_lightweightActive_falseForEmpty() {
+        XCTAssertFalse(activityLightweightWorkActive(kinds: []))
+    }
+
+    /// Pin the kind classification: only `.summarize` / `.extractKG`
+    /// require autonomous (idle) readiness; the other four are
+    /// lightweight. Drift between this and `BatteryAwareScheduler.drain()`
+    /// is the original #134 bug class.
+    func test_workKindRequiresAutonomousReadinessClassification() {
+        XCTAssertTrue(WorkKind.summarize.requiresAutonomousReadiness)
+        XCTAssertTrue(WorkKind.extractKG.requiresAutonomousReadiness)
+        XCTAssertFalse(WorkKind.transcribe.requiresAutonomousReadiness)
+        XCTAssertFalse(WorkKind.ocr.requiresAutonomousReadiness)
+        XCTAssertFalse(WorkKind.extractMemory.requiresAutonomousReadiness)
+        XCTAssertFalse(WorkKind.extractActionItems.requiresAutonomousReadiness)
+    }
 }

--- a/Desktop/Tests/ActivityPagePowerGateTests.swift
+++ b/Desktop/Tests/ActivityPagePowerGateTests.swift
@@ -73,7 +73,9 @@ final class ActivityPagePowerGateTests: XCTestCase {
         let res = resources(onBattery: false, lowPower: true)
         let corrected = GateState.blocked(reason: .onBattery, since: now, waitingFor: .acPower)
 
-        for reason in [BlockReason.thermal, .locked, .manualPause] {
+        // Issue #128: `.manualPause` pruned (no producer existed). The
+        // remaining "Run now hidden" reasons are thermal + screen-locked.
+        for reason in [BlockReason.thermal, .locked] {
             let snapshotGate = GateState.blocked(
                 reason: reason,
                 since: now,

--- a/Desktop/Tests/InternalPostFailureTrackerTests.swift
+++ b/Desktop/Tests/InternalPostFailureTrackerTests.swift
@@ -114,23 +114,26 @@ final class InternalPostFailureTrackerTests: XCTestCase {
   func test_perCategoryIsolation() {
     tracker.reportFailure(.inflight)
     tracker.reportFailure(.inflight)
-    tracker.reportFailure(.queueDepth)
+    tracker.reportFailure(.gateState)
     XCTAssertEqual(tracker.failureCount(.inflight), 2)
-    XCTAssertEqual(tracker.failureCount(.queueDepth), 1)
-    XCTAssertEqual(tracker.failureCount(.gateState), 0)
+    XCTAssertEqual(tracker.failureCount(.gateState), 1)
     XCTAssertNil(reporter.lastError)
 
     tracker.reportSuccess(.inflight)
     XCTAssertEqual(tracker.failureCount(.inflight), 0)
     XCTAssertEqual(
-      tracker.failureCount(.queueDepth), 1,
+      tracker.failureCount(.gateState), 1,
       "success on one category must not reset another")
   }
 
   func test_categoryRawValuesMatchWireFormat() {
     XCTAssertEqual(InternalPostFailureTracker.Category.inflight.rawValue, "inflight")
-    XCTAssertEqual(InternalPostFailureTracker.Category.queueDepth.rawValue, "queue-depth")
     XCTAssertEqual(InternalPostFailureTracker.Category.gateState.rawValue, "gate-state")
+    // Issue #137: `queueDepth` category pruned — Activity snapshots are
+    // DB-authoritative; no Swift producer existed.
+    XCTAssertEqual(
+      InternalPostFailureTracker.Category.allCases.count, 2,
+      "only inflight + gate-state remain after #137 prune")
   }
 
   // MARK: - Fix 6 — new tests
@@ -161,8 +164,10 @@ final class InternalPostFailureTrackerTests: XCTestCase {
   }
 
   /// Each category's escalation re-arms independently of the others:
-  /// escalating .inflight, succeeding, escalating .queueDepth, and
-  /// succeeding must all fire fresh banners.
+  /// escalating .inflight, succeeding, escalating .gateState, and
+  /// succeeding must all fire fresh banners. Issue #137: this used to
+  /// pivot through `.queueDepth` but that category was pruned along with
+  /// the legacy Swift→Rust queue-depth POST.
   func test_reArm_perCategory_independent() {
     // Escalate .inflight.
     tracker.reportFailure(.inflight)
@@ -175,16 +180,16 @@ final class InternalPostFailureTrackerTests: XCTestCase {
     tracker.reportSuccess(.inflight)
     reporter.clearLastError()
 
-    // Escalate .queueDepth.
-    tracker.reportFailure(.queueDepth)
-    tracker.reportFailure(.queueDepth)
-    tracker.reportFailure(.queueDepth)
-    let qBanner = reporter.lastError
-    XCTAssertNotNil(qBanner)
-    XCTAssertTrue(qBanner?.contains("queue-depth") == true, "got: \(qBanner ?? "<nil>")")
+    // Escalate .gateState.
+    tracker.reportFailure(.gateState)
+    tracker.reportFailure(.gateState)
+    tracker.reportFailure(.gateState)
+    let gBanner = reporter.lastError
+    XCTAssertNotNil(gBanner)
+    XCTAssertTrue(gBanner?.contains("gate-state") == true, "got: \(gBanner ?? "<nil>")")
 
-    // Success on .queueDepth + clear banner.
-    tracker.reportSuccess(.queueDepth)
+    // Success on .gateState + clear banner.
+    tracker.reportSuccess(.gateState)
     reporter.clearLastError()
 
     // Re-escalate .inflight again — must fire fresh.

--- a/docs/features/activity.md
+++ b/docs/features/activity.md
@@ -14,7 +14,7 @@ The Activity page is a live dashboard of what Infinite Recall is doing at any gi
 
 **Queued section.** Pending and failed work counts per job kind. Lets you see how much has accumulated while processing was paused.
 
-**Run now button.** Forces a single drain pass against the queue, bypassing the idle requirement. Not available under thermal cooldown, when the screen is locked, or when you have manually paused processing.
+**Run now button.** Forces a single drain pass against the queue, bypassing the idle requirement. Not available under thermal cooldown or when the screen is locked.
 
 **Unload model memory button.** Evicts the loaded text and vision models from RAM. Useful when you need that memory back immediately. The model restarts automatically on its next call.
 
@@ -40,8 +40,9 @@ The processing gate can be in one of these states:
 | Waiting for AC power | The device is on battery or in low-power mode; queued work will drain when you plug in. |
 | Screen locked | The screen is locked; processing pauses on the assumption you may have stepped away intentionally. |
 | Device active | Only relevant for the subset of jobs that require idle time; lightweight jobs continue regardless. |
-| Manual pause | You explicitly paused processing. |
 | Initialising | The app is starting up and the gate is not yet ready. |
+
+Pausing is per-kind or per-capture (Audio / Screen); there is no whole-pipeline pause. To stop all processing, pause each kind from the Activity page.
 
 ## Behind the scenes
 
@@ -55,7 +56,7 @@ The processing gate can be in one of these states:
 
 **Resource cards.** CPU and memory figures are sampled from three processes: the Swift app, `infinite-recall-api` (the local Rust daemon), and `mlx-lm.server`. The expandable CPU card breaks these out per process. The GPU card reflects system-wide usage rather than per-process, which is sufficient to see whether the vision model is active.
 
-**Run now.** Triggering this button forces one drain pass against the pending queue, bypassing the idle requirement. It deliberately refuses to override hard blockers: thermal cooldown (continuing would risk damaging the hardware), screen lock (you may have walked away), and manual pause (you explicitly said stop). Overriding idle-only gating is safe; overriding those three is not.
+**Run now.** Triggering this button forces one drain pass against the pending queue, bypassing the idle requirement. It deliberately refuses to override hard blockers: thermal cooldown (continuing would risk damaging the hardware) and screen lock (you may have walked away). Overriding idle-only gating is safe; overriding those two is not.
 
 **Unload model memory.** This calls `IdleAIController` to evict the loaded text and vision models from RAM — roughly 13–17 GB combined, depending on which models you have selected. The next call to either model triggers an automatic launchd restart within seconds, so there is no manual reload step.
 

--- a/docs/features/activity.md
+++ b/docs/features/activity.md
@@ -14,7 +14,7 @@ The Activity page is a live dashboard of what Infinite Recall is doing at any gi
 
 **Queued section.** Pending and failed work counts per job kind. Lets you see how much has accumulated while processing was paused.
 
-**Run now button.** Forces a single drain pass against the queue, bypassing the idle requirement. Not available under thermal cooldown or when the screen is locked.
+**Run now button.** Forces a single drain pass against the queue, bypassing the idle requirement and the battery / Low Power Mode gates. Not available under thermal cooldown or when the screen is locked.
 
 **Unload model memory button.** Evicts the loaded text and vision models from RAM. Useful when you need that memory back immediately. The model restarts automatically on its next call.
 
@@ -56,7 +56,7 @@ Pausing is per-kind or per-capture (Audio / Screen); there is no whole-pipeline 
 
 **Resource cards.** CPU and memory figures are sampled from three processes: the Swift app, `infinite-recall-api` (the local Rust daemon), and `mlx-lm.server`. The expandable CPU card breaks these out per process. The GPU card reflects system-wide usage rather than per-process, which is sufficient to see whether the vision model is active.
 
-**Run now.** Triggering this button forces one drain pass against the pending queue, bypassing the idle requirement. It deliberately refuses to override hard blockers: thermal cooldown (continuing would risk damaging the hardware) and screen lock (you may have walked away). Overriding idle-only gating is safe; overriding those two is not.
+**Run now.** Triggering this button forces one drain pass against the pending queue. The underlying `runOnceIgnoringPower()` bypasses the idle requirement and the battery / Low Power Mode gates so the user can spend a chunk of battery on demand. It deliberately refuses to override hard blockers: thermal cooldown (continuing would risk damaging the hardware) and screen lock (you may have walked away). Overriding idle and power gating is safe; overriding those two is not.
 
 **Unload model memory.** This calls `IdleAIController` to evict the loaded text and vision models from RAM — roughly 13–17 GB combined, depending on which models you have selected. The next call to either model triggers an automatic launchd restart within seconds, so there is no manual reload step.
 


### PR DESCRIPTION
## Summary

Three small, focused fixes for the Activity tab cluster — all picking the
recommended doc/prune path the issue authors suggested rather than adding
new UI surface.

- **#128 — manualPause prune.** The doc listed `Manual pause` as a gate
  state and the wire enum + banner copy + `disablesRunNowOverride`
  predicate exist, but no Swift code path ever produced
  `Blocked(.manualPause, ...)` — there is no whole-pipeline pause in IR
  (only per-kind / per-capture, which flow through `paused_until`, not
  the gate state). Removed the variant from both Swift and Rust enums,
  the dead switch arms, the doc row, and updated round-trip tests.

- **#134 — banner reflects draining work.** The doc paragraph "What runs
  on AC vs. idle+AC" promises lightweight kinds (transcribe / OCR /
  extractMemory / extractActionItems) drain on AC even while typing.
  `BatteryAwareScheduler.drain()` honours that — only `.summarize` /
  `.extractKG` actually require autonomous readiness — but the banner
  still read "Waiting for idle" while In-flight showed transcribe
  running. Added `WorkKind.requiresAutonomousReadiness` extension so the
  scheduler and banner share one source of truth, and a pure
  `activityLightweightWorkActive(kinds:)` helper. When
  `Blocked(.deviceActive)` and any non-autonomous kind has queued or
  in-flight work, the banner now renders "Idle processing — running"
  with detail "N items in queue. Heavy work waits for X min of idle."

- **#137 — queueDepth tracker prune.** No Swift production code calls
  `reportFailure(.queueDepth)` or `reportSuccess(.queueDepth)` —
  Activity snapshots became DB-authoritative when
  `snapshotWithAuthoritativeQueueDepth` was added. Removed
  `Category.queueDepth` from the tracker, the legacy Rust handler +
  `QueueDepthUpdate` body type + route registration, and updated tests
  + comments. Pinned that the legacy `_internal/queue-depth` route now
  returns 404 so a future re-introduction is caught.

Fixes #128
Fixes #134
Fixes #137

## Test plan

- [x] Local CI mirrored: `xcrun swift build`, `xcrun swift test` (486 passed),
  `cargo test -p infinite-recall-api`, `cargo test -p infinite-recall-api
  --features activity_test_wiring` (23 passed including the 404 assertion
  for the pruned queue-depth route).
- [x] New regression tests for #134 in
  `Desktop/Tests/ActivityPagePowerGateTests.swift` covering the
  lightweight-active predicate (queued / in-flight / heavy-only / empty)
  and the kind classification.
- [x] Round-trip tests for `BlockReason` updated on both sides
  (`ActivityModelsTests`, `Backend-Rust/api/tests/activity_endpoints.rs`,
  `Backend-Rust/api/src/activity/types.rs` unit tests).
- [ ] Manual smoke (next pass): on AC, idle below threshold, kick off a
  transcribe → confirm banner reads "Idle processing — running" with
  heavy-work detail rather than "Waiting for idle".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Removed "manual pause" as a block reason; "Run now" is now blocked only by thermal cooldown or screen lock.
  * Pruned legacy internal queue-depth reporting and its failure category; activity snapshots are DB-authoritative.
  * Work-kind readiness classification added, affecting which work requires stricter autonomous conditions.

* **Tests**
  * Updated tests to reflect removed manual-pause variant and pruned queue-depth pathway.

* **Documentation**
  * Updated activity docs and banners to match new blocking and state behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->