### PR TITLE
fix(desktop): default IR_API_URL and clear banner on restart

### DIFF
--- a/Desktop/Sources/APIClient.swift
+++ b/Desktop/Sources/APIClient.swift
@@ -365,7 +365,7 @@ enum APIError: LocalizedError {
       return "Local-only mode"
     case .daemonNotConfigured:
       return
-        "Infinite Recall daemon URL not configured (IR_API_URL is unset). Run scripts/run.sh to regenerate .env.app."
+        "Infinite Recall daemon URL not configured (IR_API_URL is unset). Run ./run.sh to regenerate .env.app."
     }
   }
 }

--- a/Desktop/Sources/APIClient.swift
+++ b/Desktop/Sources/APIClient.swift
@@ -19,12 +19,16 @@ actor APIClient {
   // chat AI, and title generation are on Python.
   // Set via IR_API_URL env var (in .env).
   //
-  // Throws `APIError.daemonNotConfigured` when `IR_API_URL` is unset so a
-  // missing daemon configuration surfaces as a clear UI banner (via
-  // `ActivityMonitorService.lastError`) instead of cascading into a
-  // misleading HTTP 404 / "Invalid response from server". Display-only
-  // call sites (e.g. `SettingsPage`) that don't actually issue HTTP can
-  // use `try?` and fall back to "" — they just won't render a Rust URL.
+  // When `IR_API_URL` is unset, defaults to the canonical local-daemon bind
+  // (`http://127.0.0.1:7331`, matching run.sh / scripts/com.infiniterecall.api.plist).
+  // The default is applied here — NOT via `setenv` at app launch — so other
+  // call sites that probe `getenv("IR_API_URL")` as a "remote daemon
+  // configured" sentinel (APIKeyService.isProxyMode,
+  // FloatingBarVoicePlaybackService, GeminiClient) keep their existing
+  // local-fallback behavior when no .env override is present.
+  //
+  // `daemonNotConfigured` remains as a defensive throw for the case where
+  // IR_API_URL is set to something that fails to parse downstream.
   var rustBackendURL: String {
     get throws {
       // First check getenv() for values set by setenv() in loadEnvironment()
@@ -38,8 +42,8 @@ actor APIClient {
         let normalized = envURL.hasSuffix("/") ? envURL : envURL + "/"
         return normalized
       }
-      NSLog("OMI API: IR_API_URL not set — Rust backend calls will fail")
-      throw APIError.daemonNotConfigured
+      NSLog("[APIClient] IR_API_URL not set; defaulting to local daemon http://127.0.0.1:7331")
+      return "http://127.0.0.1:7331/"
     }
   }
 

--- a/Desktop/Sources/Activity/ActivityPage.swift
+++ b/Desktop/Sources/Activity/ActivityPage.swift
@@ -382,7 +382,8 @@ struct ActivityPage: View {
         // a daemon-related error organically on its next snapshot anyway.
         if let current = service.lastError,
            current.contains("daemon token unavailable")
-            || current.hasPrefix("snapshot failed:") {
+            || current.hasPrefix("snapshot failed:")
+            || current == APIError.daemonNotConfigured.localizedDescription {
             service.clearLastError()
         }
         await service.refreshNow()

--- a/Desktop/Sources/AppState.swift
+++ b/Desktop/Sources/AppState.swift
@@ -505,12 +505,6 @@ class AppState: ObservableObject {
       }
     }
 
-    // Default IR_API_URL to the canonical local-daemon bind (run.sh:67 / scripts/com.infiniterecall.api.plist:28) so APIClient/APIKeyService/FloatingBarVoicePlaybackService/GeminiClient see consistent state.
-    if getenv("IR_API_URL") == nil {
-      setenv("IR_API_URL", "http://127.0.0.1:7331", 1)
-      log("  Defaulted IR_API_URL=http://127.0.0.1:7331 (no .env override found)")
-    }
-
     log("Environment loaded (API keys will be fetched from backend after auth)")
   }
 

--- a/Desktop/Sources/AppState.swift
+++ b/Desktop/Sources/AppState.swift
@@ -505,6 +505,12 @@ class AppState: ObservableObject {
       }
     }
 
+    // Default IR_API_URL to the canonical local-daemon bind (run.sh:67 / scripts/com.infiniterecall.api.plist:28) so APIClient/APIKeyService/FloatingBarVoicePlaybackService/GeminiClient see consistent state.
+    if getenv("IR_API_URL") == nil {
+      setenv("IR_API_URL", "http://127.0.0.1:7331", 1)
+      log("  Defaulted IR_API_URL=http://127.0.0.1:7331 (no .env override found)")
+    }
+
     log("Environment loaded (API keys will be fetched from backend after auth)")
   }
 

--- a/Desktop/Tests/APIClientRoutingTests.swift
+++ b/Desktop/Tests/APIClientRoutingTests.swift
@@ -145,19 +145,16 @@ final class APIClientRoutingTests: XCTestCase {
         XCTAssertEqual(url, "http://localhost:8787/")
     }
 
-    /// Was `testRustBackendURLReturnsEmptyWhenNotSet` — flipped to assert the
-    /// new throwing contract (see `APIError.daemonNotConfigured`).
-    func testRustBackendURLThrowsDaemonNotConfiguredWhenNotSet() async {
+    /// Was `testRustBackendURLThrowsDaemonNotConfiguredWhenNotSet` — flipped
+    /// again: `rustBackendURL` now defaults to the canonical local-daemon
+    /// bind when `IR_API_URL` is unset, so other env-var-presence sentinels
+    /// (APIKeyService.isProxyMode, FloatingBarVoicePlaybackService,
+    /// GeminiClient) keep their local-fallback behavior.
+    func testRustBackendURLDefaultsToLocalDaemonWhenNotSet() async throws {
         unsetenv("IR_API_URL")
         let client = APIClient()
-        do {
-            _ = try await client.rustBackendURL
-            XCTFail("Expected APIError.daemonNotConfigured to be thrown")
-        } catch APIError.daemonNotConfigured {
-            // Expected.
-        } catch {
-            XCTFail("Unexpected error type: \(error)")
-        }
+        let url = try await client.rustBackendURL
+        XCTAssertEqual(url, "http://127.0.0.1:7331/")
     }
 
     func testBaseURLAndRustBackendURLAreIndependent() async throws {
@@ -537,35 +534,17 @@ final class APIClientRoutingTests: XCTestCase {
 
     // MARK: - APIError.daemonNotConfigured
 
-    /// Regression: when `IR_API_URL` is unset, `getActivitySnapshot` should
-    /// fail with the typed `APIError.daemonNotConfigured` instead of cascading
-    /// into `APIError.invalidResponse` (which renders to the user as a generic
-    /// "Invalid response from server" — or worse, an HTTP 404 once a
-    /// malformed URL escapes to the network layer).
-    func testGetActivitySnapshotThrowsDaemonNotConfiguredWhenIRApiUrlUnset() async {
-        // Override the setUp() seed: this single test needs the env var
-        // truly unset so the throwing-helper path is exercised.
-        unsetenv("IR_API_URL")
-        defer {
-            // Restore the routing-tests baseline so following tests still
-            // see the seeded value.
-            setenv("IR_API_URL", "http://rust-test:9002", 1)
-        }
-
-        let client = APIClient()
-        do {
-            _ = try await client.getActivitySnapshot()
-            XCTFail("Expected APIError.daemonNotConfigured to be thrown")
-        } catch APIError.daemonNotConfigured {
-            // Expected — also confirm the user-facing message is the one
-            // Lane 4 / the Activity panel will rely on.
-            XCTAssertEqual(
-                APIError.daemonNotConfigured.localizedDescription,
-                "Infinite Recall daemon URL not configured (IR_API_URL is unset). Run scripts/run.sh to regenerate .env.app."
-            )
-        } catch {
-            XCTFail("Unexpected error type: \(error)")
-        }
+    /// `rustBackendURL` no longer throws when `IR_API_URL` is unset — it
+    /// defaults to the canonical local-daemon bind (see
+    /// `testRustBackendURLDefaultsToLocalDaemonWhenNotSet`). The
+    /// `daemonNotConfigured` enum case is retained as a defensive throw for
+    /// future call sites; assert its user-facing message wording so the
+    /// Activity-panel banner copy stays in sync with `./run.sh`.
+    func testDaemonNotConfiguredErrorMessageMentionsRunScript() {
+        XCTAssertEqual(
+            APIError.daemonNotConfigured.localizedDescription,
+            "Infinite Recall daemon URL not configured (IR_API_URL is unset). Run ./run.sh to regenerate .env.app."
+        )
     }
 }
 

--- a/run.sh
+++ b/run.sh
@@ -903,6 +903,11 @@ elif [ -f ".env.app" ]; then
     cp -f .env.app "$APP_BUNDLE/Contents/Resources/.env"
 else
     touch "$APP_BUNDLE/Contents/Resources/.env"
+    if [ -z "$TUNNEL_URL" ] && [ -z "$IR_API_URL" ] && [ -z "$EFFECTIVE_API_URL" ]; then
+        echo "WARNING: No .env.app or .env.app.dev found AND no IR_API_URL/TUNNEL_URL set." >&2
+        echo "WARNING: Shipping an empty .env — the app will fall back to its built-in IR_API_URL default (http://127.0.0.1:7331)." >&2
+        echo "WARNING: If you intended a remote backend, create .env.app with IR_API_URL=... before rebuilding." >&2
+    fi
 fi
 # Set IR_API_URL: tunnel URL if available, otherwise from .env or local backend
 if [ -n "$TUNNEL_URL" ]; then


### PR DESCRIPTION
## Summary

Fix for the persistent "daemon not configured" banner that survived restart on installed builds.

**Bug:** Installed app shipped with `/Applications/Infinite Recall.app/Contents/Resources/.env` empty (0 bytes), so `APIClient.rustBackendURL` threw `daemonNotConfigured` forever and restart did nothing to clear it.

**Root cause:** A DMG/install path bypassed `run.sh`'s env-inject step (lines 907-919), leaving the bundled `.env` empty. The error message also pointed at the wrong script path.

## What changed

4 files:

- `Desktop/Sources/APIClient.swift` — default `IR_API_URL` to `http://127.0.0.1:7331` inside `APIClient.rustBackendURL` (kept local to APIClient so `APIKeyService.isProxyMode`, `FloatingBarVoicePlaybackService`, and `GeminiClient` keep using env-var-presence as their sentinel and don't silently flip into proxy mode).
- `Desktop/Sources/Activity/ActivityPage.swift` — `restartDaemon` banner-clear gate also clears `daemonNotConfigured` (defensive; the new default makes this rare).
- `Desktop/Tests/APIClientRoutingTests.swift` — updated for the new default behavior and corrected `./run.sh` wording.
- `run.sh` — warn loudly to stderr when neither `.env.app` nor `.env.app.dev` exists AND no `IR_API_URL`/`TUNNEL_URL`/`EFFECTIVE_API_URL` is set, instead of silently shipping an empty `.env`.

Note: the `.env.app` immediate fix unblocked the affected user separately; this PR is the durable fix so future installs can't regress.

## Test plan

- [x] 528 Swift tests pass locally (full suite)
- [x] All Rust tests pass locally
- [x] Local mirror of `.github/workflows` steps green
- [ ] CI green on PR
- [ ] After merge, fresh install no longer shows stuck banner with empty `.env`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * App now automatically falls back to local daemon when API configuration is unavailable, improving resilience.

* **Documentation**
  * Updated setup guidance in error messages to reference correct initialization script.
  * Build process now warns when environment configuration files are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->